### PR TITLE
Skipping `test_permission_error` if runner is root.

### DIFF
--- a/tests/resources/test_file_resources.py
+++ b/tests/resources/test_file_resources.py
@@ -99,7 +99,8 @@ class TestFileResource:
             await resource.read()
 
     @pytest.mark.skipif(
-        os.name == "nt", reason="File permissions behave differently on Windows"
+        os.name == "nt" or os.getuid() == 0, 
+        reason="File permissions behave differently on Windows or when running as root"
     )
     async def test_permission_error(self, temp_file: Path):
         """Test reading a file without permissions."""

--- a/tests/resources/test_file_resources.py
+++ b/tests/resources/test_file_resources.py
@@ -99,8 +99,8 @@ class TestFileResource:
             await resource.read()
 
     @pytest.mark.skipif(
-        os.name == "nt" or os.getuid() == 0, 
-        reason="File permissions behave differently on Windows or when running as root"
+        os.name == "nt" or (hasattr(os, 'getuid') and os.getuid() == 0), 
+        reason="File permissions behave differently on Windows or when running as root",
     )
     async def test_permission_error(self, temp_file: Path):
         """Test reading a file without permissions."""

--- a/tests/resources/test_file_resources.py
+++ b/tests/resources/test_file_resources.py
@@ -99,7 +99,7 @@ class TestFileResource:
             await resource.read()
 
     @pytest.mark.skipif(
-        os.name == "nt" or (hasattr(os, "getuid") and os.getuid() == 0), 
+        os.name == "nt" or (hasattr(os, "getuid") and os.getuid() == 0),
         reason="File permissions behave differently on Windows or when running as root",
     )
     async def test_permission_error(self, temp_file: Path):

--- a/tests/resources/test_file_resources.py
+++ b/tests/resources/test_file_resources.py
@@ -99,7 +99,7 @@ class TestFileResource:
             await resource.read()
 
     @pytest.mark.skipif(
-        os.name == "nt" or (hasattr(os, 'getuid') and os.getuid() == 0), 
+        os.name == "nt" or (hasattr(os, "getuid") and os.getuid() == 0), 
         reason="File permissions behave differently on Windows or when running as root",
     )
     async def test_permission_error(self, temp_file: Path):


### PR DESCRIPTION
This fixes:
- #501

I have added a check `or os.getuid() == 0` to the skipping condition of the test to make sure it is skipped when running as root.