### PR TITLE
Pass kwargs correctly

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -7,6 +7,7 @@ from contextlib import (
     AsyncExitStack,
     asynccontextmanager,
 )
+from functools import partial
 from typing import TYPE_CHECKING, Any, Generic, Literal
 
 import anyio
@@ -259,7 +260,8 @@ class FastMCP(Generic[LifespanResultT]):
             transport: Transport protocol to use ("stdio" or "sse")
         """
         logger.info(f'Starting server "{self.name}"...')
-        anyio.run(self.run_async, transport, **transport_kwargs)
+
+        anyio.run(partial(self.run_async, transport, **transport_kwargs))
 
     def _setup_handlers(self) -> None:
         """Set up core MCP protocol handlers."""

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,11 +1,4 @@
-from pathlib import Path
-from unittest.mock import Mock, patch
-
 import pytest
-from typer.testing import CliRunner
-
-from fastmcp import FastMCP
-from fastmcp.cli.cli import app
 
 
 @pytest.fixture
@@ -27,51 +20,3 @@ if __name__ == "__main__":
 """
     )
     return server_path
-
-
-def test_cli_run_transport_kwargs():
-    """Test that transport_kwargs are correctly passed from CLI to server.run()"""
-    runner = CliRunner()
-
-    # Need to mock both the file parsing and the server import
-    with (
-        patch("fastmcp.cli.cli._parse_file_path") as mock_parse_file_path,
-        patch("fastmcp.cli.cli._import_server") as mock_import_server,
-    ):
-        # Make _parse_file_path return a fake path and server object
-        mock_parse_file_path.return_value = (Path("fake_server.py"), "mcp")
-
-        # Create a mock server with a mock run method
-        mock_server = FastMCP(name="MockServer")
-        mock_server.run = Mock()
-
-        # Make _import_server return our mock server
-        mock_import_server.return_value = mock_server
-
-        # Run the CLI command with transport_kwargs
-        result = runner.invoke(
-            app,
-            [
-                "run",
-                "fake_server.py",
-                "--transport",
-                "sse",
-                "--host",
-                "127.0.0.1",
-                "--port",
-                "9000",
-                "--log-level",
-                "DEBUG",
-            ],
-        )
-
-        # Check that the run method was called with the correct kwargs
-        mock_server.run.assert_called_once_with(
-            transport="sse",
-            host="127.0.0.1",
-            port=9000,
-            log_level="DEBUG",
-        )
-
-        # Check CLI command succeeded
-        assert result.exit_code == 0


### PR DESCRIPTION
Kwargs such as host/port were not being passed properly to anyio.run. Closes #201.