### PR TITLE
Coerce numbers to str

### DIFF
--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -127,7 +127,9 @@ class Tool(BaseModel):
                     except json.JSONDecodeError:
                         pass
 
-            type_adapter = get_cached_typeadapter(self.fn)
+            type_adapter = get_cached_typeadapter(
+                self.fn, config=frozenset([("coerce_numbers_to_str", True)])
+            )
             result = type_adapter.validate_python(parsed_args | injected_args)
             if inspect.isawaitable(result):
                 result = await result

--- a/src/fastmcp/utilities/types.py
+++ b/src/fastmcp/utilities/types.py
@@ -6,23 +6,26 @@ from collections.abc import Callable
 from functools import lru_cache
 from pathlib import Path
 from types import UnionType
-from typing import Annotated, TypeVar, Union, get_args, get_origin
+from typing import Annotated, Any, TypeVar, Union, get_args, get_origin
 
 from mcp.types import ImageContent
-from pydantic import TypeAdapter
+from pydantic import ConfigDict, TypeAdapter
 
 T = TypeVar("T")
 
 
 @lru_cache(maxsize=5000)
-def get_cached_typeadapter(cls: T) -> TypeAdapter[T]:
+def get_cached_typeadapter(
+    cls: T, config: frozenset[tuple[str, Any]] | None = None
+) -> TypeAdapter[T]:
     """
     TypeAdapters are heavy objects, and in an application context we'd typically
     create them once in a global scope and reuse them as often as possible.
     However, this isn't feasible for user-generated functions. Instead, we use a
     cache to minimize the cost of creating them as much as possible.
     """
-    return TypeAdapter(cls)
+    config_dict = dict(config or {})
+    return TypeAdapter(cls, config=ConfigDict(**config_dict))
 
 
 def issubclass_safe(cls: type, base: type) -> bool:


### PR DESCRIPTION
Closes #330 

This PR is a hotfix for #330 because the behavior is pathological. A full fix will probably require removing the auto-json parsing to ensure we don't inadvertently introduce other related edge cases (such as turning the literal string `"true"` into a bool).

The cause of the issue is an old (dating to v1) behavior that attempts to parse all tool arguments to JSON before passing them to the tool. This is because Claude Desktop tends to send stringified JSON instead of proper objects. However, this means that JSON-like arguments (such as stringified integers) are converted into integers. Pydantic does not automatically convert integers into strings (it did in v1, it does not in v2), which created this unexpected conversion error. As a temporary solution I am enabling number to string conversion but I believe we need to remove the auto parsing behavior entirely. I want to get this hotfix out quickly because of the users reporting issues. 