### PR TITLE
#267 Fix openapi template resource to support multiple path parameters

### DIFF
--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -296,7 +296,7 @@ class OpenAPIResource(Resource):
                             # Ensure we don't use resource identifier as parameter
                             if i < expected_param_count:
                                 # Get values from the end of parts
-                                param_value = parts[-1 -i]
+                                param_value = parts[-1 - i]
                                 path_params[param_name] = param_value
 
                     # Replace path parameters with their values

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -289,12 +289,14 @@ class OpenAPIResource(Resource):
                         # Reverse sorting from creation order (traversal is backwards)
                         param_matches.sort(reverse=True)
                         # Number of sent parameters is number of parts -1 (assuming first part is resource identifier)
-                        expected_param_count = len(parts) -1
+                        expected_param_count = len(parts) - 1
                         # Map parameters from the end of the URI to the parameters in the path
                         # Last parameter in URI (parts[-1]) maps to last parameter in path, and so on
                         for i, param_name in enumerate(param_matches):
-                            if i < expected_param_count:  # Ensure we don't use resource identifier as parameter
-                                param_value = parts[-1-i]  # Get values from the end of parts
+                            # Ensure we don't use resource identifier as parameter
+                            if i < expected_param_count: 
+                                # Get values from the end of parts 
+                                param_value = parts[-1-i]
                                 path_params[param_name] = param_value
 
                     # Replace path parameters with their values

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -294,9 +294,9 @@ class OpenAPIResource(Resource):
                         # Last parameter in URI (parts[-1]) maps to last parameter in path, and so on
                         for i, param_name in enumerate(param_matches):
                             # Ensure we don't use resource identifier as parameter
-                            if i < expected_param_count: 
-                                # Get values from the end of parts 
-                                param_value = parts[-1-i]
+                            if i < expected_param_count:
+                                # Get values from the end of parts
+                                param_value = parts[-1 -i]
                                 path_params[param_name] = param_value
 
                     # Replace path parameters with their values

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -278,7 +278,7 @@ class OpenAPIResource(Resource):
             if "{" in path and "}" in path:
                 # Extract the resource ID from the URI (the last part after the last slash)
                 parts = resource_uri.split("/")
-                
+
                 if len(parts) > 1:
                     # Find all path parameters in the route path
                     path_params = {}

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -278,21 +278,22 @@ class OpenAPIResource(Resource):
             if "{" in path and "}" in path:
                 # Extract the resource ID from the URI (the last part after the last slash)
                 parts = resource_uri.split("/")
+                
                 if len(parts) > 1:
                     # Find all path parameters in the route path
                     path_params = {}
 
-                    # Extract parameters from the URI
-                    param_value = parts[
-                        -1
-                    ]  # The last part contains the parameter value
-
-                    # Find the path parameter name from the route path
+                    # Find the path parameter names from the route path
                     param_matches = re.findall(r"\{([^}]+)\}", path)
                     if param_matches:
-                        # Assume the last parameter in the URI is for the first path parameter in the route
-                        path_param_name = param_matches[0]
-                        path_params[path_param_name] = param_value
+                        # Number of sent parameters is number of parts -1 (assuming first part is resource identifier)
+                        expected_param_count = len(parts) -1
+                        # Map parameters from the end of the URI to the parameters in the path
+                        # Last parameter in URI (parts[-1]) maps to last parameter in path, and so on
+                        for i, param_name in enumerate(param_matches):
+                            if i < len(expected_param_count):  # Ensure we don't use resource identifier as parameter
+                                param_value = parts[-1-i]  # Get values from the end of parts
+                                path_params[param_name] = param_value
 
                     # Replace path parameters with their values
                     for param_name, param_value in path_params.items():

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -286,12 +286,14 @@ class OpenAPIResource(Resource):
                     # Find the path parameter names from the route path
                     param_matches = re.findall(r"\{([^}]+)\}", path)
                     if param_matches:
