### PR TITLE
Generate MCP resources and templates on respective classes

### DIFF
--- a/src/fastmcp/resources/resource_manager.py
+++ b/src/fastmcp/resources/resource_manager.py
@@ -7,8 +7,13 @@ from typing import Any
 from pydantic import AnyUrl
 
 from fastmcp.exceptions import ResourceError
-from fastmcp.resources import FunctionResource, Resource
-from fastmcp.resources.template import ResourceTemplate, match_uri_template
+from fastmcp.resources import FunctionResource
+from fastmcp.resources.resource import MCPResource, Resource
+from fastmcp.resources.template import (
+    MCPResourceTemplate,
+    ResourceTemplate,
+    match_uri_template,
+)
 from fastmcp.settings import DuplicateBehavior
 from fastmcp.utilities.logging import get_logger
 
@@ -226,6 +231,21 @@ class ResourceManager:
         """List all registered resources."""
         logger.debug("Listing resources", extra={"count": len(self._resources)})
         return list(self._resources.values())
+
+    def list_mcp_resources(self) -> list[MCPResource]:
+        """List all registered resources in the format expected by the low-level MCP server."""
+
+        return [
+            resource.to_mcp_resource(uri=key)
+            for key, resource in self._resources.items()
+        ]
+
+    def list_mcp_resource_templates(self) -> list[MCPResourceTemplate]:
+        """List all registered resource templates in the format expected by the low-level MCP server."""
+        return [
+            template.to_mcp_template(uriTemplate=key)
+            for key, template in self._templates.items()
+        ]
 
     def get_templates(self) -> dict[str, ResourceTemplate]:
         """Get all registered templates, keyed by URI template."""

--- a/src/fastmcp/resources/resource_manager.py
+++ b/src/fastmcp/resources/resource_manager.py
@@ -203,8 +203,12 @@ class ResourceManager:
         self._templates[storage_key] = template
         return template
 
-    async def get_resource(self, uri: AnyUrl | str) -> Resource | None:
-        """Get resource by URI, checking concrete resources first, then templates."""
+    async def get_resource(self, uri: AnyUrl | str) -> Resource:
+        """Get resource by URI, checking concrete resources first, then templates.
+
+        Raises:
+            ResourceError: If no resource or template matching the URI is found.
+        """
         uri_str = str(uri)
         logger.debug("Getting resource", extra={"uri": uri_str})
 
@@ -221,7 +225,7 @@ class ResourceManager:
                 except Exception as e:
                     raise ValueError(f"Error creating resource from template: {e}")
 
-        raise ResourceError(f"Unknown resource: {uri}")
+        raise ResourceError(f"Unknown resource: {uri_str}")
 
     def get_resources(self) -> dict[str, Resource]:
         """Get all registered resources, keyed by URI."""

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -225,7 +225,12 @@ class FastMCP(Generic[LifespanResultT]):
         converted_result = _convert_to_content(result)
         return converted_result
 
+    def get_resources(self) -> dict[str, Resource]:
+        """Get all registered resources, indexed by registered key."""
+        return self._resource_manager.get_resources()
+
     def list_resources(self) -> list[Resource]:
+        """List all registered resources."""
         return self._resource_manager.list_resources()
 
     async def _mcp_list_resources(self) -> list[MCPResource]:
@@ -236,16 +241,7 @@ class FastMCP(Generic[LifespanResultT]):
         See `list_resources` for a more ergonomic way to list resources.
         """
 
-        resources = self.list_resources()
-        return [
-            MCPResource(
-                uri=resource.uri,
-                name=resource.name or "",
-                description=resource.description,
-                mimeType=resource.mime_type,
-            )
-            for resource in resources
-        ]
+        return self._resource_manager.list_mcp_resources()
 
     def list_resource_templates(self) -> list[ResourceTemplate]:
         return self._resource_manager.list_templates()
@@ -258,15 +254,7 @@ class FastMCP(Generic[LifespanResultT]):
         See `list_resource_templates` for a more ergonomic way to list resource
         templates.
         """
-        templates = self.list_resource_templates()
-        return [
-            MCPResourceTemplate(
-                uriTemplate=template.uri_template,
-                name=template.name,
-                description=template.description,
-            )
-            for template in templates
-        ]
+        return self._resource_manager.list_mcp_resource_templates()
 
     async def read_resource(self, uri: AnyUrl | str) -> str | bytes:
         """Read a resource by URI."""

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -43,6 +43,60 @@ def fastmcp_server():
     return server
 
 
+@pytest.fixture
+def tagged_resources_server():
+    """Fixture that creates a FastMCP server with tagged resources and templates."""
+    server = FastMCP("TaggedResourcesServer")
+
+    # Add a resource with tags
+    @server.resource(
+        uri="data://tagged", tags={"test", "metadata"}, description="A tagged resource"
+    )
+    async def get_tagged_data():
+        return {"type": "tagged_data"}
+
+    # Add a resource template with tags
+    @server.resource(
+        uri="template://{id}",
+        tags={"template", "parameterized"},
+        description="A tagged template",
+    )
+    async def get_template_data(id: str):
+        return {"id": id, "type": "template_data"}
+
+    return server
+
+
+@pytest.fixture
+def mounted_resources_server():
+    """Fixture that creates a FastMCP server with mounted resources."""
+    # Create the main server
+    main_server = FastMCP("MainServer")
+
+    # Create sub-app with its own resources
+    sub_app = FastMCP("SubAppServer")
+
+    # Add a resource to the sub-app
+    @sub_app.resource(uri="subapp://data", description="SubApp resource")
+    async def get_subapp_data():
+        return {"source": "subapp"}
+
+    # Add a template to the sub-app
+    @sub_app.resource(uri="subapp://{id}", description="SubApp template")
+    async def get_subapp_item(id: str):
+        return {"id": id, "source": "subapp"}
+
+    # Mount the sub-app to the main server with a prefix
+    main_server.mount("sub", sub_app)
+
+    # Add a resource to the main server
+    @main_server.resource(uri="main://data", description="Main resource")
+    async def get_main_data():
+        return {"source": "main"}
+
+    return main_server
+
+
 async def test_list_tools(fastmcp_server):
     """Test listing tools with InMemoryClient."""
     client = Client(transport=FastMCPTransport(fastmcp_server))
