### PR TITLE
Declare toolsChanged capability for stdio server.

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -19,7 +19,7 @@ import pydantic
 import uvicorn
 from mcp.server.auth.provider import OAuthAuthorizationServerProvider
 from mcp.server.lowlevel.helper_types import ReadResourceContents
-from mcp.server.lowlevel.server import LifespanResultT
+from mcp.server.lowlevel.server import LifespanResultT, NotificationOptions
 from mcp.server.lowlevel.server import Server as MCPServer
 from mcp.server.stdio import stdio_server
 from mcp.types import (
@@ -731,7 +731,9 @@ class FastMCP(Generic[LifespanResultT]):
             await self._mcp_server.run(
                 read_stream,
                 write_stream,
-                self._mcp_server.create_initialization_options(),
+                self._mcp_server.create_initialization_options(
+                    NotificationOptions(tools_changed=True)
+                ),
             )
 
     async def run_http_async(


### PR DESCRIPTION
### Enable `toolsChanged` capability for stdio server

This PR updates the stdio version of the `FastMCP` server to declare the `tools/list_changed` capability, as defined in the MCP spec.  Related to #439. 

### Why this matters
- The [MCP spec](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#list-changed-notification) states: *"When the list of available tools changes, servers that declared the `listChanged` capability SHOULD send a notification."*
- Declaring `listChanged = True` signals to clients that this server may notify them when the tool list changes.
- It does not require immediate notification support, nor does it change any current behavior.

### What this doesn’t do
- The server still does not send `tools/list_changed` notifications when tools are added or removed.
- Emitting those would require access to an active session, which is not currently available.
- That could be added in a follow-up PR.

Totally fine to close if you’d rather bundle this with notification support later. I mainly wanted to surface the capability gap now.