### PR TITLE
Streamable HTTP support

### DIFF
--- a/src/fastmcp/server/http.py
+++ b/src/fastmcp/server/http.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Callable, Generator
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from mcp.server.auth.middleware.auth_context import AuthContextMiddleware
 from mcp.server.auth.middleware.bearer_auth import (
@@ -32,7 +32,6 @@ try:
     STREAMABLE_HTTP_AVAILABLE = True
 except ImportError:
     STREAMABLE_HTTP_AVAILABLE = False
-
 
 if TYPE_CHECKING:
     from fastmcp.server.server import FastMCP
@@ -68,6 +67,85 @@ class RequestContextMiddleware:
                 await self.app(scope, receive, send)
         else:
             await self.app(scope, receive, send)
+
+
+def setup_auth_middleware_and_routes(
+    auth_server_provider: OAuthAuthorizationServerProvider | None,
+    auth_settings: AuthSettings | None,
+) -> tuple[list[Middleware], list[Route | Mount], list[str]]:
+    """Set up authentication middleware and routes if auth is enabled.
+
+    Args:
+        auth_server_provider: The OAuth authorization server provider
+        auth_settings: The auth settings
+
+    Returns:
+        Tuple of (middleware, auth_routes, required_scopes)
+    """
+    middleware: list[Middleware] = []
+    auth_routes: list[Route | Mount] = []
+    required_scopes: list[str] = []
+
+    if auth_server_provider:
+        if not auth_settings:
+            raise ValueError(
+                "auth_settings must be provided when auth_server_provider is specified"
+            )
+
+        middleware = [
+            Middleware(
+                AuthenticationMiddleware,
+                backend=BearerAuthBackend(provider=auth_server_provider),
+            ),
+            Middleware(AuthContextMiddleware),
+        ]
+
+        required_scopes = auth_settings.required_scopes or []
+
+        auth_routes.extend(
+            create_auth_routes(
+                provider=auth_server_provider,
+                issuer_url=auth_settings.issuer_url,
+                service_documentation_url=auth_settings.service_documentation_url,
+                client_registration_options=auth_settings.client_registration_options,
+                revocation_options=auth_settings.revocation_options,
+            )
+        )
+
+    return middleware, auth_routes, required_scopes
+
+
+def create_base_app(
+    routes: list[Route | Mount],
+    middleware: list[Middleware],
+    debug: bool,
+    lifespan: Callable | None = None,
+) -> Starlette:
+    """Create a base Starlette app with common middleware and routes.
+
+    Args:
+        routes: List of routes to include in the app
+        middleware: List of middleware to include in the app
+        debug: Whether to enable debug mode
+        lifespan: Optional lifespan manager for the app
+
+    Returns:
+        A Starlette application
+    """
+    # Always add RequestContextMiddleware as the outermost middleware
+    middleware.append(Middleware(RequestContextMiddleware))
+
+    # Create the app
+    app_kwargs = {
+        "debug": debug,
+        "routes": routes,
+        "middleware": middleware,
+    }
+
+    if lifespan:
+        app_kwargs["lifespan"] = lifespan
+
+    return Starlette(**app_kwargs)
 
 
 def create_sse_app(
@@ -106,42 +184,17 @@ def create_sse_app(
             )
         return Response()
 
-    # Configure routes and middleware
-    routes: list[Route | Mount] = []
-    middleware: list[Middleware] = []
+    # Get auth middleware and routes
+    middleware, auth_routes, required_scopes = setup_auth_middleware_and_routes(
+        auth_server_provider, auth_settings
+    )
 
-    # Handle authentication configuration
+    # Initialize routes with auth routes
+    routes: list[Route | Mount] = auth_routes.copy()
+
+    # Add SSE routes with or without auth
     if auth_server_provider:
-        # Ensure auth settings are provided when auth provider is present
-        if not auth_settings:
-            raise ValueError(
-                "auth_settings must be provided when auth_server_provider is specified"
-            )
-
-        # Configure auth middleware
-        middleware = [
-            Middleware(
-                AuthenticationMiddleware,
-                backend=BearerAuthBackend(provider=auth_server_provider),
-            ),
-            Middleware(AuthContextMiddleware),
-        ]
-
-        # Get required scopes for authentication
-        required_scopes = auth_settings.required_scopes or []
-
-        # Add auth routes
-        routes.extend(
-            create_auth_routes(
-                provider=auth_server_provider,
-                issuer_url=auth_settings.issuer_url,
-                service_documentation_url=auth_settings.service_documentation_url,
-                client_registration_options=auth_settings.client_registration_options,
-                revocation_options=auth_settings.revocation_options,
-            )
-        )
-
-        # Add authenticated routes
+        # Auth is enabled, wrap endpoints with RequireAuthMiddleware
         routes.append(
             Route(
                 sse_path,
@@ -156,7 +209,7 @@ def create_sse_app(
             )
         )
     else:
-        # No authentication required
+        # No auth required
         async def sse_endpoint(request: Request) -> Response:
             return await handle_sse(request.scope, request.receive, request._send)  # type: ignore[reportPrivateUsage]
 
@@ -176,13 +229,10 @@ def create_sse_app(
 
     # Add custom routes with lowest precedence
     if additional_routes:
-        routes.extend(additional_routes)
+        routes.extend(cast(list[Route | Mount], additional_routes))
 
-    # Add RequestContextMiddleware as the outermost middleware
-    middleware.append(Middleware(RequestContextMiddleware))
-
-    # Create and return the Starlette app with middleware
-    return Starlette(debug=debug, routes=routes, middleware=middleware)
+    # Create and return the app
+    return create_base_app(routes, middleware, debug)
 
 
 def create_streamable_http_app(
@@ -231,42 +281,17 @@ def create_streamable_http_app(
     ) -> None:
         await session_manager.handle_request(scope, receive, send)
 
-    # Configure routes and middleware
-    routes: list[Route | Mount] = []
-    middleware: list[Middleware] = []
+    # Get auth middleware and routes
+    middleware, auth_routes, required_scopes = setup_auth_middleware_and_routes(
+        auth_server_provider, auth_settings
+    )
 
-    # Handle authentication configuration
+    # Initialize routes with auth routes
+    routes: list[Route | Mount] = auth_routes.copy()
+
+    # Add StreamableHTTP routes with or without auth
     if auth_server_provider:
-        # Ensure auth settings are provided when auth provider is present
-        if not auth_settings:
-            raise ValueError(
-                "auth_settings must be provided when auth_server_provider is specified"
-            )
-
-        # Configure auth middleware
-        middleware = [
-            Middleware(
-                AuthenticationMiddleware,
-                backend=BearerAuthBackend(provider=auth_server_provider),
-            ),
-            Middleware(AuthContextMiddleware),
-        ]
-
-        # Get required scopes for authentication
-        required_scopes = auth_settings.required_scopes or []
-
-        # Add auth routes
-        routes.extend(
-            create_auth_routes(
-                provider=auth_server_provider,
-                issuer_url=auth_settings.issuer_url,
-                service_documentation_url=auth_settings.service_documentation_url,
-                client_registration_options=auth_settings.client_registration_options,
-                revocation_options=auth_settings.revocation_options,
-            )
-        )
-
-        # Add authenticated route
+        # Auth is enabled, wrap endpoint with RequireAuthMiddleware
         routes.append(
             Mount(
                 streamable_http_path,
@@ -274,7 +299,7 @@ def create_streamable_http_app(
             )
         )
     else:
-        # No authentication required
+        # No auth required
         routes.append(
             Mount(
                 streamable_http_path,
@@ -284,10 +309,7 @@ def create_streamable_http_app(
 
     # Add custom routes with lowest precedence
     if additional_routes:
-        routes.extend(additional_routes)
-
-    # Add RequestContextMiddleware as the outermost middleware
-    middleware.append(Middleware(RequestContextMiddleware))
+        routes.extend(cast(list[Route | Mount], additional_routes))
 
     # Create a lifespan manager to start and stop the session manager
     @asynccontextmanager
@@ -295,10 +317,5 @@ def create_streamable_http_app(
         async with session_manager.run():
             yield
 
-    # Create and return the Starlette app with middleware
-    return Starlette(
-        debug=debug,
-        routes=routes,
-        middleware=middleware,
-        lifespan=lifespan,
-    )
+    # Create and return the app with lifespan
+    return create_base_app(routes, middleware, debug, lifespan)

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -146,6 +146,7 @@ class FastMCP(Generic[LifespanResultT]):
                 "is specified"
             )
         self._auth_server_provider = auth_server_provider
+
         self._additional_http_routes: list[Route] = []
         self.dependencies = self.settings.dependencies
 
@@ -167,30 +168,36 @@ class FastMCP(Generic[LifespanResultT]):
         return self._mcp_server.instructions
 
     async def run_async(
-        self, transport: Literal["stdio", "sse"] | None = None, **transport_kwargs: Any
+        self,
+        transport: Literal["stdio", "sse", "streamable-http"] | None = None,
+        **transport_kwargs: Any,
     ) -> None:
         """Run the FastMCP server asynchronously.
 
         Args:
-            transport: Transport protocol to use ("stdio" or "sse")
+            transport: Transport protocol to use ("stdio", "sse", or "streamable-http")
         """
         if transport is None:
             transport = "stdio"
-        if transport not in ["stdio", "sse"]:
+        if transport not in ["stdio", "sse", "streamable-http"]:
             raise ValueError(f"Unknown transport: {transport}")
 
         if transport == "stdio":
             await self.run_stdio_async(**transport_kwargs)
-        else:  # transport == "sse"
+        elif transport == "sse":
             await self.run_sse_async(**transport_kwargs)
+        else:  # transport == "streamable-http"
+            await self.run_streamable_http_async(**transport_kwargs)
 
     def run(
-        self, transport: Literal["stdio", "sse"] | None = None, **transport_kwargs: Any
+        self,
+        transport: Literal["stdio", "sse", "streamable-http"] | None = None,
+        **transport_kwargs: Any,
     ) -> None:
         """Run the FastMCP server. Note this is a synchronous function.
 
         Args:
-            transport: Transport protocol to use ("stdio" or "sse")
+            transport: Transport protocol to use ("stdio", "sse", or "streamable-http")
         """
         logger.info(f'Starting server "{self.name}"...')
 
@@ -742,6 +749,52 @@ class FastMCP(Generic[LifespanResultT]):
             debug=self.settings.debug,
             additional_routes=self._additional_http_routes,
         )
+
+    def streamable_http_app(self) -> Starlette:
+        """Return an instance of the StreamableHTTP server app."""
+        try:
+            from fastmcp.server.http import create_streamable_http_app
+
+            return create_streamable_http_app(
+                server=self,
+                streamable_http_path=self.settings.streamable_http_path,
+                event_store=None,
+                auth_server_provider=self._auth_server_provider,
+                auth_settings=self.settings.auth,
+                json_response=self.settings.json_response,
+                stateless_http=self.settings.stateless_http,
+                debug=self.settings.debug,
+                additional_routes=self._additional_http_routes,
+            )
+        except ImportError as e:
+            logger.error(f"Failed to create StreamableHTTP app: {e}")
+            raise ImportError(
+                "StreamableHTTP transport is not available. Make sure your version of `mcp` is up-to-date."
+            ) from e
+
+    async def run_streamable_http_async(
+        self,
+        host: str | None = None,
+        port: int | None = None,
+        log_level: str | None = None,
+        uvicorn_config: dict | None = None,
+    ) -> None:
+        """Run the server using StreamableHTTP transport."""
+        uvicorn_config = uvicorn_config or {}
+        uvicorn_config.setdefault("timeout_graceful_shutdown", 0)
+
+        app = self.streamable_http_app()
+
+        config = uvicorn.Config(
+            app,
+            host=host or self.settings.host,
+            port=port or self.settings.port,
+            log_level=log_level or self.settings.log_level.lower(),
+            lifespan="on",
+            **uvicorn_config,
+        )
+        server = uvicorn.Server(config)
+        await server.serve()
 
     def mount(
         self,

--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -61,6 +61,7 @@ class ServerSettings(BaseSettings):
     port: int = 8000
     sse_path: str = "/sse"
     message_path: str = "/messages/"
+    streamable_http_path: str = "/mcp"
     debug: bool = False
 
     # resource settings
@@ -81,6 +82,12 @@ class ServerSettings(BaseSettings):
     cache_expiration_seconds: float = 0
 
     auth: AuthSettings | None = None
+
+    # StreamableHTTP settings
+    json_response: bool = False
+    stateless_http: bool = (
+        False  # If True, uses true stateless mode (new transport per request)
+    )
 
 
 class ClientSettings(BaseSettings):

--- a/tests/client/test_streamable_http.py
+++ b/tests/client/test_streamable_http.py
@@ -1,0 +1,102 @@
+import json
+import sys
+from collections.abc import Generator
+
+import pytest
+import uvicorn
+from mcp.types import TextResourceContents
+
+from fastmcp.client import Client
+from fastmcp.client.transports import StreamableHttpTransport
+from fastmcp.server.dependencies import get_http_request
+from fastmcp.server.server import FastMCP
+from fastmcp.utilities.tests import run_server_in_process
+
+
+def fastmcp_server():
+    """Fixture that creates a FastMCP server with tools, resources, and prompts."""
+    server = FastMCP("TestServer")
+
+    # Add a tool
+    @server.tool()
+    def greet(name: str) -> str:
+        """Greet someone by name."""
+        return f"Hello, {name}!"
+
+    # Add a second tool
+    @server.tool()
+    def add(a: int, b: int) -> int:
+        """Add two numbers together."""
+        return a + b
+
+    # Add a resource
+    @server.resource(uri="data://users")
+    async def get_users():
+        return ["Alice", "Bob", "Charlie"]
+
+    # Add a resource template
+    @server.resource(uri="data://user/{user_id}")
+    async def get_user(user_id: str):
+        return {"id": user_id, "name": f"User {user_id}", "active": True}
+
+    @server.resource(uri="request://headers")
+    async def get_headers() -> dict[str, str]:
+        request = get_http_request()
+
+        return dict(request.headers)
+
+    # Add a prompt
+    @server.prompt()
+    def welcome(name: str) -> str:
+        """Example greeting prompt."""
+        return f"Welcome to FastMCP, {name}!"
+
+    return server
+
+
+def run_server(host: str, port: int) -> None:
+    try:
+        app = fastmcp_server().streamable_http_app()
+        server = uvicorn.Server(
+            config=uvicorn.Config(
+                app=app,
+                host=host,
+                port=port,
+                log_level="error",
+                lifespan="on",
+            )
+        )
+        server.run()
+    except Exception as e:
+        print(f"Server error: {e}")
+        sys.exit(1)
+    sys.exit(0)
+
+
+@pytest.fixture(scope="module")
+def streamable_http_server() -> Generator[str, None, None]:
+    with run_server_in_process(run_server) as url:
+        yield f"{url}/mcp"
+
+
+async def test_ping(streamable_http_server: str):
+    """Test pinging the server."""
+    async with Client(
+        transport=StreamableHttpTransport(streamable_http_server)
+    ) as client:
+        result = await client.ping()
+        assert result is True
+
+
+async def test_http_headers(streamable_http_server: str):
+    """Test getting HTTP headers from the server."""
+    async with Client(
+        transport=StreamableHttpTransport(
+            streamable_http_server, headers={"X-DEMO-HEADER": "ABC"}
+        )
+    ) as client:
+        raw_result = await client.read_resource("request://headers")
+        assert isinstance(raw_result[0], TextResourceContents)
+        json_result = json.loads(raw_result[0].text)
+        assert "x-demo-header" in json_result
+        assert json_result["x-demo-header"] == "ABC"

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -4,6 +4,10 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import anyio
+import pytest
+from mcp.server.lowlevel.server import NotificationOptions, Server
+from mcp.server.models import InitializationOptions
+from mcp.shared.message import SessionMessage
 from mcp.types import (
     ClientCapabilities,
     Implementation,
@@ -17,6 +21,118 @@ from pydantic import TypeAdapter
 from fastmcp import Context, FastMCP
 
 
+@pytest.mark.anyio
+async def test_lowlevel_server_lifespan():
+    """Test that lifespan works in low-level server."""
+
+    @asynccontextmanager
+    async def test_lifespan(server: Server) -> AsyncIterator[dict[str, bool]]:
+        """Test lifespan context that tracks startup/shutdown."""
+        context = {"started": False, "shutdown": False}
+        try:
+            context["started"] = True
+            yield context
+        finally:
+            context["shutdown"] = True
+
+    server = Server("test", lifespan=test_lifespan)
+
+    # Create memory streams for testing
+    send_stream1, receive_stream1 = anyio.create_memory_object_stream(100)
+    send_stream2, receive_stream2 = anyio.create_memory_object_stream(100)
+
+    # Create a tool that accesses lifespan context
+    @server.call_tool()
+    async def check_lifespan(name: str, arguments: dict) -> list:
+        ctx = server.request_context
+        assert isinstance(ctx.lifespan_context, dict)
+        assert ctx.lifespan_context["started"]
+        assert not ctx.lifespan_context["shutdown"]
+        return [{"type": "text", "text": "true"}]
+
+    # Run server in background task
+    async with (
+        anyio.create_task_group() as tg,
+        send_stream1,
+        receive_stream1,
+        send_stream2,
+        receive_stream2,
+    ):
+
+        async def run_server():
+            await server.run(
+                receive_stream1,
+                send_stream2,
+                InitializationOptions(
+                    server_name="test",
+                    server_version="0.1.0",
+                    capabilities=server.get_capabilities(
+                        notification_options=NotificationOptions(),
+                        experimental_capabilities={},
+                    ),
+                ),
+                raise_exceptions=True,
+            )
+
+        tg.start_soon(run_server)
+
+        # Initialize the server
+        params = InitializeRequestParams(
+            protocolVersion="2024-11-05",
+            capabilities=ClientCapabilities(),
+            clientInfo=Implementation(name="test-client", version="0.1.0"),
+        )
+        await send_stream1.send(
+            SessionMessage(
+                JSONRPCMessage(
+                    root=JSONRPCRequest(
+                        jsonrpc="2.0",
+                        id=1,
+                        method="initialize",
+                        params=TypeAdapter(InitializeRequestParams).dump_python(params),
+                    )
+                )
+            )
+        )
+        response = await receive_stream2.receive()
+        response = response.message
+
+        # Send initialized notification
+        await send_stream1.send(
+            SessionMessage(
+                JSONRPCMessage(
+                    root=JSONRPCNotification(
+                        jsonrpc="2.0",
+                        method="notifications/initialized",
+                    )
+                )
+            )
+        )
+
+        # Call the tool to verify lifespan context
+        await send_stream1.send(
+            SessionMessage(
+                JSONRPCMessage(
+                    root=JSONRPCRequest(
+                        jsonrpc="2.0",
+                        id=2,
+                        method="tools/call",
+                        params={"name": "check_lifespan", "arguments": {}},
+                    )
+                )
+            )
+        )
+
+        # Get response and verify
+        response = await receive_stream2.receive()
+        response = response.message
+        assert response.root.result["content"][0]["text"] == "true"
+
+        # Cancel server task
+        tg.cancel_scope.cancel()
+
+
+@pytest.mark.anyio
 async def test_fastmcp_server_lifespan():
     """Test that lifespan works in FastMCP server."""
 
@@ -71,41 +187,49 @@ async def test_fastmcp_server_lifespan():
             clientInfo=Implementation(name="test-client", version="0.1.0"),
         )
         await send_stream1.send(
-            JSONRPCMessage(
-                root=JSONRPCRequest(
-                    jsonrpc="2.0",
-                    id=1,
-                    method="initialize",
-                    params=TypeAdapter(InitializeRequestParams).dump_python(params),
+            SessionMessage(
+                JSONRPCMessage(
+                    root=JSONRPCRequest(
+                        jsonrpc="2.0",
+                        id=1,
+                        method="initialize",
+                        params=TypeAdapter(InitializeRequestParams).dump_python(params),
+                    )
                 )
             )
         )
         response = await receive_stream2.receive()
+        response = response.message
 
         # Send initialized notification
         await send_stream1.send(
-            JSONRPCMessage(
-                root=JSONRPCNotification(
-                    jsonrpc="2.0",
-                    method="notifications/initialized",
+            SessionMessage(
+                JSONRPCMessage(
+                    root=JSONRPCNotification(
+                        jsonrpc="2.0",
+                        method="notifications/initialized",
+                    )
                 )
             )
         )
 
         # Call the tool to verify lifespan context
         await send_stream1.send(
-            JSONRPCMessage(
-                root=JSONRPCRequest(
-                    jsonrpc="2.0",
-                    id=2,
-                    method="tools/call",
-                    params={"name": "check_lifespan", "arguments": {}},
+            SessionMessage(
+                JSONRPCMessage(
+                    root=JSONRPCRequest(
+                        jsonrpc="2.0",
+                        id=2,
+                        method="tools/call",
+                        params={"name": "check_lifespan", "arguments": {}},
+                    )
                 )
             )
         )
 
         # Get response and verify
         response = await receive_stream2.receive()
+        response = response.message
         assert response.root.result["content"][0]["text"] == "true"
 
         # Cancel server task


### PR DESCRIPTION
This implementation is based on changes introduced to the low-level server in https://github.com/modelcontextprotocol/python-sdk/pull/641, and requires the new objects introduced there. However we need to do more work to abstract out auth and routes to avoid polluting the `FastMCP` object further, as it is at risk of becoming as configuration-heavy as the low-level server. Since Streamable HTTP is so popular, it's ok to merge this and risk some breaking changes in auth (which can be made backwards compatible via deprecation) in order to get to a more sane configuration setup. 

Opening as draft until 641 is merged. Supersedes #304 