### PR TITLE
logging stack trace for easier debugging

### DIFF
--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -143,6 +143,7 @@ class Tool(BaseModel):
 
             return _convert_to_content(result, serializer=self.serializer)
         except Exception as e:
+            logger.exception(e)
             raise ToolError(f"Error executing tool {self.name}: {e}") from e
 
     def to_mcp_tool(self, **overrides: Any) -> MCPTool:

--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -143,7 +143,7 @@ class Tool(BaseModel):
 
             return _convert_to_content(result, serializer=self.serializer)
         except Exception as e:
-            logger.exception(e)
+            logger.exception(f"Tool {self.name} failed")
             raise ToolError(f"Error executing tool {self.name}: {e}") from e
 
     def to_mcp_tool(self, **overrides: Any) -> MCPTool:


### PR DESCRIPTION
When an exception happens in a tool, most of the details are dropped including stack traces, which makes debugging pretty challenging. The PR is to add a logging for exceptions at the low level to capture what's happening properly.

I'd be happy to update it to generalize the solution if the maintainer can give more guidance.