### PR TITLE
Support Python dependencies in Server

### DIFF
--- a/examples/screenshot.py
+++ b/examples/screenshot.py
@@ -1,7 +1,3 @@
-# /// script
-# dependencies = ["fastmcp", "pyautogui", "Pillow"]
-# ///
-
 """
 FastMCP Screenshot Example
 
@@ -9,20 +5,24 @@ Give Claude a tool to capture and view screenshots.
 """
 
 import io
-
 from fastmcp import FastMCP, Image
 
+
 # Create server
-mcp = FastMCP("Screenshot Demo")
+mcp = FastMCP("Screenshot Demo", dependencies=["pyautogui", "Pillow"])
 
 
 @mcp.tool()
 def take_screenshot() -> Image:
-    """Take a screenshot of the user's screen and return it as an image"""
+    """
+    Take a screenshot of the user's screen and return it as an image. Use
+    this tool anytime the user wants you to look at something they're doing.
+    """
     import pyautogui
 
-    screenshot = pyautogui.screenshot()
     buffer = io.BytesIO()
+
     # if the file exceeds ~1MB, it will be rejected by Claude
+    screenshot = pyautogui.screenshot()
     screenshot.convert("RGB").save(buffer, format="JPEG", quality=60, optimize=True)
     return Image(data=buffer.getvalue(), format="jpeg")

--- a/src/fastmcp/cli/claude.py
+++ b/src/fastmcp/cli/claude.py
@@ -68,15 +68,19 @@ def update_claude_config(
                 env_vars = existing_env
 
         # Build uv run command
-        args = ["run", "--with", "fastmcp"]
+        args = ["run"]
+
+        # Collect all packages in a set to deduplicate
+        packages = {"fastmcp"}
+        if with_packages:
+            packages.update(pkg for pkg in with_packages if pkg)
+
+        # Add all packages with --with
+        for pkg in sorted(packages):
+            args.extend(["--with", pkg])
 
         if with_editable:
             args.extend(["--with-editable", str(with_editable)])
-
-        if with_packages:
-            for pkg in with_packages:
-                if pkg:
-                    args.extend(["--with", pkg])
 
         # Convert file path to absolute before adding to command
         # Split off any :object suffix first

--- a/src/fastmcp/server.py
+++ b/src/fastmcp/server.py
@@ -9,6 +9,7 @@ from itertools import chain
 from typing import Any, Callable, Dict, Literal, Sequence
 
 import pydantic_core
+from pydantic import Field
 import uvicorn
 from mcp.server import Server as MCPServer
 from mcp.server.sse import SseServerTransport
@@ -76,6 +77,11 @@ class Settings(BaseSettings):
     # prompt settings
     warn_on_duplicate_prompts: bool = True
 
+    dependencies: list[str] = Field(
+        default_factory=list,
+        description="List of dependencies to install in the server environment",
+    )
+
 
 class FastMCP:
     def __init__(self, name: str | None = None, **settings: Any):
@@ -90,6 +96,7 @@ class FastMCP:
         self._prompt_manager = PromptManager(
             warn_on_duplicate_prompts=self.settings.warn_on_duplicate_prompts
         )
+        self.dependencies = self.settings.dependencies
 
         # Set up MCP protocol handlers
         self._setup_handlers()


### PR DESCRIPTION
When developing and deploying a server, we want to be able to specify Python dependencies without having to do `--with dep` every time. 

In earlier versions of FastMCP, it was possible to use uv's [script dependencies] (https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies) to declare dependenceis as frontmatter, but since we now use `fastmcp run server.py` instead of `uv run server.py` by default, they don't get parsed.

This PR makes the following code possible (which requires pandas) while keeping the install command `fastmcp install demo.py`

```python
# demo.py

from fastmcp import FastMCP

mcp = FastMCP("demo", dependencies=['pandas']

@mcp.tool()
def demo():
    import pandas
    ...
```

The README is also updated to clarify that:

- `fastmcp install` will respect server dependencies when creating an environment for Claude desktop
- `fastmcp dev` will respect server dependencies when creating an environment for the MCP Inspector
- `fastmcp run` will NOT respect dependencies; it assumes they are already set up. However it does not require a if __name__ == '__main__' block
- `python run` and `uv run` are perfectly valid as long as the user calls `mcp.run()` themselves and takes responsibility for all dependencies. 
