### PR TITLE
Avoid hanging on initializing server session

### DIFF
--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime
 from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
@@ -164,7 +163,7 @@ class Client:
                     with anyio.fail_after(1):
                         self._initialize_result = await self._session.initialize()
                     yield
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     raise RuntimeError("Failed to initialize server session")
                 finally:
                     self._exit_stack = None

--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -160,8 +160,6 @@ class Client:
             ) as session:
                 self._session = session
                 # Initialize the session
-                self._initialize_result = await self._session.initialize()
-
                 try:
                     with anyio.fail_after(1):
                         self._initialize_result = await self._session.initialize()


### PR DESCRIPTION
Based on https://github.com/modelcontextprotocol/python-sdk/issues/332

This does *not* universally solve hanging issues with STDIO, of which there are many! See e.g. #499. But it does solve a common one in which the initial handshake fails.