### PR TITLE
Improve handling of exceptiongroups when raised in clients

### DIFF
--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -427,7 +427,7 @@ class Client:
     ]:
         """Call a tool on the server.
 
-        Unlike call_tool_mcp, this method raises a ClientError if the tool call results in an error.
+        Unlike call_tool_mcp, this method raises a ToolError if the tool call results in an error.
 
         Args:
             name (str): The name of the tool to call.
@@ -438,7 +438,7 @@ class Client:
                 The content returned by the tool.
 
         Raises:
-            ClientError: If the tool call results in an error.
+            ToolError: If the tool call results in an error.
             RuntimeError: If called while the client is not connected.
         """
         result = await self.call_tool_mcp(name=name, arguments=arguments or {})

--- a/src/fastmcp/utilities/exceptions.py
+++ b/src/fastmcp/utilities/exceptions.py
@@ -1,0 +1,39 @@
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any
+
+from exceptiongroup import BaseExceptionGroup
+
+import fastmcp
+
+
+def iter_exc(group: BaseExceptionGroup):
+    for exc in group.exceptions:
+        if isinstance(exc, BaseExceptionGroup):
+            yield from iter_exc(exc)
+        else:
+            yield exc
+
+
+def _exception_handler(group: BaseExceptionGroup):
+    for leaf in iter_exc(group):
+        raise leaf
+
+
+# this catch handler is used to catch taskgroup exception groups and raise the
+# first exception. This allows more sane debugging.
+catch_handlers: Mapping[
+    type[BaseException] | Iterable[type[BaseException]],
+    Callable[[BaseExceptionGroup[Any]], Any],
+] = {
+    Exception: _exception_handler,
+}
+
+
+def get_catch_handlers() -> Mapping[
+    type[BaseException] | Iterable[type[BaseException]],
+    Callable[[BaseExceptionGroup[Any]], Any],
+]:
+    if fastmcp.settings.settings.client_raise_first_exceptiongroup_error:
+        return catch_handlers
+    else:
+        return {}

--- a/tests/server/test_openapi.py
+++ b/tests/server/test_openapi.py
@@ -15,7 +15,7 @@ from pydantic.networks import AnyUrl
 
 from fastmcp import FastMCP
 from fastmcp.client import Client
