### PR TITLE
Deprecate transport-specific methods on FastMCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 > [!NOTE]
 > #### FastMCP 2.0 & The Official MCP SDK
 >
-> Recognize the `FastMCP` name? You might have used the version integrated into the [official MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk), which was based on **FastMCP 1.0**.
+> Recognize the `FastMCP` name? You might have seen the version that was contributed to the [official MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk), which was based on **FastMCP 1.0**.
 >
 > **Welcome to FastMCP 2.0!** This is the actively developed successor, and it significantly expands on 1.0 by introducing powerful client capabilities, server proxying & composition, OpenAPI/FastAPI integration, and more advanced features.
 >

--- a/docs/deployment/asgi.mdx
+++ b/docs/deployment/asgi.mdx
@@ -19,7 +19,7 @@ Please note that all FastMCP servers have a `run()` method that can be used to s
 
 FastMCP servers can be created as [Starlette](https://www.starlette.io/) ASGI apps for straightforward hosting or integration into existing applications.
 
-The first step is to obtain a Starlette application instance from your FastMCP server using either the `streamable_http_app()` (preferred) or `sse_app()` (legacy) methods:
+The first step is to obtain a Starlette application instance from your FastMCP server using the `http_app()` method:
 
 ```python
 from fastmcp import FastMCP
@@ -30,18 +30,23 @@ mcp = FastMCP("MyServer")
 def hello(name: str) -> str:
     return f"Hello, {name}!"
 
-# Get a Starlette app instance for the preferred transport
-http_app = mcp.streamable_http_app()   # For Streamable HTTP transport
-sse_app = mcp.sse_app()                # For SSE transport
+# Get a Starlette app instance for Streamable HTTP transport (recommended)
+http_app = mcp.http_app()
+
+# For legacy SSE transport (deprecated)
+sse_app = mcp.http_app(transport="sse")
 ```
 
-Both methods return a Starlette application that can be integrated with other ASGI-compatible web frameworks. 
+Both approaches return a Starlette application that can be integrated with other ASGI-compatible web frameworks. 
 
-The MCP server's endpoint is mounted at the root path `/mcp` for Streamable HTTP transport, and `/sse` for SSE transport, though you can change these paths by passing a `path` argument to the `streamable_http_app()` or `sse_app()` methods:
+The MCP server's endpoint is mounted at the root path `/mcp` for Streamable HTTP transport, and `/sse` for SSE transport, though you can change these paths by passing a `path` argument to the `http_app()` method:
 
 ```python
-http_app = mcp.streamable_http_app(path="/custom-mcp-path")
-sse_app = mcp.sse_app(path="/custom-sse-path")
+# For Streamable HTTP transport
+http_app = mcp.http_app(path="/custom-mcp-path")
+
+# For SSE transport (deprecated)
+sse_app = mcp.http_app(path="/custom-sse-path", transport="sse")
 ```
 
 ### Running the Server
@@ -49,9 +54,12 @@ sse_app = mcp.sse_app(path="/custom-sse-path")
 To run the FastMCP server, you can use the `uvicorn` ASGI server:
 
 ```python
+from fastmcp import FastMCP
 import uvicorn
 
-# (define the app here)
+mcp = FastMCP("MyServer")
+
+http_app = mcp.http_app()
 
 if __name__ == "__main__":
     uvicorn.run(http_app, host="0.0.0.0", port=8000)
@@ -83,7 +91,7 @@ custom_middleware = [
 ]
 
 # Create ASGI app with custom middleware
-http_app = mcp.streamable_http_app(middleware=custom_middleware)
+http_app = mcp.http_app(middleware=custom_middleware)
 ```
 
 
@@ -91,7 +99,7 @@ http_app = mcp.streamable_http_app(middleware=custom_middleware)
 
 <VersionBadge version="2.3.1" />
 
-You can mount your FastMCP server in another Starlette application using the `Mount` class.
+You can mount your FastMCP server in another Starlette application:
 
 ```python
 from fastmcp import FastMCP
@@ -102,7 +110,7 @@ from starlette.routing import Mount
 mcp = FastMCP("MyServer")
 
 # Create the ASGI app
-mcp_app = mcp.streamable_http_app(path='/mcp')
+mcp_app = mcp.http_app(path='/mcp')
 
 # Create a Starlette app and mount the MCP server
 app = Starlette(
@@ -134,7 +142,7 @@ from starlette.routing import Mount
 mcp = FastMCP("MyServer")
 
 # Create the ASGI app
-mcp_app = mcp.streamable_http_app(path='/mcp')
+mcp_app = mcp.http_app(path='/mcp')
 
 # Create nested application structure
 inner_app = Starlette(routes=[Mount("/inner", app=mcp_app)])
@@ -164,7 +172,7 @@ from starlette.routing import Mount
 mcp = FastMCP("MyServer")
 
 # Create the ASGI app
-mcp_app = mcp.streamable_http_app(path='/mcp')
+mcp_app = mcp.http_app(path='/mcp')
 
 # Create a FastAPI app and mount the MCP server
 app = FastAPI(lifespan=mcp_app.router.lifespan_context)

--- a/docs/deployment/running-server.mdx
+++ b/docs/deployment/running-server.mdx
@@ -40,8 +40,8 @@ Below is a comparison of available transport options to help you choose the righ
 | Transport | Use Cases | Recommendation |
 | --------- | --------- | -------------- |
 | **STDIO** | Local tools, command-line scripts, and integrations with clients like Claude Desktop | Best for local tools and when clients manage server processes |
-| **Streamable HTTP** | Web-based deployments, microservices, exposing MCP over a network | Recommended choice for new web-based deployments |
-| **SSE** | Existing web-based deployments that rely on SSE | Suitable for compatibility with SSE clients; prefer Streamable HTTP for new projects |
+| **Streamable HTTP** | Web-based deployments, microservices, exposing MCP over a network | Recommended choice for web-based deployments |
+| **SSE** | Existing web-based deployments that rely on SSE | Deprecated - prefer Streamable HTTP for new projects |
 
 ### STDIO
 
@@ -64,7 +64,7 @@ When using Stdio transport, you will typically *not* run the server yourself as 
 
 <VersionBadge version="2.3.0" />
 
-Streamable HTTP is a modern, efficient transport for exposing your MCP server via HTTP. It is generally recommended over SSE for new web-based deployments.
+Streamable HTTP is a modern, efficient transport for exposing your MCP server via HTTP. It is the recommended transport for web-based deployments.
 
 To run a server using Streamable HTTP, you can use the `run()` method with the `transport` argument set to `"streamable-http"`. This will start a Uvicorn server on the default host (`127.0.0.1`), port (`8000`), and path (`/mcp`).
 <CodeGroup>
@@ -122,7 +122,12 @@ if __name__ == "__main__":
 
 ### SSE
 
-Server-Sent Events (SSE) is an HTTP-based protocol for server-to-client streaming. While FastMCP supports SSE, Streamable HTTP is preferred for new projects.
+<Warning>
+The SSE transport is deprecated and may be removed in a future version.
+New applications should use Streamable HTTP transport instead.
+</Warning>
+
+Server-Sent Events (SSE) is an HTTP-based protocol for server-to-client streaming. While FastMCP still supports SSE, it is deprecated and Streamable HTTP is preferred for new projects.
 
 To run a server using SSE, you can use the `run()` method with the `transport` argument set to `"sse"`. This will start a Uvicorn server on the default host (`127.0.0.1`), port (`8000`), and with default SSE path (`/sse`) and message path (`/messages/`).
 
@@ -170,7 +175,6 @@ if __name__ == "__main__":
         port=4200,
         log_level="debug",
         path="/my-custom-sse-path",
-        message_path="/my-custom-message-path/",
     )
 ```
 ```python {7} client.py
@@ -189,9 +193,37 @@ if __name__ == "__main__":
 ```
 </CodeGroup>
 
-Your client only needs to know the host, port, and "main" path; the message path will be transmitted to it as part of the connection handshake.
 
 
+## Async Usage
+
+FastMCP provides both synchronous and asynchronous APIs for running your server. The `run()` method seen in previous examples is a synchronous method that internally uses `anyio.run()` to run the asynchronous server. For applications that are already running in an async context, FastMCP provides the `run_async()` method.
+
+```python {10-12}
+from fastmcp import FastMCP
+import asyncio
+
+mcp = FastMCP(name="MyServer")
+
+@mcp.tool()
+def hello(name: str) -> str:
+    return f"Hello, {name}!"
+
+async def main():
+    # Use run_async() in async contexts
+    await mcp.run_async(transport="streamable-http")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+<Warning>
+The `run()` method cannot be called from inside an async function because it already creates its own async event loop internally. If you attempt to call `run()` from inside an async function, you'll get an error about the event loop already running.
+
+Always use `run_async()` inside async functions and `run()` in synchronous contexts.
+</Warning>
+
+Both `run()` and `run_async()` accept the same transport arguments, so all the examples above apply to both methods.
 
 ## Custom Routes
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -44,7 +44,7 @@ FastMCP root path:            ~/Developer/fastmcp
 ```
 ## Upgrading from the Official MCP SDK
 
-Upgrading from the official MCP SDK's FastMCP 1.0 to FastMCP 2.0 is easy! The core server API is highly compatible, so after you install the `fastmcp` package, just change your import statement from `from mcp.server.fastmcp import FastMCP` to `from fastmcp import FastMCP`. 
+Upgrading from the official MCP SDK's FastMCP 1.0 to FastMCP 2.0 is generally straightforward. The core server API is highly compatible, and in many cases, changing your import statement from `from mcp.server.fastmcp import FastMCP` to `from fastmcp import FastMCP` will be sufficient. 
 
 
 ```python {1-5}
@@ -56,8 +56,9 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("My MCP Server")
 ```
-
-While the 1.0 server API is very stable for common use cases, FastMCP 2.0 introduces many new features (like the Client, proxying, composition) documented throughout this site. Review the documentation for details on new capabilities.
+<Warning>
+Prior to `fastmcp==2.3.0` and `mcp==1.8.0`, the 2.x API always mirrored the 1.0 API. However, as the projects diverge, this can not be guaranteed. You may see deprecation warnings if you attempt to use 1.0 APIs in FastMCP 2.x. Please refer to this documentation for details on new capabilities.
+</Warning>
 
 ## Installing for Development
 

--- a/docs/getting-started/welcome.mdx
+++ b/docs/getting-started/welcome.mdx
@@ -27,7 +27,7 @@ if __name__ == "__main__":
 ## FastMCP 2.0 and the Official MCP SDK
 
 <Tip>
-Recognize the `FastMCP` name? You might have used the version integrated into the [official MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk), which was based on **FastMCP 1.0**.
+Recognize the `FastMCP` name? You might have seen the version that was contributed to the [official MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk), which was based on **FastMCP 1.0**.
 
 
 **Welcome to FastMCP 2.0!** This is the [actively developed successor](https://github.com/jlowin/fastmcp), and it significantly expands on 1.0 by introducing powerful client capabilities, server proxying & composition, OpenAPI/FastAPI integration, and more advanced features.

--- a/docs/servers/fastmcp.mdx
+++ b/docs/servers/fastmcp.mdx
@@ -114,11 +114,16 @@ if __name__ == "__main__":
     # This runs the server, defaulting to STDIO transport
     mcp.run()
     
-    # To use a different transport, e.g., Streamable HTTP:
+    # To use a different transport, e.g., HTTP:
     # mcp.run(transport="streamable-http", host="127.0.0.1", port=9000)
 ```
 
-FastMCP supports several transport options like STDIO (default, for local tools), Streamable HTTP (recommended for web services), and SSE (legacy web transport). The server can also be run using the FastMCP CLI.
+FastMCP supports several transport options: 
+- STDIO (default, for local tools)
+- Streamable HTTP (recommended for web services)
+- SSE (legacy web transport, deprecated)
+
+The server can also be run using the FastMCP CLI.
 
 For detailed information on each transport, how to configure them (host, port, paths), and when to use which, please refer to the [**Running Your FastMCP Server**](/deployment/running-server) guide.
 

--- a/src/fastmcp/utilities/tests.py
+++ b/src/fastmcp/utilities/tests.py
@@ -55,7 +55,7 @@ def temporary_settings(**kwargs: Any):
 def _run_server(mcp_server: FastMCP, transport: Literal["sse"], port: int) -> None:
     # Some Starlette apps are not pickleable, so we need to create them here based on the indicated transport
     if transport == "sse":
-        app = mcp_server.sse_app()
+        app = mcp_server.http_app(transport="sse")
     else:
         raise ValueError(f"Invalid transport: {transport}")
     uvicorn_server = uvicorn.Server(

--- a/tests/client/test_sse.py
+++ b/tests/client/test_sse.py
@@ -58,7 +58,7 @@ def fastmcp_server():
 
 def run_server(host: str, port: int) -> None:
     try:
-        app = fastmcp_server().sse_app()
+        app = fastmcp_server().http_app(transport="sse")
         server = uvicorn.Server(
             config=uvicorn.Config(app=app, host=host, port=port, log_level="error")
         )
@@ -96,7 +96,7 @@ async def test_http_headers(sse_server: str):
 
 def run_nested_server(host: str, port: int) -> None:
     try:
-        app = fastmcp_server().sse_app()
+        app = fastmcp_server().http_app(transport="sse")
         mount = Starlette(routes=[Mount("/nest-inner", app=app)])
         mount2 = Starlette(routes=[Mount("/nest-outer", app=mount)])
         server = uvicorn.Server(

--- a/tests/client/test_streamable_http.py
+++ b/tests/client/test_streamable_http.py
@@ -58,7 +58,7 @@ def fastmcp_server():
 
 def run_server(host: str, port: int) -> None:
     try:
-        app = fastmcp_server().streamable_http_app()
+        app = fastmcp_server().http_app()
         server = uvicorn.Server(
             config=uvicorn.Config(
                 app=app,
@@ -106,7 +106,7 @@ async def test_http_headers(streamable_http_server: str):
 
 def run_nested_server(host: str, port: int) -> None:
     try:
-        mcp_app = fastmcp_server().streamable_http_app()
+        mcp_app = fastmcp_server().http_app()
 
         mount = Starlette(routes=[Mount("/nest-inner", app=mcp_app)])
         mount2 = Starlette(

--- a/tests/server/test_http_dependencies.py
+++ b/tests/server/test_http_dependencies.py
@@ -43,7 +43,7 @@ def fastmcp_server():
 
 def run_server(host: str, port: int) -> None:
     try:
-        app = fastmcp_server().streamable_http_app()
+        app = fastmcp_server().http_app()
         server = uvicorn.Server(
             config=uvicorn.Config(
                 app=app,

--- a/tests/server/test_http_middleware.py
+++ b/tests/server/test_http_middleware.py
@@ -1,4 +1,4 @@
-"""Tests for custom middleware in HTTP servers."""
+"""Tests for middleware in HTTP apps."""
 
 from collections.abc import Callable
 from typing import Any
@@ -68,7 +68,7 @@ async def test_sse_app_with_custom_middleware():
     server._additional_http_routes = routes
 
     # Create the app with custom middleware
-    app = server.sse_app(middleware=custom_middleware)
+    app = server.http_app(transport="sse", middleware=custom_middleware)
 
     # Create a test client
     transport = ASGITransport(app=app)
@@ -99,7 +99,7 @@ async def test_streamable_http_app_with_custom_middleware():
     server._additional_http_routes = routes
 
     # Create the app with custom middleware
-    app = server.streamable_http_app(middleware=custom_middleware)
+    app = server.http_app(transport="streamable-http", middleware=custom_middleware)
 
     # Create a test client
     transport = ASGITransport(app=app)
@@ -204,7 +204,7 @@ async def test_multiple_middleware_ordering():
     server._additional_http_routes = routes
 
     # Create the app with custom middleware
-    app = server.sse_app(middleware=custom_middleware)
+    app = server.http_app(transport="sse", middleware=custom_middleware)
 
     # Create a test client
     transport = ASGITransport(app=app)

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -1,0 +1,82 @@
+"""Tests for deprecated functionality."""
+
+import warnings
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from starlette.applications import Starlette
+
+from fastmcp import FastMCP
+
+
+def test_sse_app_deprecation_warning():
+    """Test that sse_app raises a deprecation warning."""
+    server = FastMCP("TestServer")
+
+    with pytest.warns(DeprecationWarning, match="The sse_app method is deprecated"):
+        app = server.sse_app()
+        assert isinstance(app, Starlette)
+
+
+def test_streamable_http_app_deprecation_warning():
+    """Test that streamable_http_app raises a deprecation warning."""
+    server = FastMCP("TestServer")
+
+    with pytest.warns(
+        DeprecationWarning, match="The streamable_http_app method is deprecated"
+    ):
+        app = server.streamable_http_app()
+        assert isinstance(app, Starlette)
+
+
+@pytest.mark.asyncio
+async def test_run_sse_async_deprecation_warning():
+    """Test that run_sse_async raises a deprecation warning."""
+    server = FastMCP("TestServer")
+
+    # Use patch to avoid actually running the server
+    with patch.object(server, "run_http_async", new_callable=AsyncMock) as mock_run:
+        with pytest.warns(
+            DeprecationWarning, match="The run_sse_async method is deprecated"
+        ):
+            await server.run_sse_async()
+
+        # Verify the mock was called with the right transport
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs.get("transport") == "sse"
+
+
+@pytest.mark.asyncio
+async def test_run_streamable_http_async_deprecation_warning():
+    """Test that run_streamable_http_async raises a deprecation warning."""
+    server = FastMCP("TestServer")
+
+    # Use patch to avoid actually running the server
+    with patch.object(server, "run_http_async", new_callable=AsyncMock) as mock_run:
+        with pytest.warns(
+            DeprecationWarning,
+            match="The run_streamable_http_async method is deprecated",
+        ):
+            await server.run_streamable_http_async()
+
+        # Verify the mock was called with the right transport
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs.get("transport") == "streamable-http"
+
+
+def test_http_app_with_sse_transport():
+    """Test that http_app with SSE transport works (no warning)."""
+    server = FastMCP("TestServer")
+
+    # This should not raise a warning since we're using the new API
+    with warnings.catch_warnings(record=True) as recorded_warnings:
+        app = server.http_app(transport="sse")
+        assert isinstance(app, Starlette)
+
+        # Verify no deprecation warnings were raised for using transport parameter
+        deprecation_warnings = [
+            w for w in recorded_warnings if issubclass(w.category, DeprecationWarning)
+        ]
+        assert len(deprecation_warnings) == 0


### PR DESCRIPTION
This adds `run_http_async()` and `http_app()` methods to the FastMCP instance, with a `transport` kwarg, and adds related deprecation notices to `run_sse_async()`, `run_streamable_http_async()`, `sse_app()`, and `streamable_http_app()` (which still function).

Related to discussion in #396 