### PR TITLE
fix: use stderr for logging

### DIFF
--- a/src/fastmcp/utilities/logging.py
+++ b/src/fastmcp/utilities/logging.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Literal
 
+from rich.console import Console
 from rich.logging import RichHandler
 
 
@@ -27,5 +28,7 @@ def configure_logging(
         level: the log level to use
     """
     logging.basicConfig(
-        level=level, format="%(message)s", handlers=[RichHandler(rich_tracebacks=True)]
+        level=level,
+        format="%(message)s",
+        handlers=[RichHandler(console=Console(stderr=True), rich_tracebacks=True)],
     )


### PR DESCRIPTION
Without this, logs get sent to stdout which is captured by the
JSONRPC protocol (which also causes some errors with clients when
the invalid JSON is sent over the stdout pipe).
