### PR TITLE
Allow * Methods and all routes as tools shortcuts

### DIFF
--- a/docs/patterns/openapi.mdx
+++ b/docs/patterns/openapi.mdx
@@ -61,19 +61,27 @@ Internally, FastMCP uses a priority-ordered set of `RouteMap` objects to determi
 # Simplified version of the actual mapping rules
 DEFAULT_ROUTE_MAPPINGS = [
     # GET with path parameters -> ResourceTemplate
-    RouteMap(methods=["GET"], pattern=r".*\{.*\}.*", 
-             route_type=RouteType.RESOURCE_TEMPLATE),
+    RouteMap(
+        methods=["GET"], 
+        pattern=r".*\{.*\}.*", 
+        route_type=RouteType.RESOURCE_TEMPLATE,
+    ),
     
     # GET without path parameters -> Resource
-    RouteMap(methods=["GET"], pattern=r".*", 
-             route_type=RouteType.RESOURCE),
+    RouteMap(
+        methods=["GET"], 
+        pattern=r".*", 
+        route_type=RouteType.RESOURCE,
+    ),
     
     # All other methods -> Tool
-    RouteMap(methods=["POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
-             pattern=r".*", route_type=RouteType.TOOL),
+    RouteMap(
+        methods="*",
+        pattern=r".*", 
+        route_type=RouteType.TOOL,
+    ),
 ]
 ```
-
 ### Custom Route Maps
 
 Users can add custom route maps to override the default mapping behavior. User-supplied route maps are always applied first, before the default route maps.
@@ -96,6 +104,35 @@ mcp = await FastMCP.from_openapi(
     route_maps=custom_maps
 )
 ```
+
+
+### All Routes as Tools
+
+When building AI agent backends, it's often useful to treat all routes as callable tools regardless of their HTTP method. You can use the `all_routes_as_tools` parameter to automatically map every route to a Tool:
+
+```python
+# Make all endpoints tools, regardless of HTTP method
+mcp = FastMCP.from_openapi(
+    openapi_spec=spec,
+    client=api_client,
+    all_routes_as_tools=True
+)
+```
+
+This is equivalent to defining a single route map that matches all routes:
+
+```python
+# Same effect as all_routes_as_tools=True
+mcp = FastMCP.from_openapi(
+    openapi_spec=spec,
+    client=api_client,
+    route_maps=[
+        RouteMap(methods="*", pattern=r".*", route_type=RouteType.TOOL)
+    ]
+)
+```
+
+Note that `all_routes_as_tools` and `route_maps` cannot be used together - if you need more complex mapping rules, use `route_maps` instead.
 
 ## How It Works
 

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -47,7 +47,7 @@ class RouteType(enum.Enum):
 class RouteMap:
     """Mapping configuration for HTTP routes to FastMCP component types."""
 
-    methods: list[HttpMethod]
+    methods: list[HttpMethod] | Literal["*"]
     pattern: Pattern[str] | str
     route_type: RouteType
 
@@ -86,7 +86,7 @@ def _determine_route_type(
     # Check mappings in priority order (first match wins)
     for route_map in mappings:
         # Check if the HTTP method matches
-        if route.method in route_map.methods:
+        if route_map.methods == "*" or route.method in route_map.methods:
             # Handle both string patterns and compiled Pattern objects
             if isinstance(route_map.pattern, Pattern):
                 pattern_matches = route_map.pattern.search(route.path)

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -62,7 +62,7 @@ from fastmcp.utilities.logging import get_logger
 if TYPE_CHECKING:
     from fastmcp.client import Client
     from fastmcp.client.transports import ClientTransport
-    from fastmcp.server.openapi import FastMCPOpenAPI
+    from fastmcp.server.openapi import FastMCPOpenAPI, RouteMap
     from fastmcp.server.proxy import FastMCPProxy
 logger = get_logger(__name__)
 
@@ -1082,24 +1082,59 @@ class FastMCP(Generic[LifespanResultT]):
 
     @classmethod
     def from_openapi(
-        cls, openapi_spec: dict[str, Any], client: httpx.AsyncClient, **settings: Any
+        cls,
+        openapi_spec: dict[str, Any],
+        client: httpx.AsyncClient,
+        route_maps: list[RouteMap] | None = None,
+        all_routes_as_tools: bool = False,
+        **settings: Any,
     ) -> FastMCPOpenAPI:
         """
         Create a FastMCP server from an OpenAPI specification.
         """
-        from .openapi import FastMCPOpenAPI
+        from .openapi import FastMCPOpenAPI, RouteMap, RouteType
 
-        return FastMCPOpenAPI(openapi_spec=openapi_spec, client=client, **settings)
+        if all_routes_as_tools and route_maps:
+            raise ValueError("Cannot specify both all_routes_as_tools and route_maps")
+
+        elif all_routes_as_tools:
+            route_maps = [
+                RouteMap(
+                    methods="*",
+                    pattern=r".*",
+                    route_type=RouteType.TOOL,
+                )
+            ]
+
+        return FastMCPOpenAPI(
+            openapi_spec=openapi_spec,
+            client=client,
+            route_maps=route_maps,
+            **settings,
+        )
 
     @classmethod
     def from_fastapi(
-        cls, app: Any, name: str | None = None, **settings: Any
+        cls,
+        app: Any,
+        name: str | None = None,
+        route_maps: list[RouteMap] | None = None,
+        all_routes_as_tools: bool = False,
+        **settings: Any,
     ) -> FastMCPOpenAPI:
         """
         Create a FastMCP server from a FastAPI application.
         """
 
-        from .openapi import FastMCPOpenAPI
+        from .openapi import FastMCPOpenAPI, RouteMap, RouteType
+
+        if all_routes_as_tools and route_maps:
+            raise ValueError("Cannot specify both all_routes_as_tools and route_maps")
+
+        elif all_routes_as_tools:
+            route_maps = [
+                RouteMap(methods="*", pattern=r".*", route_type=RouteType.TOOL)
+            ]
 
         client = httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app), base_url="http://fastapi"
@@ -1108,7 +1143,11 @@ class FastMCP(Generic[LifespanResultT]):
         name = name or app.title
 
         return FastMCPOpenAPI(
-            openapi_spec=app.openapi(), client=client, name=name, **settings
+            openapi_spec=app.openapi(),
+            client=client,
+            name=name,
+            route_maps=route_maps,
+            **settings,
         )
 
     @classmethod


### PR DESCRIPTION
This PR permits custom RouteMaps to absorb all HTTP Methods by providing `RouteMap(methods='*')`, and also adds a new `all_routes_as_tools` kwarg when converting OpenAPI and FastAPI apps.