@@ -157,3 +211,146 @@ async def test_resource_template(fastmcp_server):
         assert '"id": "123"' in content_str
         assert '"name": "User 123"' in content_str
         assert '"active": true' in content_str
+
+
+async def test_mcp_resource_generation(fastmcp_server):
+    """Test that resources are properly generated in MCP format."""
+    client = Client(transport=FastMCPTransport(fastmcp_server))
+
+    async with client:
+        resources = await client.list_resources()
+        assert len(resources) == 1
+        resource = resources[0]
+
+        # Verify resource has correct MCP format
+        assert hasattr(resource, "uri")
+        assert hasattr(resource, "name")
+        assert hasattr(resource, "description")
+        assert str(resource.uri) == "data://users"
+
+
+async def test_mcp_template_generation(fastmcp_server):
+    """Test that templates are properly generated in MCP format."""
+    client = Client(transport=FastMCPTransport(fastmcp_server))
+
+    async with client:
+        templates = await client.list_resource_templates()
+        assert len(templates) == 1
+        template = templates[0]
+
+        # Verify template has correct MCP format
+        assert hasattr(template, "uriTemplate")
+        assert hasattr(template, "name")
+        assert hasattr(template, "description")
+        assert "data://user/{user_id}" in template.uriTemplate
+
+
+async def test_template_access_via_client(fastmcp_server):
+    """Test that templates can be accessed through a client."""
+    client = Client(transport=FastMCPTransport(fastmcp_server))
+
+    async with client:
+        # Verify template works correctly when accessed
+        uri = cast(AnyUrl, "data://user/456")
+        result = await client.read_resource(uri)
+        content_str = str(result[0])
+        assert '"id": "456"' in content_str
+
+
+async def test_tagged_resource_metadata(tagged_resources_server):
+    """Test that resource metadata is preserved in MCP format."""
+    client = Client(transport=FastMCPTransport(tagged_resources_server))
+
+    async with client:
+        resources = await client.list_resources()
+        assert len(resources) == 1
+        resource = resources[0]
+
+        # Verify resource metadata is preserved
+        assert str(resource.uri) == "data://tagged"
+        assert resource.description == "A tagged resource"
+
+
+async def test_tagged_template_metadata(tagged_resources_server):
+    """Test that template metadata is preserved in MCP format."""
+    client = Client(transport=FastMCPTransport(tagged_resources_server))
+
+    async with client:
+        templates = await client.list_resource_templates()
+        assert len(templates) == 1
+        template = templates[0]
+
+        # Verify template metadata is preserved
+        assert "template://{id}" in template.uriTemplate
+        assert template.description == "A tagged template"
+
+
+async def test_tagged_template_functionality(tagged_resources_server):
+    """Test that tagged templates function correctly when accessed."""
+    client = Client(transport=FastMCPTransport(tagged_resources_server))
+
+    async with client:
+        # Verify template functionality
+        uri = cast(AnyUrl, "template://123")
+        result = await client.read_resource(uri)
+        content_str = str(result[0])
+        assert '"id": "123"' in content_str
+        assert '"type": "template_data"' in content_str
+
+
+async def test_mounted_resources(mounted_resources_server):
+    """Test that resources from mounted apps are correctly prefixed."""
+    client = Client(transport=FastMCPTransport(mounted_resources_server))
+
+    async with client:
+        resources = await client.list_resources()
+
+        # Should have two resources (one from main, one from sub)
+        assert len(resources) == 2
+
+        # Find resources by URI
+        main_resource = next(
+            (r for r in resources if str(r.uri) == "main://data"), None
+        )
+        sub_resource = next(
+            (r for r in resources if str(r.uri) == "sub+subapp://data"), None
+        )
+
+        # Both resources should exist
+        assert main_resource is not None
+        assert sub_resource is not None
+
+        # Check descriptions
+        assert main_resource.description == "Main resource"
+        assert sub_resource.description == "SubApp resource"
+
+
+async def test_mounted_templates(mounted_resources_server):
+    """Test that templates from mounted apps are correctly prefixed."""
+    client = Client(transport=FastMCPTransport(mounted_resources_server))
+
+    async with client:
+        templates = await client.list_resource_templates()
+
+        # Should have one template (from sub)
+        assert len(templates) == 1
+
+        # Check the template
+        template = templates[0]
+        assert "sub+subapp://{id}" in template.uriTemplate
+        assert template.description == "SubApp template"
+
+
+async def test_mounted_template_functionality(mounted_resources_server):
+    """Test that templates from mounted apps function correctly."""
+    client = Client(transport=FastMCPTransport(mounted_resources_server))
+
+    async with client:
+        # Use the prefixed template
+        uri = cast(AnyUrl, "sub+subapp://123")
+        result = await client.read_resource(uri)
+        content_str = str(result[0])
+
+        # Check the content
+        assert '"id": "123"' in content_str
+        assert '"source": "subapp"' in content_str


### PR DESCRIPTION
- Generate MCP resources/templates on the relevant object rather than the server
- Fix bug in template matching introduced in #170 