### PR TITLE
Additional Windows Fixes for Dev running and for importing modules in a server

### DIFF
--- a/Windows_Notes.md
+++ b/Windows_Notes.md
@@ -18,5 +18,35 @@ return isinstance(x, Callable)
 ```
 
 # Helpful notes
+For developing FastMCP
+## Install local development version of FastMCP into a local FastMCP project server
+- ensure
+- change directories to your FastMCP Server location so you can install it in your .venv
+- run `.venv\Scripts\activate` to activate your virtual environment
+- Then run a series of commands to uninstall the old version and install the new
+```bash
+# First uninstall
+uv pip uninstall fastmcp
+
+# Clean any build artifacts in your fastmcp directory
+cd C:\path\to\fastmcp
+del /s /q *.egg-info
+
+# Then reinstall in your weather project
+cd C:\path\to\new\fastmcp_server
+uv pip install --no-cache-dir -e C:\Users\justj\PycharmProjects\fastmcp
+
+# Check that it installed properly and has the correct git hash
+pip show fastmcp
+```
+
+## Running the FastMCP server with Inspector
+MCP comes with a node.js application called Inspector that can be used to inspect the FastMCP server. To run the inspector, you'll need to install node.js and npm. Then you can run the following commands:
+```bash
+fastmcp dev server.py
+```
+This will launch a web app on http://localhost:5173/ that you can use to inspect the FastMCP server.
+
+
 
 

--- a/Windows_Notes.md
+++ b/Windows_Notes.md
@@ -47,6 +47,12 @@ fastmcp dev server.py
 ```
 This will launch a web app on http://localhost:5173/ that you can use to inspect the FastMCP server.
 
-
+## If you start development before creating a fork - your get out of jail free card
+- Add your fork as a new remote to your local repository `git remote add fork git@github.com:YOUR-USERNAME/REPOSITORY-NAME.git`
+  - This will add your repo, short named 'fork', as a remote to your local repository
+- Verify that it was added correctly by running `git remote -v`
+- Commit your changes
+- Push your changes to your fork `git push fork <branch>`
+- Create your pull request on GitHub 
 
 

--- a/Windows_Notes.md
+++ b/Windows_Notes.md
@@ -1,9 +1,13 @@
 # Getting your development environment set up properly
+To get your environment up and running properly, you'll need a slightly different set of commands that are windows specific:
 ```bash
 uv venv
 .venv\Scripts\activate
 uv pip install -e ".[dev]"
 ```
+
+This will install the package in editable mode, and install the development dependencies.
+
 
 # Fixing `AttributeError: module 'collections' has no attribute 'Callable'`
 - open `.venv\Lib\site-packages\pyreadline\py3k_compat.py`
@@ -12,4 +16,7 @@ uv pip install -e ".[dev]"
 from collections.abc import Callable
 return isinstance(x, Callable)
 ```
+
+# Helpful notes
+
 


### PR DESCRIPTION
This PR fixes 2 issues:

1) The dev action in cli.py could not find node or npx in the running processes due to the way they are called and managed.  Added additional code for windows that checks for node/npx properly. This required an OS aware test change.  Windows calls for npx subprocess twice, and unix only once.  The test was only expecting once in all occasions.

2) If a MCP server included modules, the cli would fail to build them because it wouldn't do it from the root of the mcp server being built.  Added short code to add parent directory to path if not already there.