### PR TITLE
Skip timeout tests on windows

### DIFF
--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 from typing import cast
 
 import pytest
@@ -509,6 +510,10 @@ class TestErrorHandling:
             assert "This is a resource error (xyz)" in str(excinfo.value)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Timeout tests are flaky on Windows. Timeouts *are* supported but the tests are unreliable.",
+)
 class TestTimeout:
     async def test_timeout(self, fastmcp_server: FastMCP):
         async with Client(

--- a/tests/client/test_sse.py
+++ b/tests/client/test_sse.py
@@ -136,11 +136,11 @@ async def test_nested_sse_server_resolves_correctly():
             assert result is True
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Timeout tests are flaky on Windows. Timeouts *are* supported but the tests are unreliable.",
+)
 class TestTimeout:
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="This test is flaky on Windows. Sometimes the client timeout is respected and sometimes it is not.",
-    )
     async def test_timeout(self, sse_server: str):
         with pytest.raises(
             McpError,
@@ -167,10 +167,6 @@ class TestTimeout:
             with pytest.raises(McpError, match="Timed out"):
                 await client.call_tool("sleep", {"seconds": 0.1}, timeout=0.01)
 
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="This test is flaky on Windows. Sometimes the client timeout is respected and sometimes it is not.",
-    )
     async def test_timeout_client_timeout_does_not_override_tool_call_timeout_if_lower(
         self, sse_server: str
     ):

--- a/tests/client/test_streamable_http.py
+++ b/tests/client/test_streamable_http.py
@@ -149,6 +149,10 @@ async def test_nested_streamable_http_server_resolves_correctly():
             assert result is True
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Timeout tests are flaky on Windows. Timeouts *are* supported but the tests are unreliable.",
+)
 class TestTimeout:
     async def test_timeout(self, streamable_http_server: str):
         # note this transport behaves differently than others and raises


### PR DESCRIPTION
@zzstoatzz what do you think? These tests are flaky. I do wonder if it's a timing thing, like if we increased the timeouts to ~1 second it would have enough time to properly respond, but I don't want to add such overhead to the test suite. Maybe only on windows we use higher timeouts? Happy to merge this now regardless.