### PR TITLE
Fix missing parentheses in `@mcp.tool` decorator example

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -32,7 +32,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("My MCP Server")
 
-@mcp.tool
+@mcp.tool()
 def greet(name: str) -> str:
     return f"Hello, {name}!"
 ```
@@ -48,7 +48,7 @@ from fastmcp import FastMCP, Client
 
 mcp = FastMCP("My MCP Server")
 
-@mcp.tool
+@mcp.tool()
 def greet(name: str) -> str:
     return f"Hello, {name}!"
 
@@ -75,7 +75,7 @@ from fastmcp import FastMCP, Client
 
 mcp = FastMCP("My MCP Server")
 
-@mcp.tool
+@mcp.tool()
 def greet(name: str) -> str:
     return f"Hello, {name}!"
 


### PR DESCRIPTION
The example in the documentation shows the `@mcp.tool` decorator without parentheses, which leads to a runtime error:

`TypeError: The @tool decorator was used incorrectly. Did you forget to call it? Use @tool() instead of @tool`

This PR adds the missing parentheses (`@mcp.tool()`) in the usage example to avoid confusion and ensure the example works out of the box.

