### PR TITLE
Allow tool manager to store an alternative name for tools

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -185,7 +185,12 @@ class FastMCP(Generic[LifespanResultT]):
         self._mcp_server.get_prompt()(self._mcp_get_prompt)
         self._mcp_server.list_resource_templates()(self._mcp_list_resource_templates)
 
+    def get_tools(self) -> dict[str, Tool]:
+        """Get all registered tools, keyed by registered name."""
+        return self._tool_manager.get_tools()
+
     def list_tools(self) -> list[Tool]:
+        """List all registered tools."""
         return self._tool_manager.list_tools()
 
     async def _mcp_list_tools(self) -> list[MCPTool]:

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -195,17 +195,7 @@ class FastMCP(Generic[LifespanResultT]):
 
         See `list_tools` for a more ergonomic way to list tools.
         """
-
-        tools = self.list_tools()
-
-        return [
-            MCPTool(
-                name=info.name,
-                description=info.description,
-                inputSchema=info.parameters,
-            )
-            for info in tools
-        ]
+        return self._tool_manager.list_mcp_tools()
 
     def get_context(self) -> "Context[ServerSession, LifespanResultT]":
         """

--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -4,6 +4,7 @@ import inspect
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Annotated, Any
 
+from mcp.types import Tool as MCPTool
 from pydantic import BaseModel, BeforeValidator, Field
 
 from fastmcp.exceptions import ToolError
@@ -100,6 +101,14 @@ class Tool(BaseModel):
             )
         except Exception as e:
             raise ToolError(f"Error executing tool {self.name}: {e}") from e
+
+    def to_mcp_tool(self, **overrides: Any) -> MCPTool:
+        kwargs = {
+            "name": self.name,
+            "description": self.description,
+            "inputSchema": self.parameters,
+        }
+        return MCPTool(**kwargs | overrides)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Tool):

--- a/src/fastmcp/tools/tool_manager.py
+++ b/src/fastmcp/tools/tool_manager.py
@@ -29,9 +29,13 @@ class ToolManager:
         """Get tool by name."""
         return self._tools.get(name)
 
+    def get_tools(self) -> dict[str, Tool]:
+        """Get all registered tools, keyed by registered name."""
+        return self._tools
+
     def list_tools(self) -> list[Tool]:
         """List all registered tools."""
-        return list(self._tools.values())
+        return list(self.get_tools().values())
 
     def list_mcp_tools(self) -> list[MCPTool]:
         """List all registered tools in the format expected by the low-level MCP server."""

--- a/src/fastmcp/tools/tool_manager.py
+++ b/src/fastmcp/tools/tool_manager.py
@@ -1,6 +1,5 @@
 from __future__ import annotations as _annotations
 
-import copy
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -8,7 +7,7 @@ from mcp.shared.context import LifespanContextT
 
 from fastmcp.exceptions import ToolError
 from fastmcp.settings import DuplicateBehavior
-from fastmcp.tools.tool import Tool
+from fastmcp.tools.tool import MCPTool, Tool
 from fastmcp.utilities.logging import get_logger
 
 if TYPE_CHECKING:
@@ -34,6 +33,10 @@ class ToolManager:
         """List all registered tools."""
         return list(self._tools.values())
 
+    def list_mcp_tools(self) -> list[MCPTool]:
+        """List all registered tools in the format expected by the low-level MCP server."""
+        return [tool.to_mcp_tool(name=name) for name, tool in self._tools.items()]
+
     def add_tool_from_fn(
         self,
         fn: Callable[..., Any],
@@ -45,20 +48,21 @@ class ToolManager:
         tool = Tool.from_function(fn, name=name, description=description, tags=tags)
         return self.add_tool(tool)
 
-    def add_tool(self, tool: Tool) -> Tool:
+    def add_tool(self, tool: Tool, name: str | None = None) -> Tool:
         """Register a tool with the server."""
-        existing = self._tools.get(tool.name)
+        name = name or tool.name
+        existing = self._tools.get(name)
         if existing:
             if self.duplicate_behavior == DuplicateBehavior.WARN:
-                logger.warning(f"Tool already exists: {tool.name}")
-                self._tools[tool.name] = tool
+                logger.warning(f"Tool already exists: {name}")
+                self._tools[name] = tool
             elif self.duplicate_behavior == DuplicateBehavior.REPLACE:
-                self._tools[tool.name] = tool
+                self._tools[name] = tool
             elif self.duplicate_behavior == DuplicateBehavior.ERROR:
-                raise ValueError(f"Tool already exists: {tool.name}")
+                raise ValueError(f"Tool already exists: {name}")
             elif self.duplicate_behavior == DuplicateBehavior.IGNORE:
                 pass
-        self._tools[tool.name] = tool
+        self._tools[name] = tool
         return tool
 
     async def call_tool(
@@ -90,10 +94,5 @@ class ToolManager:
         """
         for name, tool in tool_manager._tools.items():
             prefixed_name = f"{prefix}{name}" if prefix else name
-
-            new_tool = copy.copy(tool)
-            new_tool.name = prefixed_name
-
-            # Store the copied tool
-            self.add_tool(new_tool)
-            logger.debug(f'Imported tool "{name}" as "{prefixed_name}"')
+            self.add_tool(tool, name=prefixed_name)
+            logger.debug(f'Imported tool "{tool.name}" as "{prefixed_name}"')

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -204,6 +204,30 @@ class TestToolDecorator:
         assert len(tools) == 1
         assert tools[0].tags == {"example", "test-tag"}
 
+    async def test_add_tool_with_custom_name(self):
+        """Test adding a tool with a custom name using server.add_tool()."""
+        mcp = FastMCP()
+
+        def multiply(a: int, b: int) -> int:
+            """Multiply two numbers."""
+            return a * b
+
+        # Add the tool with a custom name
+        mcp.add_tool(multiply, name="custom_multiply")
+
+        # Check that the tool is registered with the custom name
+        tools = mcp.list_tools()
+        tool_names = [t.name for t in tools]
+        assert "custom_multiply" in tool_names
+
+        # Call the tool by its custom name
+        result = await mcp.call_tool("custom_multiply", {"a": 5, "b": 3})
+        assert isinstance(result[0], TextContent)
+        assert result[0].text == "15"
+
+        # Original name should not be registered
+        assert "multiply" not in tool_names
+
 
 class TestResourceDecorator:
     async def test_no_resources_before_decorator(self):


### PR DESCRIPTION
Avoids copying tools during import by using a custom name to reference them without changing the underlying tool name. Ensures that Proxy tools can be imported successfully.