### PR TITLE
Add an init to make mcp_mixin a module

### DIFF
--- a/src/contrib/mcp_mixin/README.md
+++ b/src/contrib/mcp_mixin/README.md
@@ -10,7 +10,7 @@ Inherit from `MCPMixin` and use the decorators on the methods you want to regist
 
 ```python
 from fastmcp import FastMCP
-from contrib.mcp_mixin.mcp_mixin import MCPMixin, mcp_tool, mcp_resource
+from contrib.mcp_mixin import MCPMixin, mcp_tool, mcp_resource
 
 class MyComponent(MCPMixin):
     @mcp_tool(name="my_tool", description="Does something cool.")

--- a/src/contrib/mcp_mixin/__init__.py
+++ b/src/contrib/mcp_mixin/__init__.py
@@ -1,0 +1,8 @@
+from .mcp_mixin import MCPMixin, mcp_tool, mcp_resource, mcp_prompt
+
+__all__ = [
+    "MCPMixin",
+    "mcp_tool",
+    "mcp_resource",
+    "mcp_prompt",
+]

--- a/src/contrib/mcp_mixin/example.py
+++ b/src/contrib/mcp_mixin/example.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from contrib.mcp_mixin.mcp_mixin import (
+from contrib.mcp_mixin import (
     MCPMixin,
     mcp_prompt,
     mcp_resource,

--- a/tests/contrib/test_mcp_mixin.py
+++ b/tests/contrib/test_mcp_mixin.py
@@ -2,14 +2,16 @@
 
 import pytest
 
-from contrib.mcp_mixin.mcp_mixin import (
-    _DEFAULT_SEPARATOR_PROMPT,
-    _DEFAULT_SEPARATOR_RESOURCE,
-    _DEFAULT_SEPARATOR_TOOL,
+from contrib.mcp_mixin import (
     MCPMixin,
     mcp_prompt,
     mcp_resource,
     mcp_tool,
+)
+from contrib.mcp_mixin.mcp_mixin import (
+    _DEFAULT_SEPARATOR_PROMPT,
+    _DEFAULT_SEPARATOR_RESOURCE,
+    _DEFAULT_SEPARATOR_TOOL,
 )
 from fastmcp import FastMCP
 


### PR DESCRIPTION
Allow usage of mcp_mixin via 

```
from contrib.mcp_mixin import MCPMixin, mcp_tool, mcp_resource
```