### PR TITLE
Fix flaky timeout test by increasing timeout (#474)

### DIFF
--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -512,11 +512,11 @@ class TestErrorHandling:
 class TestTimeout:
     async def test_timeout(self, fastmcp_server: FastMCP):
         async with Client(
-            transport=FastMCPTransport(fastmcp_server), timeout=0.01
+            transport=FastMCPTransport(fastmcp_server), timeout=0.05
         ) as client:
             with pytest.raises(
                 McpError,
-                match="Timed out while waiting for response to ClientRequest. Waited 0.01 seconds",
+                match="Timed out while waiting for response to ClientRequest. Waited 0.05 seconds",
             ):
                 await client.call_tool("sleep", {"seconds": 0.1})
 


### PR DESCRIPTION
This PR addresses #474 by increasing the client timeout in `TestTimeout::test_timeout` from 0.01s to 0.05s.

**Background:**  
With the original 0.01s timeout, the test would occasionally fail due to event loop scheduling and system timing, as confirmed by running:

```sh
pytest tests/client/test_client.py::TestTimeout::test_timeout --count=5000
```

Results:
- timeout=0.01s: 1 failure in 5,000 runs
- timeout=0.05s: 0 failures in 5,000 runs

**Rationale:**  
A slightly longer timeout gives the event loop enough time to enforce it reliably, making the test more robust.
