### PR TITLE
Fixing various text typos

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -81,7 +81,7 @@ pytest
 
 ### Pre-Commit Hooks
 
-FastMCP uses pre-commit to manage code quality, including formatting, linting, and type-safety. All PR's must pass the pre-commit hooks, which are run as a part of the CI process. To install the pre-commit hooks, run:
+FastMCP uses pre-commit to manage code quality, including formatting, linting, and type-safety. All PRs must pass the pre-commit hooks, which are run as a part of the CI process. To install the pre-commit hooks, run:
 
 ```bash
 uv run pre-commit install

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -89,7 +89,7 @@ This lets us run the server with `python my_server.py`, using the default `stdio
 <Tip>
 Why do we need the `if __name__ == "__main__":` block?
 
-Within the FastMCP ecosystem, this line may be unecessary. However, including it ensures that your FastMCP server runs for all users and clients in a consistent way and is therefore recommended as best practice.
+Within the FastMCP ecosystem, this line may be unnecessary. However, including it ensures that your FastMCP server runs for all users and clients in a consistent way and is therefore recommended as best practice.
 </Tip>
 
 ### Interacting with the Python server
@@ -124,5 +124,5 @@ fastmcp run my_server.py:mcp
 Note that FastMCP *does not* require the `__main__` block in the server file, and will ignore it if it is present. Instead, it looks for the server object provided in the CLI command (here, `mcp`). If no server object is provided, `fastmcp run` will automatically search for servers called "mcp", "app", or "server" in the file.
 
 <Tip>
-We pointed our client at the server file, which is recognized as a Python MCP server and executed with `python my_server.py` by default. This exceutes the `__main__` block of the server file. There are other ways to run the server, which are described in the [server configuration](/servers/fastmcp#running-the-server) guide.
+We pointed our client at the server file, which is recognized as a Python MCP server and executed with `python my_server.py` by default. This executes the `__main__` block of the server file. There are other ways to run the server, which are described in the [server configuration](/servers/fastmcp#running-the-server) guide.
 </Tip>

--- a/src/fastmcp/server/proxy.py
+++ b/src/fastmcp/server/proxy.py
@@ -124,7 +124,7 @@ class ProxyTemplate(ResourceTemplate):
         params: dict[str, Any],
         context: Context | None = None,
     ) -> ProxyResource:
-        # dont use the provided uri, because it may not be the same as the
+        # don't use the provided uri, because it may not be the same as the
         # uri_template on the remote server.
         # quote params to ensure they are valid for the uri_template
         parameterized_uri = self.uri_template.format(

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -892,7 +892,7 @@ class FastMCP(Generic[LifespanResultT]):
         future changes to the imported server will not be reflected in the
         importing server. Server-level configurations and lifespans are not imported.
 
-        When an server is mounted: - The tools are imported with prefixed names
+        When a server is mounted: - The tools are imported with prefixed names
         using the tool_separator
           Example: If server has a tool named "get_weather", it will be
           available as "weatherget_weather"


### PR DESCRIPTION
Hi,

As title says, fixing various typos found when reading the docs.

For details, see commit diff.

BTW, fastmcp is great! Thks for that

Didier