### PR TITLE
Add base_path support for SSE endpoint subpath routing via nginx or other http middleware

### DIFF
--- a/src/fastmcp/server/http.py
+++ b/src/fastmcp/server/http.py
@@ -135,10 +135,36 @@ def create_base_app(
     )
 
 
+def _normalize_path(mount_path: str, endpoint: str) -> str:
+    """
+    Combine mount path and endpoint to return a normalized path.
+    Args:
+        mount_path: The mount path (e.g. "/mcp" or "/")
+        endpoint: The endpoint path (e.g. "/messages/")
+    Returns:
+        Normalized path (e.g. "/mcp/messages/")
+    """
+    # Special case: root path
+    if mount_path == "/":
+        return endpoint
+
+    # Remove trailing slash from mount path
+    if mount_path.endswith("/"):
+        mount_path = mount_path[:-1]
+
+    # Ensure endpoint starts with slash
+    if not endpoint.startswith("/"):
+        endpoint = "/" + endpoint
+
+    # Combine paths
+    return mount_path + endpoint
+
+
 def create_sse_app(
     server: FastMCP,
     message_path: str,
     sse_path: str,
+    mount_path: str | None = None,
     auth_server_provider: OAuthAuthorizationServerProvider | None = None,
     auth_settings: AuthSettings | None = None,
     debug: bool = False,
@@ -151,6 +177,7 @@ def create_sse_app(
         server: The FastMCP server instance
         message_path: Path for SSE messages
         sse_path: Path for SSE connections
+        mount_path: Optional mount path for SSE transport
         auth_server_provider: Optional auth provider
         auth_settings: Optional auth settings
         debug: Whether to enable debug mode
@@ -163,8 +190,13 @@ def create_sse_app(
     server_routes: list[BaseRoute] = []
     server_middleware: list[Middleware] = []
 
+    normalized_message_endpoint = message_path
+    if mount_path is not None:
+        # Create normalized endpoint considering the mount path
+        normalized_message_endpoint = _normalize_path(mount_path, message_path)
+
     # Set up SSE transport
-    sse = SseServerTransport(message_path)
+    sse = SseServerTransport(normalized_message_endpoint)
 
     # Create handler for SSE connections
     async def handle_sse(scope: Scope, receive: Receive, send: Send) -> Response:

--- a/src/fastmcp/server/http.py
+++ b/src/fastmcp/server/http.py
@@ -135,36 +135,36 @@ def create_base_app(
     )
 
 
-def _normalize_path(mount_path: str, endpoint: str) -> str:
+def _normalize_path(base_path: str, endpoint: str) -> str:
     """
-    Combine mount path and endpoint to return a normalized path.
+    Combine base path and endpoint to return a normalized path.
     Args:
-        mount_path: The mount path (e.g. "/mcp" or "/")
+        base_path: The base path (e.g. "/mcp" or "/")
         endpoint: The endpoint path (e.g. "/messages/")
     Returns:
         Normalized path (e.g. "/mcp/messages/")
     """
     # Special case: root path
-    if mount_path == "/":
+    if base_path == "/":
         return endpoint
 
     # Remove trailing slash from mount path
-    if mount_path.endswith("/"):
-        mount_path = mount_path[:-1]
+    if base_path.endswith("/"):
+        base_path = base_path[:-1]
 
     # Ensure endpoint starts with slash
     if not endpoint.startswith("/"):
         endpoint = "/" + endpoint
 
     # Combine paths
-    return mount_path + endpoint
+    return base_path + endpoint
 
 
 def create_sse_app(
     server: FastMCP,
     message_path: str,
     sse_path: str,
-    mount_path: str | None = None,
+    base_path: str | None = None,
     auth_server_provider: OAuthAuthorizationServerProvider | None = None,
     auth_settings: AuthSettings | None = None,
     debug: bool = False,
@@ -177,7 +177,7 @@ def create_sse_app(
         server: The FastMCP server instance
         message_path: Path for SSE messages
         sse_path: Path for SSE connections
-        mount_path: Optional mount path for SSE transport
+        base_path: Optional base path for SSE transport
         auth_server_provider: Optional auth provider
         auth_settings: Optional auth settings
         debug: Whether to enable debug mode
@@ -191,9 +191,9 @@ def create_sse_app(
     server_middleware: list[Middleware] = []
 
     normalized_message_endpoint = message_path
-    if mount_path is not None:
-        # Create normalized endpoint considering the mount path
-        normalized_message_endpoint = _normalize_path(mount_path, message_path)
+    if base_path is not None:
+        # Create normalized endpoint considering the base path
+        normalized_message_endpoint = _normalize_path(base_path, message_path)
 
     # Set up SSE transport
     sse = SseServerTransport(normalized_message_endpoint)

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -173,14 +173,12 @@ class FastMCP(Generic[LifespanResultT]):
     async def run_async(
         self,
         transport: Literal["stdio", "streamable-http", "sse"] | None = None,
-        mount_path: str | None = None,
         **transport_kwargs: Any,
     ) -> None:
         """Run the FastMCP server asynchronously.
 
         Args:
             transport: Transport protocol to use ("stdio", "sse", or "streamable-http")
-            mount_path: Optional mount path for SSE transport
         """
         if transport is None:
             transport = "stdio"
@@ -192,16 +190,13 @@ class FastMCP(Generic[LifespanResultT]):
         elif transport == "streamable-http":
             await self.run_http_async(transport="streamable-http", **transport_kwargs)
         elif transport == "sse":
-            await self.run_http_async(
-                transport="sse", mount_path=mount_path, **transport_kwargs
-            )
+            await self.run_http_async(transport="sse", **transport_kwargs)
         else:
             raise ValueError(f"Unknown transport: {transport}")
 
     def run(
         self,
         transport: Literal["stdio", "streamable-http", "sse"] | None = None,
-        mount_path: str | None = None,
         **transport_kwargs: Any,
     ) -> None:
         """Run the FastMCP server. Note this is a synchronous function.
@@ -212,11 +207,7 @@ class FastMCP(Generic[LifespanResultT]):
         """
         logger.info(f'Starting server "{self.name}"...')
 
-        anyio.run(
-            partial(
-                self.run_async, transport, mount_path=mount_path, **transport_kwargs
-            )
-        )
+        anyio.run(partial(self.run_async, transport, **transport_kwargs))
 
     def _setup_handlers(self) -> None:
         """Set up core MCP protocol handlers."""
@@ -733,7 +724,7 @@ class FastMCP(Generic[LifespanResultT]):
         transport: Literal["streamable-http", "sse"] = "streamable-http",
         host: str | None = None,
         port: int | None = None,
-        mount_path: str | None = None,
+        base_path: str | None = None,
         log_level: str | None = None,
         path: str | None = None,
         uvicorn_config: dict | None = None,
@@ -744,7 +735,7 @@ class FastMCP(Generic[LifespanResultT]):
             transport: Transport protocol to use - either "streamable-http" (default) or "sse"
             host: Host address to bind to (defaults to settings.host)
             port: Port to bind to (defaults to settings.port)
-            mount_path: Optional mount path for SSE transport
+            base_path: Optional base path for SSE transport
             log_level: Log level for the server (defaults to settings.log_level)
             path: Path for the endpoint (defaults to settings.streamable_http_path or settings.sse_path)
             uvicorn_config: Additional configuration for the Uvicorn server
@@ -754,7 +745,7 @@ class FastMCP(Generic[LifespanResultT]):
         # lifespan is required for streamable http
         uvicorn_config["lifespan"] = "on"
 
-        app = self.http_app(mount_path=mount_path, path=path, transport=transport)
+        app = self.http_app(base_path=base_path or self.settings.base_path, path=path, transport=transport)
 
         config = uvicorn.Config(
             app,
@@ -850,15 +841,15 @@ class FastMCP(Generic[LifespanResultT]):
     def http_app(
         self,
         path: str | None = None,
-        mount_path: str | None = None,
+        base_path: str | None = None,
         middleware: list[Middleware] | None = None,
         transport: Literal["streamable-http", "sse"] = "streamable-http",
     ) -> Starlette:
         """Create a Starlette app using the specified HTTP transport.
 
         Args:
-            mount_path: Optional mount path for SSE transport
             path: The path for the HTTP endpoint
+            base_path: Optional base path for SSE transport
             middleware: A list of middleware to apply to the app
             transport: Transport protocol to use - either "streamable-http" (default) or "sse"
 
@@ -881,15 +872,15 @@ class FastMCP(Generic[LifespanResultT]):
                 middleware=middleware,
             )
         elif transport == "sse":
-            # Update mount_path in settings if provided
-            if mount_path is not None:
-                self.settings.mount_path = mount_path
+            # Update base_path in settings if provided
+            if base_path is not None:
+                self.settings.base_path = base_path
 
             return create_sse_app(
                 server=self,
                 message_path=self.settings.message_path,
                 sse_path=path or self.settings.sse_path,
-                mount_path=self.settings.mount_path,
+                base_path=self.settings.base_path,
                 auth_server_provider=self._auth_server_provider,
                 auth_settings=self.settings.auth,
                 debug=self.settings.debug,

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -745,7 +745,11 @@ class FastMCP(Generic[LifespanResultT]):
         # lifespan is required for streamable http
         uvicorn_config["lifespan"] = "on"
 
-        app = self.http_app(base_path=base_path or self.settings.base_path, path=path, transport=transport)
+        app = self.http_app(
+            base_path=base_path or self.settings.base_path,
+            path=path,
+            transport=transport,
+        )
 
         config = uvicorn.Config(
             app,

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -192,7 +192,9 @@ class FastMCP(Generic[LifespanResultT]):
         elif transport == "streamable-http":
             await self.run_http_async(transport="streamable-http", **transport_kwargs)
         elif transport == "sse":
-            await self.run_http_async(transport="sse", mount_path=mount_path, **transport_kwargs)
+            await self.run_http_async(
+                transport="sse", mount_path=mount_path, **transport_kwargs
+            )
         else:
             raise ValueError(f"Unknown transport: {transport}")
 
@@ -210,7 +212,11 @@ class FastMCP(Generic[LifespanResultT]):
         """
         logger.info(f'Starting server "{self.name}"...')
 
-        anyio.run(partial(self.run_async, transport, mount_path=mount_path, **transport_kwargs))
+        anyio.run(
+            partial(
+                self.run_async, transport, mount_path=mount_path, **transport_kwargs
+            )
+        )
 
     def _setup_handlers(self) -> None:
         """Set up core MCP protocol handlers."""

--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -59,7 +59,7 @@ class ServerSettings(BaseSettings):
     # HTTP settings
     host: str = "127.0.0.1"
     port: int = 8000
-    mount_path: str = "/"
+    base_path: str = "/"
     sse_path: str = "/sse"
     message_path: str = "/messages/"
     streamable_http_path: str = "/mcp"

--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -59,6 +59,7 @@ class ServerSettings(BaseSettings):
     # HTTP settings
     host: str = "127.0.0.1"
     port: int = 8000
+    mount_path: str = "/"
     sse_path: str = "/sse"
     message_path: str = "/messages/"
     streamable_http_path: str = "/mcp"

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -1,4 +1,5 @@
 from typing import Annotated
+from unittest.mock import patch
 
 import pytest
 from mcp.types import (
@@ -6,11 +7,11 @@ from mcp.types import (
     TextResourceContents,
 )
 from pydantic import Field
-from starlette.routing import Route, Mount
+from starlette.routing import Mount, Route
 
 from fastmcp import Client, FastMCP
 from fastmcp.exceptions import ClientError, NotFoundError
-from unittest.mock import patch
+
 
 class TestCreateServer:
     async def test_create_server(self):

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -741,6 +741,7 @@ class TestPromptDecorator:
 class TestSSEUseMountPath:
     def test_normalize(self):
         from fastmcp.server.http import _normalize_path
+
         # Test root path
         assert _normalize_path("/", "/messages/") == "/messages/"
 
@@ -757,17 +758,16 @@ class TestSSEUseMountPath:
         assert _normalize_path("/api/", "/v1/") == "/api/v1/"
 
     async def test_http_app_mount_path(self):
-
         mcp = FastMCP()
         with patch(
-                "fastmcp.server.http._normalize_path", return_value="/messages/"
+            "fastmcp.server.http._normalize_path", return_value="/messages/"
         ) as mock_normalize:
             mcp.http_app(transport="sse")
             mock_normalize.assert_called_once_with("/", "/messages/")
 
         mcp = FastMCP()
         with patch(
-                "fastmcp.server.http._normalize_path", return_value="/mcp/messages/"
+            "fastmcp.server.http._normalize_path", return_value="/mcp/messages/"
         ) as mock_normalize:
             mcp.http_app(mount_path="/mcp", transport="sse")
             mock_normalize.assert_called_once_with("/mcp", "/messages/")
@@ -775,7 +775,7 @@ class TestSSEUseMountPath:
         mcp = FastMCP()
         mcp.settings.mount_path = "/api"
         with patch(
-                "fastmcp.server.http._normalize_path", return_value="/api/messages/"
+            "fastmcp.server.http._normalize_path", return_value="/api/messages/"
         ) as mock_normalize:
             mcp.http_app(transport="sse")
             mock_normalize.assert_called_once_with("/api", "/messages/")
@@ -794,9 +794,9 @@ class TestSSEUseMountPath:
 
         # Verify path values
         assert sse_routes[0].path == "/sse", "SSE route path should be /sse"
-        assert (
-            mount_routes[0].path == "/messages"
-        ), "Mount route path should be /messages"
+        assert mount_routes[0].path == "/messages", (
+            "Mount route path should be /messages"
+        )
 
         mcp = FastMCP()
         mcp.settings.mount_path = "/api"
@@ -812,6 +812,6 @@ class TestSSEUseMountPath:
 
         # Verify path values
         assert sse_routes[0].path == "/sse", "SSE route path should be /sse"
-        assert (
-            mount_routes[0].path == "/messages"
-        ), "Mount route path should be /messages"
+        assert mount_routes[0].path == "/messages", (
+            "Mount route path should be /messages"
+        )

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -738,7 +738,7 @@ class TestPromptDecorator:
         assert prompt.tags == {"example", "test-tag"}
 
 
-class TestSSEUseMountPath:
+class TestSSEUseBasePath:
     def test_normalize(self):
         from fastmcp.server.http import _normalize_path
 
@@ -757,7 +757,7 @@ class TestSSEUseMountPath:
         # Test both with trailing/leading slashes
         assert _normalize_path("/api/", "/v1/") == "/api/v1/"
 
-    async def test_http_app_mount_path(self):
+    async def test_http_app_base_path(self):
         mcp = FastMCP()
         with patch(
             "fastmcp.server.http._normalize_path", return_value="/messages/"
@@ -769,20 +769,20 @@ class TestSSEUseMountPath:
         with patch(
             "fastmcp.server.http._normalize_path", return_value="/mcp/messages/"
         ) as mock_normalize:
-            mcp.http_app(mount_path="/mcp", transport="sse")
+            mcp.http_app(base_path="/mcp", transport="sse")
             mock_normalize.assert_called_once_with("/mcp", "/messages/")
 
         mcp = FastMCP()
-        mcp.settings.mount_path = "/api"
+        mcp.settings.base_path = "/api"
         with patch(
             "fastmcp.server.http._normalize_path", return_value="/api/messages/"
         ) as mock_normalize:
             mcp.http_app(transport="sse")
             mock_normalize.assert_called_once_with("/api", "/messages/")
 
-    async def test_starlette_routes_not_change_with_mount_path(self):
+    async def test_starlette_routes_not_change_with_base_path(self):
         mcp = FastMCP()
-        app = mcp.http_app(mount_path="/mcp", transport="sse")
+        app = mcp.http_app(base_path="/mcp", transport="sse")
 
         # Find routes by type
         sse_routes = [r for r in app.routes if isinstance(r, Route)]
@@ -799,7 +799,7 @@ class TestSSEUseMountPath:
         )
 
         mcp = FastMCP()
-        mcp.settings.mount_path = "/api"
+        mcp.settings.base_path = "/api"
         app = mcp.http_app(transport="sse")
 
         # Find routes by type


### PR DESCRIPTION
## Description:

This PR introduces a base_path parameter to the SSE configuration in MCP, similar to the baseurl concept commonly found in other web applications. eg:  [base_url in jupyter](https://jupyter-server-proxy.readthedocs.io/en/latest/server-process.html#command)、[base_url in filebrowser](https://filebrowser.org/cli/filebrowser-config-set#options) or [root_url in grafana](https://grafana.com/tutorials/run-grafana-behind-a-proxy/#alternative-for-serving-grafana-under-a-sub-path)

## Background & Reasoning:

When using Nginx or other HTTP proxies to route requests to MCP, the endpoint paths can become inconsistent. For example, when routing `/mcp` to a specific MCP service, the SSE endpoint can be set as `https://example.com/mcp/sse`. However, the client currently receives a messages endpoint as `https://example.com/messages/`, which is incorrect. The correct endpoint should be `https://example.com/mcp/messages/`.

By introducing the mount_path parameter, users can set a base path (e.g., /mcp). This ensures that the SSE server correctly adjusts its internal endpoints to match the proxy configuration, providing accurate endpoint paths to clients.

## Implementation Note:

Initially, the parameter was considered to be named baseurl, but to maintain consistency with another related repository that implemented a similar change, the parameter is named mount_path. [PR](https://github.com/modelcontextprotocol/python-sdk/pull/540)

## Example Usage:
```python
from fastmcp import FastMCP

# Create a server instance
mcp = FastMCP(name="MyAssistantServer", host="0.0.0.0", base_path="/mcp")

@mcp.tool()
def multiply(a: float, b: float) -> float:
    """Multiplies two numbers."""
    return a * b

if __name__ == "__main__":
    mcp.run(transport="sse")
```

This change improves compatibility when deploying MCP behind reverse proxies or HTTP routers.