### PR TITLE
Deprecate passing settings to the FastMCP instance

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -119,9 +119,9 @@ class FastMCP(Generic[LifespanResultT]):
         if settings:
             # TODO: remove settings. Deprecated since 2.3.4
             warnings.warn(
-                "Passing transport-specific and other runtime settings as kwargs "
+                "Passing runtime and transport-specific settings as kwargs "
                 "to the FastMCP constructor is deprecated (as of 2.3.4), "
-                "including most transport settings. Provide settings when calling "
+                "including most transport settings. If possible, provide settings when calling "
                 "run() instead.",
                 DeprecationWarning,
                 stacklevel=2,

--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -3,8 +3,9 @@ from __future__ import annotations as _annotations
 from typing import TYPE_CHECKING, Literal
 
 from mcp.server.auth.settings import AuthSettings
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing_extensions import Self
 
 if TYPE_CHECKING:
     pass
@@ -37,6 +38,15 @@ class Settings(BaseSettings):
         LLMs that stringify JSON instead of passing actual lists and objects.
         Defaults to False.""",
     )
+
+    @model_validator(mode="after")
+    def setup_logging(self) -> Self:
+        """Finalize the settings."""
+        from fastmcp.utilities.logging import configure_logging
+
+        configure_logging(self.log_level)
+
+        return self
 
 
 class ServerSettings(BaseSettings):

--- a/src/fastmcp/utilities/logging.py
+++ b/src/fastmcp/utilities/logging.py
@@ -21,22 +21,27 @@ def get_logger(name: str) -> logging.Logger:
 
 def configure_logging(
     level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] | int = "INFO",
+    logger: logging.Logger | None = None,
 ) -> None:
-    """Configure logging for FastMCP.
+    """
+    Configure logging for FastMCP.
 
     Args:
+        logger: the logger to configure
         level: the log level to use
     """
+    if logger is None:
+        logger = logging.getLogger("FastMCP")
+
     # Only configure the FastMCP logger namespace
     handler = RichHandler(console=Console(stderr=True), rich_tracebacks=True)
     formatter = logging.Formatter("%(message)s")
     handler.setFormatter(formatter)
 
-    fastmcp_logger = logging.getLogger("FastMCP")
-    fastmcp_logger.setLevel(level)
+    logger.setLevel(level)
 
     # Remove any existing handlers to avoid duplicates on reconfiguration
-    for hdlr in fastmcp_logger.handlers[:]:
-        fastmcp_logger.removeHandler(hdlr)
+    for hdlr in logger.handlers[:]:
+        logger.removeHandler(hdlr)
 
-    fastmcp_logger.addHandler(handler)
+    logger.addHandler(handler)

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -13,7 +13,7 @@ def test_fastmcp_kwargs_settings_deprecation_warning():
     """Test that passing settings as kwargs to FastMCP raises a deprecation warning."""
     with pytest.warns(
         DeprecationWarning,
-        match="Passing settings as kwargs to the FastMCP constructor is deprecated",
+        match="Passing runtime and transport-specific settings as kwargs to the FastMCP constructor is deprecated",
     ):
         server = FastMCP("TestServer", host="127.0.0.2", port=8001)
         assert server.settings.host == "127.0.0.2"

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -9,6 +9,17 @@ from starlette.applications import Starlette
 from fastmcp import FastMCP
 
 
+def test_fastmcp_kwargs_settings_deprecation_warning():
+    """Test that passing settings as kwargs to FastMCP raises a deprecation warning."""
+    with pytest.warns(
+        DeprecationWarning,
+        match="Passing settings as kwargs to the FastMCP constructor is deprecated",
+    ):
+        server = FastMCP("TestServer", host="127.0.0.2", port=8001)
+        assert server.settings.host == "127.0.0.2"
+        assert server.settings.port == 8001
+
+
 def test_sse_app_deprecation_warning():
     """Test that sse_app raises a deprecation warning."""
     server = FastMCP("TestServer")


### PR DESCRIPTION
Adds a deprecation notice but does not change behavior. In the future, transport-specific settings will not be provided via the FastMCP constructor; only settings related to the server's universal operation will be accepted. This is to avoid the reasonable confusion in cases like #419, and more broadly to avoid the apparent trend of FastMCP becoming a dumping group for configuration (this is definitely the case in 1.x, and many of these settings are holdovers from that approach, in addition to new ones like streamable http)