### PR TITLE
fix warning and flake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ tests = [
     "pre-commit",
     "pytest>=8.3.3",
     "pytest-asyncio>=0.23.5",
+    "pytest-flakefinder",
     "pytest-xdist>=3.6.1",
     "ruff",
 ]

--- a/tests/test_func_metadata.py
+++ b/tests/test_func_metadata.py
@@ -241,12 +241,12 @@ def test_complex_function_json_schema():
                 "title": "InnerModel",
                 "type": "object",
             },
-            "TestInputModelA": {
+            "SomeInputModelA": {
                 "properties": {},
-                "title": "TestInputModelA",
+                "title": "SomeInputModelA",
                 "type": "object",
             },
-            "TestInputModelB": {
+            "SomeInputModelB": {
                 "properties": {
                     "how_many_shrimp": {
                         "description": "How many shrimp in the tank???",
@@ -257,7 +257,7 @@ def test_complex_function_json_schema():
                     "y": {"title": "Y", "type": "null"},
                 },
                 "required": ["how_many_shrimp", "ok", "y"],
-                "title": "TestInputModelB",
+                "title": "SomeInputModelB",
                 "type": "object",
             },
         },
@@ -301,9 +301,9 @@ def test_complex_function_json_schema():
                 "type": "integer",
             },
             "unannotated": {"title": "unannotated", "type": "string"},
-            "my_model_a": {"$ref": "#/$defs/TestInputModelA"},
-            "my_model_a_forward_ref": {"$ref": "#/$defs/TestInputModelA"},
-            "my_model_b": {"$ref": "#/$defs/TestInputModelB"},
+            "my_model_a": {"$ref": "#/$defs/SomeInputModelA"},
+            "my_model_a_forward_ref": {"$ref": "#/$defs/SomeInputModelA"},
+            "my_model_b": {"$ref": "#/$defs/SomeInputModelB"},
             "an_int_annotated_with_field_default": {
                 "default": 1,
                 "description": "An int with a field",
@@ -316,7 +316,7 @@ def test_complex_function_json_schema():
                 "type": "string",
             },
             "my_model_a_with_default": {
-                "$ref": "#/$defs/TestInputModelA",
+                "$ref": "#/$defs/SomeInputModelA",
                 "default": {},
             },
             "an_int_with_default": {

--- a/tests/test_func_metadata.py
+++ b/tests/test_func_metadata.py
@@ -1,15 +1,17 @@
-from pydantic import BaseModel, Field
 from typing import Annotated
+
 import annotated_types
-from fastmcp.utilities.func_metadata import func_metadata
 import pytest
+from pydantic import BaseModel, Field
+
+from fastmcp.utilities.func_metadata import func_metadata
 
 
-class TestInputModelA(BaseModel):
+class SomeInputModelA(BaseModel):
     pass
 
 
-class TestInputModelB(BaseModel):
+class SomeInputModelB(BaseModel):
     class InnerModel(BaseModel):
         x: int
 
@@ -44,15 +46,15 @@ def complex_arguments_fn(
         int, Field(1)
     ],
     unannotated,
-    my_model_a: TestInputModelA,
-    my_model_a_forward_ref: "TestInputModelA",
-    my_model_b: TestInputModelB,
+    my_model_a: SomeInputModelA,
+    my_model_a_forward_ref: "SomeInputModelA",
+    my_model_b: SomeInputModelB,
     an_int_annotated_with_field_default: Annotated[
         int,
         Field(1, description="An int with a field"),
     ],
     unannotated_with_default=5,
-    my_model_a_with_default: TestInputModelA = TestInputModelA(),  # noqa: B008
+    my_model_a_with_default: SomeInputModelA = SomeInputModelA(),  # noqa: B008
     an_int_with_default: int = 1,
     must_be_none_with_default: None = None,
     an_int_with_equals_field: int = Field(1, ge=0),

--- a/uv.lock
+++ b/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "0.3.2.dev0+g5656200.d20241201"
+version = "0.3.6.dev0+gf03184b.d20241203"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -247,6 +247,15 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-flakefinder" },
+    { name = "pytest-xdist" },
+    { name = "ruff" },
+]
+tests = [
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-flakefinder" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -259,13 +268,20 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.0.0,<2.0.0" },
     { name = "pdbpp", marker = "extra == 'dev'", specifier = ">=0.10.3" },
     { name = "pre-commit", marker = "extra == 'dev'" },
+    { name = "pre-commit", marker = "extra == 'tests'" },
     { name = "pydantic", specifier = ">=2.5.3,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.6.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
+    { name = "pytest", marker = "extra == 'tests'", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.5" },
+    { name = "pytest-asyncio", marker = "extra == 'tests'", specifier = ">=0.23.5" },
+    { name = "pytest-flakefinder", marker = "extra == 'dev'" },
+    { name = "pytest-flakefinder", marker = "extra == 'tests'" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.1" },
+    { name = "pytest-xdist", marker = "extra == 'tests'", specifier = ">=3.6.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "ruff", marker = "extra == 'tests'" },
     { name = "typer", specifier = ">=0.9.0" },
 ]
 
@@ -741,6 +757,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/6d/c6cf50ce320cf8611df7a1254d86233b3df7cc07f9b5f5cbcb82e08aa534/pytest_asyncio-0.24.0.tar.gz", hash = "sha256:d081d828e576d85f875399194281e92bf8a68d60d72d1a2faf2feddb6c46b276", size = 49855 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/31/6607dab48616902f76885dfcf62c08d929796fc3b2d2318faf9fd54dbed9/pytest_asyncio-0.24.0-py3-none-any.whl", hash = "sha256:a811296ed596b69bf0b6f3dc40f83bcaf341b155a269052d82efa2b25ac7037b", size = 18024 },
+]
+
+[[package]]
+name = "pytest-flakefinder"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/53/69c56a93ea057895b5761c5318455804873a6cd9d796d7c55d41c2358125/pytest-flakefinder-1.1.0.tar.gz", hash = "sha256:e2412a1920bdb8e7908783b20b3d57e9dad590cc39a93e8596ffdd493b403e0e", size = 6795 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/8b/06787150d0fd0cbd3a8054262b56f91631c7778c1bc91bf4637e47f909ad/pytest_flakefinder-1.1.0-py2.py3-none-any.whl", hash = "sha256:741e0e8eea427052f5b8c89c2b3c3019a50c39a59ce4df6a305a2c2d9ba2bd13", size = 4644 },
 ]
 
 [[package]]


### PR DESCRIPTION
see warnings and failures https://github.com/jlowin/fastmcp/actions/runs/12131427611

- fix pytest warnings "cannot collect" `TestClassNotGroupingCases` -> `SomeClassNotGroupingCases`
- order-independent check for `test_dev_with_dependencies`
- adds `pytest-flakefinder` as a dev dep so I can do
```
» pytest tests/test_cli.py -k with_dep --flake-finder

tests/test_cli.py ....................................................................................................    [100%]

======= 100 passed, 600 deselected in 0.84s ======
```