### PR TITLE
Prevent invalid resource URIs

### DIFF
--- a/tests/server/test_import_server.py
+++ b/tests/server/test_import_server.py
@@ -1,6 +1,7 @@
 import json
 from urllib.parse import quote
 
+import pytest
 from mcp.types import TextContent, TextResourceContents
 
 from fastmcp.client.client import Client
@@ -391,3 +392,25 @@ async def test_import_with_proxy_resource_templates():
         user_data = json.loads(result[0].text)
         assert user_data["name"] == "John Doe"
         assert user_data["email"] == "john@example.com"
+
+
+async def test_import_invalid_resource_prefix():
+    main_app = FastMCP("MainApp")
+    api_app = FastMCP("APIApp")
+
+    with pytest.raises(
+        ValueError,
+        match="Resource prefix or separator would result in an invalid resource URI",
+    ):
+        await main_app.import_server("api_sub", api_app)
+
+
+async def test_import_invalid_resource_separator():
+    main_app = FastMCP("MainApp")
+    api_app = FastMCP("APIApp")
+
+    with pytest.raises(
+        ValueError,
+        match="Resource prefix or separator would result in an invalid resource URI",
+    ):
+        await main_app.import_server("api", api_app, resource_separator="_")

--- a/tests/server/test_mount.py
+++ b/tests/server/test_mount.py
@@ -59,6 +59,26 @@ class TestBasicMount:
         assert isinstance(result[0], TextContent)
         assert result[0].text == "Hello, World!"
 
+    async def test_mount_invalid_resource_prefix(self):
+        main_app = FastMCP("MainApp")
+        api_app = FastMCP("APIApp")
+
+        with pytest.raises(
+            ValueError,
+            match="Resource prefix or separator would result in an invalid resource URI",
+        ):
+            main_app.mount("api_sub", api_app)
+
+    async def test_mount_invalid_resource_separator(self):
+        main_app = FastMCP("MainApp")
+        api_app = FastMCP("APIApp")
+
+        with pytest.raises(
+            ValueError,
+            match="Resource prefix or separator would result in an invalid resource URI",
+        ):
+            main_app.mount("api", api_app, resource_separator="_")
+
     async def test_unmount_server(self):
         """Test unmounting a server removes access to its tools."""
         main_app = FastMCP("MainApp")


### PR DESCRIPTION
Adds a validation check that will raise an error if invalid resource URIs are created via mount or import prefix.

Closes #335 