### PR TITLE
[Idea] Delayed Registration of Instance Methods

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -1,0 +1,29 @@
+from src.fastmcp import FastMCP
+
+mcp = FastMCP()
+
+class Sample:
+    def __init__(self, name):
+        self.name = name
+
+    @mcp.tool(delay_registration=True)
+    def first_tool(self):
+        """First tool description."""
+        return f"Executed first tool {self.name}."
+    
+    @mcp.tool(delay_registration=True)
+    def second_tool(self):
+        """Second tool description."""
+        return f"Executed second tool {self.name}."
+    
+first_sample = Sample("First")
+second_sample = Sample("Second")
+
+mcp.perform_delayed_registration("first", first_sample)
+mcp.perform_delayed_registration("second", second_sample)
+
+def main():
+    mcp.run("sse")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Related to: https://github.com/jlowin/fastmcp/issues/174

Add `delay_registration` to the tool decorator (as an example) and a method on the MCP Server to perform delayed registration. 

See both objects get their own tools, which are callable, and return data from the data in the corresponding instance.
<img width="1191" alt="Screenshot 2025-04-15 at 5 55 22 PM" src="https://github.com/user-attachments/assets/87026c73-5ccc-4446-9588-a7d722dce51b" />

The `prefix` implementation is a bit sloppy, ideally prefix would be supported natively on the decorators but anyway