### PR TITLE
fix: use Mount instead of Route for SSE message handling

### DIFF
--- a/src/fastmcp/server.py
+++ b/src/fastmcp/server.py
@@ -428,9 +428,9 @@ class FastMCP:
     async def run_sse_async(self) -> None:
         """Run the server using SSE transport."""
         from starlette.applications import Starlette
-        from starlette.routing import Route
+        from starlette.routing import Route, Mount
 
-        sse = SseServerTransport("/messages")
+        sse = SseServerTransport("/messages/")
 
         async def handle_sse(request):
             async with sse.connect_sse(
@@ -442,14 +442,11 @@ class FastMCP:
                     self._mcp_server.create_initialization_options(),
                 )
 
-        async def handle_messages(request):
-            await sse.handle_post_message(request.scope, request.receive, request._send)
-
         starlette_app = Starlette(
             debug=self.settings.debug,
             routes=[
                 Route("/sse", endpoint=handle_sse),
-                Route("/messages", endpoint=handle_messages, methods=["POST"]),
+                Mount("/messages/", app=sse.handle_post_message),
             ],
         )
 


### PR DESCRIPTION
## Description
This PR modifies how FastMCP handles SSE message endpoints by using Starlette's `Mount` instead of `Route`. This change follows the recommended approach from the MCP SDK team as discussed in [modelcontextprotocol/python-sdk#83](https://github.com/modelcontextprotocol/python-sdk/pull/83).

## Problem
When using FastMCP with SSE transport, users encounter a `TypeError: 'NoneType' object is not callable` error. This occurs because:
1. The current implementation uses a Starlette `Route` for handling SSE messages
2. `SseServerTransport.handle_post_message` is designed as a full ASGI application
3. Starlette's `Route` expects handlers to return a response object, but our handler doesn't

## Solution
Following the guidance from @jspahrsummers in [python-sdk#83](https://github.com/modelcontextprotocol/python-sdk/pull/83), we:
1. Replace `Route("/messages", endpoint=handle_messages)` with `Mount("/messages/", app=sse.handle_post_message)`
2. Update the SSE transport path to include a trailing slash
3. Remove the custom message handler since `Mount` handles the ASGI application directly

This approach:
- Maintains compatibility with MCP SDK's ASGI application design
- Properly handles the response flow
- Follows the recommended pattern from the MCP SDK team

## Changes
- Modified `run_sse_async()` to use `Mount` instead of `Route`
- Updated SSE transport initialization to use "/messages/" path
- Added trailing slash to message endpoint path

## Testing
- Verified SSE connection works correctly
- Confirmed message handling functions properly
- Ensured no TypeError is raised during message handling

## Related Issues
Fixes #69