+                        # Reverse sorting from creation order (traversal is backwards)
+                        param_matches.sort(reverse=True)
                         # Number of sent parameters is number of parts -1 (assuming first part is resource identifier)
                         expected_param_count = len(parts) -1
                         # Map parameters from the end of the URI to the parameters in the path
                         # Last parameter in URI (parts[-1]) maps to last parameter in path, and so on
                         for i, param_name in enumerate(param_matches):
-                            if i < len(expected_param_count):  # Ensure we don't use resource identifier as parameter
+                            if i < expected_param_count:  # Ensure we don't use resource identifier as parameter
                                 param_value = parts[-1-i]  # Get values from the end of parts
                                 path_params[param_name] = param_value
 

--- a/tests/server/test_openapi.py
+++ b/tests/server/test_openapi.py
@@ -318,7 +318,7 @@ class TestResourceTemplates:
             == r"resource://openapi/get_user_users__user_id__get/{user_id}"
         )
         assert (
-            resource_templates[1].name 
+            resource_templates[1].name
             == "get_user_active_state_users__user_id___is_active__get"
         )
         assert (

--- a/tests/server/test_openapi.py
+++ b/tests/server/test_openapi.py
@@ -50,7 +50,7 @@ def fastapi_app(users_db: dict[int, User]) -> FastAPI:
     async def get_user(user_id: int) -> User | None:
         """Get a user by ID."""
         return users_db.get(user_id)
-    
+
     @app.get("/users/{user_id}/{is_active}", tags=["users", "detail"])
     async def get_user_active_state(user_id: int, is_active: bool) -> User | None:
         """Get a user by ID and filter by active state."""

--- a/tests/server/test_openapi.py
+++ b/tests/server/test_openapi.py
@@ -317,7 +317,10 @@ class TestResourceTemplates:
             resource_templates[0].uriTemplate
             == r"resource://openapi/get_user_users__user_id__get/{user_id}"
         )
-        assert resource_templates[1].name == "get_user_active_state_users__user_id___is_active__get"
+        assert (
+            resource_templates[1].name 
+            == "get_user_active_state_users__user_id___is_active__get"
+        )
         assert (
             resource_templates[1].uriTemplate
             == r"resource://openapi/get_user_active_state_users__user_id___is_active__get/{is_active}/{user_id}"

--- a/tests/server/test_openapi.py
+++ b/tests/server/test_openapi.py
@@ -53,7 +53,7 @@ def fastapi_app(users_db: dict[int, User]) -> FastAPI:
     
     @app.get("/users/{user_id}/{is_active}", tags=["users", "detail"])
     async def get_user_active_state(user_id: int, is_active: bool) -> User | None:
-        """Get a user by ID."""
+        """Get a user by ID and filter by active state."""
         user = users_db.get(user_id)
         if user is not None and user.active == is_active:
             return user
@@ -359,7 +359,7 @@ class TestResourceTemplates:
         is_active = True
         async with Client(fastmcp_openapi_server) as client:
             resource_response = await client.read_resource(
-                f"resource://openapi/get_user_users__user_type__user_id__get/{user_id}/{is_active}"
+                f"resource://openapi/get_user_active_state_users__user_id___is_active__get/{is_active}/{user_id}"
             )
             assert isinstance(resource_response[0], TextResourceContents)
             response_text = resource_response[0].text

--- a/tests/server/test_openapi.py
+++ b/tests/server/test_openapi.py
@@ -348,7 +348,6 @@ class TestResourceTemplates:
         response = await api_client.get(f"/users/{user_id}")
         assert resource == response.json()
 
-
     async def test_get_resource_template_multi_param(
         self,
         fastmcp_openapi_server: FastMCPOpenAPI,


### PR DESCRIPTION
The implementation now correctly handles multiple path parameters in OpenAPI endpoints. Previously, only the last parameter was recognized, leading to incorrect behavior when accessing resources with multiple parameters. The changes include updates to the parameter extraction logic and the addition of tests to ensure proper functionality. This addresses issue https://github.com/jlowin/fastmcp/issues/267.