### PR TITLE
Handle *args/**kwargs appropriately for various components

### DIFF
--- a/docs/servers/prompts.mdx
+++ b/docs/servers/prompts.mdx
@@ -53,6 +53,9 @@ def generate_code_request(language: str, task_description: str) -> UserMessage:
 *   **Inferred Metadata:** By default:
     *   Prompt Name: Taken from the function name (`ask_about_topic`).
     *   Prompt Description: Taken from the function's docstring.
+<Tip>
+Functions with `*args` or `**kwargs` are not supported as prompts. This restriction exists because FastMCP needs to generate a complete parameter schema for the MCP protocol, which isn't possible with variable argument lists.
+</Tip>
 
 ### Return Values
 
@@ -104,6 +107,7 @@ def generate_content_request(
         
     return prompt
 ```
+
 
 ### Required vs. Optional Parameters
 

--- a/docs/servers/resources.mdx
+++ b/docs/servers/resources.mdx
@@ -239,6 +239,10 @@ Resource templates share most configuration options with regular resources (name
 
 Resource templates generate a new resource for each unique set of parameters, which means that resources can be dynamically created on-demand. For example, if the resource template `"user://profile/{name}"` is registered, MCP clients could request `"user://profile/ford"` or `"user://profile/marvin"` to retrieve either of those two user profiles as resources, without having to register each resource individually.
 
+<Tip>
+Functions with `*args` are not supported as resource templates. However, unlike tools and prompts, resource templates do support `**kwargs` because the URI template defines specific parameter names that will be collected and passed as keyword arguments.
+</Tip>
+
 Here is a complete example that shows how to define two resource templates:
 
 ```python

--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -43,8 +43,11 @@ When this tool is registered, FastMCP automatically:
 - Generates an input schema based on the function's parameters and type annotations.
 - Handles parameter validation and error reporting.
 
-
 The way you define your Python function dictates how the tool appears and behaves for the LLM client.
+
+<Tip>
+Functions with `*args` or `**kwargs` are not supported as tools. This restriction exists because FastMCP needs to generate a complete parameter schema for the MCP protocol, which isn't possible with variable argument lists.
+</Tip>
 
 ### Parameters
 
@@ -89,6 +92,7 @@ def process_image(
     """Process an image with optional resizing."""
     # Implementation...
 ```
+
 
 You can also use the Field as a default value, though the Annotated approach is preferred:
 

--- a/src/fastmcp/prompts/prompt.py
+++ b/src/fastmcp/prompts/prompt.py
@@ -111,6 +111,13 @@ class Prompt(BaseModel):
 
         if func_name == "<lambda>":
             raise ValueError("You must provide a name for lambda functions")
+            # Reject functions with *args or **kwargs
+        sig = inspect.signature(fn)
+        for param in sig.parameters.values():
+            if param.kind == inspect.Parameter.VAR_POSITIONAL:
+                raise ValueError("Functions with *args are not supported as prompts")
+            if param.kind == inspect.Parameter.VAR_KEYWORD:
+                raise ValueError("Functions with **kwargs are not supported as prompts")
 
         type_adapter = get_cached_typeadapter(fn)
         parameters = type_adapter.json_schema()

--- a/src/fastmcp/resources/template.py
+++ b/src/fastmcp/resources/template.py
@@ -146,7 +146,7 @@ class ResourceTemplate(BaseModel):
                 f"Required function arguments {required_params} must be a subset of the URI parameters {uri_params}"
             )
 
-        # CHeck if the URI parameters are a subset of the function parameters (skip if **kwargs present)
+        # Check if the URI parameters are a subset of the function parameters (skip if **kwargs present)
         if not any(
             param.kind == inspect.Parameter.VAR_KEYWORD
             for param in sig.parameters.values()

--- a/src/fastmcp/resources/template.py
+++ b/src/fastmcp/resources/template.py
@@ -109,6 +109,15 @@ class ResourceTemplate(BaseModel):
         if func_name == "<lambda>":
             raise ValueError("You must provide a name for lambda functions")
 
+        # Reject functions with *args
+        # (**kwargs is allowed because the URI will define the parameter names)
+        sig = inspect.signature(fn)
+        for param in sig.parameters.values():
+            if param.kind == inspect.Parameter.VAR_POSITIONAL:
+                raise ValueError(
+                    "Functions with *args are not supported as resource templates"
+                )
+
         # Auto-detect context parameter if not provided
         if context_kwarg is None:
             context_kwarg = find_kwarg_by_type(fn, kwarg_type=Context)
@@ -118,7 +127,7 @@ class ResourceTemplate(BaseModel):
         if not uri_params:
             raise ValueError("URI template must contain at least one parameter")
 
-        func_params = set(inspect.signature(fn).parameters.keys())
+        func_params = set(sig.parameters.keys())
         if context_kwarg:
             func_params.discard(context_kwarg)
 
@@ -126,20 +135,26 @@ class ResourceTemplate(BaseModel):
         required_params = {
             p
             for p in func_params
-            if inspect.signature(fn).parameters[p].default is inspect.Parameter.empty
+            if sig.parameters[p].default is inspect.Parameter.empty
+            and sig.parameters[p].kind != inspect.Parameter.VAR_KEYWORD
+            and p != context_kwarg
         }
-        if context_kwarg and context_kwarg in required_params:
-            required_params.discard(context_kwarg)
 
+        # Check if required parameters are a subset of the URI parameters
         if not required_params.issubset(uri_params):
             raise ValueError(
-                f"URI parameters {uri_params} must be a subset of the required function arguments: {required_params}"
+                f"Required function arguments {required_params} must be a subset of the URI parameters {uri_params}"
             )
 
-        if not uri_params.issubset(func_params):
-            raise ValueError(
-                f"URI parameters {uri_params} must be a subset of the function arguments: {func_params}"
-            )
+        # CHeck if the URI parameters are a subset of the function parameters (skip if **kwargs present)
+        if not any(
+            param.kind == inspect.Parameter.VAR_KEYWORD
+            for param in sig.parameters.values()
+        ):
+            if not uri_params.issubset(func_params):
+                raise ValueError(
+                    f"URI parameters {uri_params} must be a subset of the function arguments: {func_params}"
+                )
 
         # Get schema from TypeAdapter - will fail if function isn't properly typed
         parameters = TypeAdapter(fn).json_schema()

--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -67,6 +67,14 @@ class Tool(BaseModel):
         """Create a Tool from a function."""
         from fastmcp import Context
 
+        # Reject functions with *args or **kwargs
+        sig = inspect.signature(fn)
+        for param in sig.parameters.values():
+            if param.kind == inspect.Parameter.VAR_POSITIONAL:
+                raise ValueError("Functions with *args are not supported as tools")
+            if param.kind == inspect.Parameter.VAR_KEYWORD:
+                raise ValueError("Functions with **kwargs are not supported as tools")
+
         func_name = name or fn.__name__
 
         if func_name == "<lambda>":

--- a/tests/prompts/test_prompt_manager.py
+++ b/tests/prompts/test_prompt_manager.py
@@ -189,6 +189,30 @@ class TestPromptManager:
         with pytest.raises(ValueError, match="Missing required arguments"):
             await manager.render_prompt("fn")
 
+    async def test_prompt_with_varargs_not_allowed(self):
+        """Test that a prompt with *args is not allowed."""
+
+        def fn(*args: int) -> str:
+            return f"Hello, {args}!"
+
+        manager = PromptManager()
+        with pytest.raises(
+            ValueError, match=r"Functions with \*args are not supported as prompts"
+        ):
+            manager.add_prompt(Prompt.from_function(fn))
+
+    async def test_prompt_with_varkwargs_not_allowed(self):
+        """Test that a prompt with **kwargs is not allowed."""
+
+        def fn(**kwargs: int) -> str:
+            return f"Hello, {kwargs}!"
+
+        manager = PromptManager()
+        with pytest.raises(
+            ValueError, match=r"Functions with \*\*kwargs are not supported as prompts"
+        ):
+            manager.add_prompt(Prompt.from_function(fn))
+
 
 class TestPromptTags:
     """Test functionality related to prompt tags."""

--- a/tests/server/test_server_interactions.py
+++ b/tests/server/test_server_interactions.py
@@ -930,7 +930,7 @@ class TestResourceTemplates:
 
         with pytest.raises(
             ValueError,
-            match="URI parameters .* must be a subset of the required function arguments",
+            match="Required function arguments .* must be a subset of the URI parameters",
         ):
 
             @mcp.resource("resource://{name}/data")
@@ -958,7 +958,7 @@ class TestResourceTemplates:
 
         with pytest.raises(
             ValueError,
-            match="URI parameters .* must be a subset of the required function arguments",
+            match="Required function arguments .* must be a subset of the URI parameters",
         ):
 
             @mcp.resource("resource://{org}/{repo}/data")
@@ -976,6 +976,19 @@ class TestResourceTemplates:
             result = await client.read_resource(AnyUrl("resource://static"))
             assert isinstance(result[0], TextResourceContents)
             assert result[0].text == "Static data"
+
+    async def test_template_with_varkwargs(self):
+        """Test that a template can have **kwargs."""
+        mcp = FastMCP()
+
+        @mcp.resource("test://{x}/{y}/{z}")
+        def func(**kwargs: int) -> int:
+            return sum(kwargs.values())
+
+        async with Client(mcp) as client:
+            result = await client.read_resource(AnyUrl("test://1/2/3"))
+            assert isinstance(result[0], TextResourceContents)
+            assert result[0].text == "6"
 
     async def test_template_with_default_params(self):
         """Test that a template can have default parameters."""

--- a/tests/tools/test_tool_manager.py
+++ b/tests/tools/test_tool_manager.py
@@ -84,9 +84,9 @@ class TestAddTools:
         assert tool.parameters["properties"]["data"]["type"] == "string"
         assert isinstance(result[0], ImageContent)
 
-    def test_add_invalid_tool(self):
+    def test_add_noncallable_tool(self):
         manager = ToolManager()
-        with pytest.raises(AttributeError):
+        with pytest.raises(TypeError, match="not a callable object"):
             manager.add_tool_from_fn(1)  # type: ignore
 
     def test_add_lambda(self):


### PR DESCRIPTION
Closes #313 

This PR:
- prevents registering tools with *args / **kwargs (because no sensible parameter schema can be generated)
- prevents registering templates with *args but allows **kwargs (because parameter names are inferred from the URI template)
- prevents registering prompts with *args / **kwargs