-from fastmcp.exceptions import ClientError
+from fastmcp.exceptions import ToolError
 from fastmcp.server.openapi import (
     FastMCPOpenAPI,
     OpenAPIResource,
@@ -1029,7 +1029,7 @@ async def test_none_path_parameters_rejected(
     # Create a client and try to call a tool with a None path parameter
     async with Client(mcp_server) as client:
         # get_user has a required path parameter user_id
-        with pytest.raises(ClientError, match="Missing required path parameters"):
+        with pytest.raises(ToolError, match="Missing required path parameters"):
             await client.call_tool(
                 "update_user_name_users__user_id__name_patch",
                 {

--- a/tests/server/test_proxy.py
+++ b/tests/server/test_proxy.py
@@ -4,11 +4,12 @@ from typing import Any
 import mcp.types
 import pytest
 from dirty_equals import Contains
+from mcp import McpError
 
 from fastmcp import FastMCP
 from fastmcp.client import Client
 from fastmcp.client.transports import FastMCPTransport
-from fastmcp.exceptions import ClientError
+from fastmcp.exceptions import ToolError
 from fastmcp.server.proxy import FastMCPProxy
 
 USERS = [
@@ -109,7 +110,7 @@ class TestTools:
         assert proxy_result[0].text == "3"
 
     async def test_error_tool_raises_error(self, proxy_server):
-        with pytest.raises(ClientError, match=""):
+        with pytest.raises(ToolError, match=""):
             async with Client(proxy_server) as client:
                 await client.call_tool("error_tool", {})
 
@@ -147,9 +148,7 @@ class TestResources:
         assert json.loads(result[0].text) == USERS
 
     async def test_read_resource_returns_none_if_not_found(self, proxy_server):
-        with pytest.raises(
-            ClientError, match="Unknown resource: resource://nonexistent"
-        ):
+        with pytest.raises(McpError, match="Unknown resource: resource://nonexistent"):
             async with Client(proxy_server) as client:
                 await client.read_resource("resource://nonexistent")
 

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -1,6 +1,7 @@
 from typing import Annotated
 
 import pytest
+from mcp import McpError
 from mcp.types import (
     TextContent,
     TextResourceContents,
@@ -8,7 +9,7 @@ from mcp.types import (
 from pydantic import Field
 
 from fastmcp import Client, FastMCP
-from fastmcp.exceptions import ClientError, NotFoundError
+from fastmcp.exceptions import NotFoundError
 
 
 class TestCreateServer:
@@ -296,7 +297,7 @@ class TestResourceDecorator:
     async def test_no_resources_before_decorator(self):
         mcp = FastMCP()
 
-        with pytest.raises(ClientError, match="Unknown resource"):
+        with pytest.raises(McpError, match="Unknown resource"):
             async with Client(mcp) as client:
                 await client.read_resource("resource://data")
 

--- a/tests/server/test_server_interactions.py
+++ b/tests/server/test_server_interactions.py
@@ -8,6 +8,7 @@ from typing import Annotated, Literal
 
 import pydantic_core
 import pytest
+from mcp import McpError
 from mcp.types import (
     BlobResourceContents,
     ImageContent,
@@ -18,7 +19,7 @@ from pydantic import AnyUrl, Field
 
 from fastmcp import Client, Context, FastMCP
 from fastmcp.client.transports import FastMCPTransport
-from fastmcp.exceptions import ClientError
+from fastmcp.exceptions import ToolError
 from fastmcp.prompts.prompt import EmbeddedResource, PromptMessage
 from fastmcp.resources import FileResource, FunctionResource
 from fastmcp.utilities.types import Image
@@ -320,7 +321,7 @@ class TestToolParameters:
 
         async with Client(mcp) as client:
             with pytest.raises(
-                ClientError,
+                ToolError,
                 match="Error calling tool 'my_tool'",
             ):
                 await client.call_tool("my_tool", {"x": "not an int"})
@@ -365,7 +366,7 @@ class TestToolParameters:
             pass
 
         async with Client(mcp) as client:
-            with pytest.raises(ClientError, match="Error calling tool 'analyze'"):
+            with pytest.raises(ToolError, match="Error calling tool 'analyze'"):
                 await client.call_tool("analyze", {"x": 0})
 
     async def test_default_field_validation(self):
@@ -376,7 +377,7 @@ class TestToolParameters:
             pass
 
         async with Client(mcp) as client:
-            with pytest.raises(ClientError, match="Error calling tool 'analyze'"):
+            with pytest.raises(ToolError, match="Error calling tool 'analyze'"):
                 await client.call_tool("analyze", {"x": 0})
 
     async def test_default_field_is_still_required_if_no_default_specified(self):
@@ -387,7 +388,7 @@ class TestToolParameters:
             pass
 
         async with Client(mcp) as client:
-            with pytest.raises(ClientError, match="Error calling tool 'analyze'"):
+            with pytest.raises(ToolError, match="Error calling tool 'analyze'"):
                 await client.call_tool("analyze", {})
 
     async def test_literal_type_validation_error(self):
@@ -398,7 +399,7 @@ class TestToolParameters:
             pass
 
         async with Client(mcp) as client:
-            with pytest.raises(ClientError, match="Error calling tool 'analyze'"):
+            with pytest.raises(ToolError, match="Error calling tool 'analyze'"):
                 await client.call_tool("analyze", {"x": "c"})
 
     async def test_literal_type_validation_success(self):
@@ -426,7 +427,7 @@ class TestToolParameters:
             return x.value
 
         async with Client(mcp) as client:
-            with pytest.raises(ClientError, match="Error calling tool 'analyze'"):
+            with pytest.raises(ToolError, match="Error calling tool 'analyze'"):
                 await client.call_tool("analyze", {"x": "some-color"})
 
     async def test_enum_type_validation_success(self):
@@ -462,7 +463,7 @@ class TestToolParameters:
             assert isinstance(result[0], TextContent)
             assert result[0].text == "1.0"
 
-            with pytest.raises(ClientError, match="Error calling tool 'analyze'"):
+            with pytest.raises(ToolError, match="Error calling tool 'analyze'"):
                 await client.call_tool("analyze", {"x": "not a number"})
 
     async def test_path_type(self):
@@ -489,7 +490,7 @@ class TestToolParameters:
             return str(path)
 
         async with Client(mcp) as client:
-            with pytest.raises(ClientError, match="Error calling tool 'send_path'"):
+            with pytest.raises(ToolError, match="Error calling tool 'send_path'"):
                 await client.call_tool("send_path", {"path": 1})
 
     async def test_uuid_type(self):
@@ -515,7 +516,7 @@ class TestToolParameters:
             return str(x)
 
         async with Client(mcp) as client:
-            with pytest.raises(ClientError, match="Error calling tool 'send_uuid'"):
+            with pytest.raises(ToolError, match="Error calling tool 'send_uuid'"):
                 await client.call_tool("send_uuid", {"x": "not a uuid"})
 
     async def test_datetime_type(self):
@@ -554,7 +555,7 @@ class TestToolParameters:
             return x.isoformat()
 
         async with Client(mcp) as client:
-            with pytest.raises(ClientError, match="Error calling tool 'send_datetime'"):
+            with pytest.raises(ToolError, match="Error calling tool 'send_datetime'"):
                 await client.call_tool("send_datetime", {"x": "not a datetime"})
 
     async def test_date_type(self):
@@ -1230,7 +1231,7 @@ class TestPrompts:
     async def test_get_unknown_prompt(self):
         """Test error when getting unknown prompt."""
         mcp = FastMCP()
-        with pytest.raises(ClientError, match="Unknown prompt"):
+        with pytest.raises(McpError, match="Unknown prompt"):
             async with Client(mcp) as client:
                 await client.get_prompt("unknown")
 
@@ -1242,7 +1243,7 @@ class TestPrompts:
         def prompt_fn(name: str) -> str:
             return f"Hello, {name}!"
 
-        with pytest.raises(ClientError, match="Missing required arguments"):
+        with pytest.raises(McpError, match="Missing required arguments"):
             async with Client(mcp) as client:
                 await client.get_prompt("prompt_fn")
 

--- a/tests/tools/test_tool.py
+++ b/tests/tools/test_tool.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 from fastmcp import FastMCP, Image
 from fastmcp.client import Client
-from fastmcp.exceptions import ClientError
+from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import Tool
 from fastmcp.utilities.tests import temporary_settings
 
@@ -299,7 +299,7 @@ class TestLegacyToolJsonParsing:
 
         async with Client(mcp) as client:
             with pytest.raises(
-                ClientError,
+                ToolError,
                 match="Error calling tool 'process_list'",
             ):
                 await client.call_tool("process_list", {"items": "['a', 'b', 3]"})


### PR DESCRIPTION
Currently, we are naively raising taskgroup ExceptionGroups which give messy and complicated ASCII tracebacks. This modifies client behavior to raise the first group in each exception group. The setting is configurable in case there is a situation where this degree of visibility is undesireable because it masks multiple errors, but that is unexpected.