### PR TITLE
Ensure openapi tool responses are properly converted

### DIFF
--- a/src/fastmcp/server/proxy.py
+++ b/src/fastmcp/server/proxy.py
@@ -61,7 +61,7 @@ class ProxyTool(Tool):
         self,
         arguments: dict[str, Any],
         context: Context[ServerSessionT, LifespanContextT] | None = None,
-    ) -> Any:
+    ) -> list[TextContent | ImageContent | EmbeddedResource]:
         # the client context manager will swallow any exceptions inside a TaskGroup
         # so we return the raw result and raise an exception ourselves
         async with self._client:


### PR DESCRIPTION
Closes #275, supersedes #277 

If an openapi tool returned a list, it was not properly converted to an MCP response. This ensures _convert_to_content is always called.