### PR TITLE
Fix all_routes_as_tools route map getting overwritten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,6 @@ dmypy.json
 .python-version
 .envrc
 .direnv/
-lib
 
 # Logs and databases
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ venv/
 env/
 ENV/
 .env
+*venv
 
 # System files
 .DS_Store
@@ -54,6 +55,7 @@ dmypy.json
 .python-version
 .envrc
 .direnv/
+lib
 
 # Logs and databases
 *.log

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -614,7 +614,6 @@ class FastMCPOpenAPI(FastMCP):
             if all_routes_as_tools
             else (route_maps or []) + DEFAULT_ROUTE_MAPPINGS
         )
-        
 
         for route in http_routes:
             # Determine route type based on mappings or default rules

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -603,11 +603,17 @@ class FastMCPOpenAPI(FastMCP):
         self._timeout = timeout
         http_routes = openapi.parse_openapi_to_http_routes(openapi_spec)
 
-        route_maps = [RouteMap(
+        route_maps = (
+            [
+                RouteMap(
                     methods="*",
                     pattern=r".*",
                     route_type=RouteType.TOOL,
-                )] if all_routes_as_tools else (route_maps or []) + DEFAULT_ROUTE_MAPPINGS
+                )
+            ]
+            if all_routes_as_tools
+            else (route_maps or []) + DEFAULT_ROUTE_MAPPINGS
+        )
         
 
         for route in http_routes:

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -581,6 +581,7 @@ class FastMCPOpenAPI(FastMCP):
         client: httpx.AsyncClient,
         name: str | None = None,
         route_maps: list[RouteMap] | None = None,
+        all_routes_as_tools: bool = False,
         timeout: float | None = None,
         **settings: Any,
     ):
@@ -592,6 +593,7 @@ class FastMCPOpenAPI(FastMCP):
             client: httpx AsyncClient for making HTTP requests
             name: Optional name for the server
             route_maps: Optional list of RouteMap objects defining route mappings
+            all_routes_as_tools: If True, all routes will be treated as tools
             timeout: Optional timeout (in seconds) for all requests
             **settings: Additional settings for FastMCP
         """
@@ -601,8 +603,13 @@ class FastMCPOpenAPI(FastMCP):
         self._timeout = timeout
         http_routes = openapi.parse_openapi_to_http_routes(openapi_spec)
 
-        # Process routes
-        route_maps = (route_maps or []) + DEFAULT_ROUTE_MAPPINGS
+        route_maps = [RouteMap(
+                    methods="*",
+                    pattern=r".*",
+                    route_type=RouteType.TOOL,
+                )] if all_routes_as_tools else (route_maps or []) + DEFAULT_ROUTE_MAPPINGS
+        
+
         for route in http_routes:
             # Determine route type based on mappings or default rules
             route_type = _determine_route_type(route, route_maps)

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -1168,6 +1168,7 @@ class FastMCP(Generic[LifespanResultT]):
             openapi_spec=openapi_spec,
             client=client,
             route_maps=route_maps,
+            all_routes_as_tools=all_routes_as_tools,
             **settings,
         )
 


### PR DESCRIPTION
- `route_maps` in `openapi.py` were something like this if using all_routes_as_tools in `server.py`:
```
[
    RouteMap(
        methods=['GET'],
        pattern=r'.*\{.*\}.*',
        route_type=RouteType.RESOURCE_TEMPLATE
    ),
    RouteMap(
        methods=['GET'],
        pattern=r'.*',
        route_type=RouteType.RESOURCE
    ),
    RouteMap(
        methods=['POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'],
        pattern=r'.*',
        route_type=RouteType.TOOL
    ),
    RouteMap(
        methods='*',
        pattern=r'.*',
        route_type=RouteType.TOOL
    ),
]
```
- Although we had the `methods='*'`    to set as TOOL, the others were still taking precedence, so `GET` endpoints were still being assigned as `RESOURCE`.
- Changed this to ONLY use the `methods='*'` RouteMap if all_routes_as_tools.