### PR TITLE
fix issues with proxy mcp server

### DIFF
--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -45,7 +45,7 @@ class Client:
     ):
         self.transport = infer_transport(transport)
         self._session: ClientSession | None = None
-        self._session_cms: AbstractAsyncContextManager[ClientSession] | None = None
+        self._session_cm: AbstractAsyncContextManager[ClientSession] | None = None
         self._nesting_counter: int = 0
 
         self._session_kwargs: SessionKwargs = {
@@ -95,11 +95,11 @@ class Client:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        self._nesting_counter -= 0
+        self._nesting_counter -= 1
 
-        if self._nesting_counter == 0 and self._session_cms is not None:
-            await self._session_cms.__aexit__(exc_type, exc_val, exc_tb)
-            self._session_cms = None
+        if self._nesting_counter == 0 and self._session_cm is not None:
+            await self._session_cm.__aexit__(exc_type, exc_val, exc_tb)
+            self._session_cm = None
             self._session = None
 
     # --- MCP Client Methods ---

--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -45,7 +45,9 @@ class Client:
     ):
         self.transport = infer_transport(transport)
         # stack to record nested context manager, None is pushed if reuse existing session
-        self._session_cms: list[(AbstractAsyncContextManager[ClientSession], ClientSession)] = []
+        self._session_cms: list[
+            (AbstractAsyncContextManager[ClientSession], ClientSession)
+        ] = []
 
         self._session_kwargs: SessionKwargs = {
             "sampling_callback": None,

--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -65,7 +65,7 @@ class Client:
     @property
     def session(self) -> ClientSession:
         """Get the current active session. Raises RuntimeError if not connected."""
-        if not self._session:
+        if self._session is None:
             raise RuntimeError(
                 "Client is not connected. Use 'async with client:' context manager first."
             )

--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -1,7 +1,7 @@
 import datetime
 from contextlib import AbstractAsyncContextManager
 from pathlib import Path
-from typing import Any, Literal, cast, overload, Tuple
+from typing import Any, Literal, cast, overload
 
 import mcp.types
 from mcp import ClientSession
@@ -46,7 +46,7 @@ class Client:
         self.transport = infer_transport(transport)
         # stack to record nested context manager, None is pushed if reuse existing session
         self._session_cms: list[
-            Tuple[AbstractAsyncContextManager[ClientSession] | None, ClientSession]
+            tuple[AbstractAsyncContextManager[ClientSession] | None, ClientSession]
         ] = []
 
         self._session_kwargs: SessionKwargs = {

--- a/src/fastmcp/server/proxy.py
+++ b/src/fastmcp/server/proxy.py
@@ -3,16 +3,16 @@ from urllib.parse import quote
 
 import mcp.types
 from mcp.server.lowlevel.helper_types import ReadResourceContents
+from mcp.shared.exceptions import McpError
 from mcp.types import (
+    METHOD_NOT_FOUND,
     BlobResourceContents,
     EmbeddedResource,
     GetPromptResult,
     ImageContent,
     TextContent,
     TextResourceContents,
-    METHOD_NOT_FOUND,
 )
-from mcp.shared.exceptions import McpError
 from pydantic.networks import AnyUrl
 
 from fastmcp.client import Client

--- a/src/fastmcp/server/proxy.py
+++ b/src/fastmcp/server/proxy.py
@@ -180,6 +180,8 @@ class FastMCPProxy(FastMCP):
             except McpError as e:
                 if e.error.code == METHOD_NOT_FOUND:
                     client_tools = []
+                else:
+                    raise e
             for tool in client_tools:
                 tool_proxy = await ProxyTool.from_client(self.client, tool)
                 tools[tool_proxy.name] = tool_proxy
@@ -195,6 +197,8 @@ class FastMCPProxy(FastMCP):
             except McpError as e:
                 if e.error.code == METHOD_NOT_FOUND:
                     client_resources = []
+                else:
+                    raise e
             for resource in client_resources:
                 resource_proxy = await ProxyResource.from_client(self.client, resource)
                 resources[str(resource_proxy.uri)] = resource_proxy
@@ -210,6 +214,8 @@ class FastMCPProxy(FastMCP):
             except McpError as e:
                 if e.error.code == METHOD_NOT_FOUND:
                     client_templates = []
+                else:
+                    raise e
             for template in client_templates:
                 template_proxy = await ProxyTemplate.from_client(self.client, template)
                 templates[template_proxy.uri_template] = template_proxy
@@ -225,6 +231,8 @@ class FastMCPProxy(FastMCP):
             except McpError as e:
                 if e.error.code == METHOD_NOT_FOUND:
                     client_prompts = []
+                else:
+                    raise e
             for prompt in client_prompts:
                 prompt_proxy = await ProxyPrompt.from_client(self.client, prompt)
                 prompts[prompt_proxy.name] = prompt_proxy

--- a/src/fastmcp/server/proxy.py
+++ b/src/fastmcp/server/proxy.py
@@ -10,7 +10,9 @@ from mcp.types import (
     ImageContent,
     TextContent,
     TextResourceContents,
+    METHOD_NOT_FOUND,
 )
+from mcp.shared.exceptions import McpError
 from pydantic.networks import AnyUrl
 
 from fastmcp.client import Client
@@ -173,7 +175,12 @@ class FastMCPProxy(FastMCP):
         tools = await super().get_tools()
 
         async with self.client:
-            for tool in await self.client.list_tools():
+            try:
+                client_tools =await self.client.list_tools()
+            except McpError as e:
+                if e.error.code == METHOD_NOT_FOUND:
+                    client_tools = []
+            for tool in client_tools:
                 tool_proxy = await ProxyTool.from_client(self.client, tool)
                 tools[tool_proxy.name] = tool_proxy
 
@@ -183,7 +190,12 @@ class FastMCPProxy(FastMCP):
         resources = await super().get_resources()
 
         async with self.client:
-            for resource in await self.client.list_resources():
+            try:
+                client_resources = await self.client.list_resources()
+            except McpError as e:
+                if e.error.code == METHOD_NOT_FOUND:
+                    client_resources = []
+            for resource in client_resources:
                 resource_proxy = await ProxyResource.from_client(self.client, resource)
                 resources[str(resource_proxy.uri)] = resource_proxy
 
@@ -193,7 +205,12 @@ class FastMCPProxy(FastMCP):
         templates = await super().get_resource_templates()
 
         async with self.client:
-            for template in await self.client.list_resource_templates():
+            try:
+                client_templates = await self.client.list_resource_templates()
+            except McpError as e:
+                if e.error.code == METHOD_NOT_FOUND:
+                    client_templates = []
+            for template in client_templates:
                 template_proxy = await ProxyTemplate.from_client(self.client, template)
                 templates[template_proxy.uri_template] = template_proxy
 
@@ -203,7 +220,12 @@ class FastMCPProxy(FastMCP):
         prompts = await super().get_prompts()
 
         async with self.client:
-            for prompt in await self.client.list_prompts():
+            try:
+                client_prompts = await self.client.list_prompts()
+            except McpError as e:
+                if e.error.code == METHOD_NOT_FOUND:
+                    client_prompts = []
+            for prompt in client_prompts:
                 prompt_proxy = await ProxyPrompt.from_client(self.client, prompt)
                 prompts[prompt_proxy.name] = prompt_proxy
         return prompts

--- a/src/fastmcp/server/proxy.py
+++ b/src/fastmcp/server/proxy.py
@@ -176,7 +176,7 @@ class FastMCPProxy(FastMCP):
 
         async with self.client:
             try:
-                client_tools =await self.client.list_tools()
+                client_tools = await self.client.list_tools()
             except McpError as e:
                 if e.error.code == METHOD_NOT_FOUND:
                     client_tools = []

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,15 +1,15 @@
-from typing import cast
-from typing_extensions import Unpack
-from collections.abc import AsyncIterator
-from mcp import ClientSession
 import contextlib
-from mcp.shared.memory import create_client_server_memory_streams
+from collections.abc import AsyncIterator
+from typing import cast
 
 import pytest
+from mcp import ClientSession
+from mcp.shared.memory import create_client_server_memory_streams
 from pydantic import AnyUrl
+from typing_extensions import Unpack
 
 from fastmcp.client import Client
-from fastmcp.client.transports import FastMCPTransport, ClientTransport, SessionKwargs
+from fastmcp.client.transports import ClientTransport, FastMCPTransport, SessionKwargs
 from fastmcp.server.server import FastMCP
 
 
@@ -164,15 +164,18 @@ async def test_client_connection(fastmcp_server):
     # After connection
     assert not client.is_connected()
 
+
 async def test_client_nested_context_manager(fastmcp_server):
     """Test that the client connects and disconnects once in nested context manager."""
+
     class MockTransport(ClientTransport):
         def __init__(self):
             self._connected = False
 
         @contextlib.asynccontextmanager
         async def connect_session(
-            self, **session_kwargs: Unpack[SessionKwargs],
+            self,
+            **session_kwargs: Unpack[SessionKwargs],
         ) -> AsyncIterator[ClientSession]:
             assert not self._connected, "Transport is connected multiple times"
             self._connected = True
@@ -199,6 +202,7 @@ async def test_client_nested_context_manager(fastmcp_server):
 
     # After connection
     assert not client.is_connected()
+
 
 async def test_resource_template(fastmcp_server):
     """Test using a resource template with InMemoryClient."""

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,10 +1,15 @@
 from typing import cast
+from typing_extensions import Unpack
+from collections.abc import AsyncIterator
+from mcp import ClientSession
+import contextlib
+from mcp.shared.memory import create_client_server_memory_streams
 
 import pytest
 from pydantic import AnyUrl
 
 from fastmcp.client import Client
-from fastmcp.client.transports import FastMCPTransport
+from fastmcp.client.transports import FastMCPTransport, ClientTransport, SessionKwargs
 from fastmcp.server.server import FastMCP
 
 
@@ -159,6 +164,38 @@ async def test_client_connection(fastmcp_server):
     # After connection
     assert not client.is_connected()
 
+async def test_client_nested_context_manager(fastmcp_server):
+    """Test that the client connects and disconnects once in nested context manager."""
+    class MockTransport(ClientTransport):
+        def __init__(self):
+            self._connected = False
+
+        @contextlib.asynccontextmanager
+        async def connect_session(
+            self, **session_kwargs: Unpack[SessionKwargs],
+        ) -> AsyncIterator[ClientSession]:
+            assert not self._connected, "Transport is connected multiple times"
+            self._connected = True
+            async with create_client_server_memory_streams() as (
+                _,
+                server_streams,
+            ):
+                yield ClientSession(*server_streams)
+
+    client = Client(transport=MockTransport())
+
+    # Before connection
+    assert not client.is_connected()
+
+    # During connection
+    async with client:
+        assert client.is_connected()
+
+        async with client:
+            assert client.is_connected()
+
+    # After connection
+    assert not client.is_connected()
 
 async def test_resource_template(fastmcp_server):
     """Test using a resource template with InMemoryClient."""

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -194,6 +194,9 @@ async def test_client_nested_context_manager(fastmcp_server):
         async with client:
             assert client.is_connected()
 
+        async with client:
+            assert client.is_connected()
+
     # After connection
     assert not client.is_connected()
 


### PR DESCRIPTION
Fix two issues with proxy mcp server, let me know if you want to separate into two PRs:
1. tolerate METHOD_NOT_FOUND error, because the legacy server might not support all methods
2. Fix nested client context manager behavior which is important for proxy server use case.

  ```python
  with Client(...) as client:
    proxy_mcp = MCPServer.from_client(client)
    # operations will create nested context manager on client, and they should reuse the existing session.
    await proxy_mcp.list_tools()
  ```