### PR TITLE
Expose model preferences in `Context.sample` for flexible model selection.

### DIFF
--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -228,7 +228,7 @@ async def analyze_sentiment(text: str, ctx: Context) -> dict:
     # Create a sampling prompt asking for sentiment analysis
     prompt = f"Analyze the sentiment of the following text as positive, negative, or neutral. Just output a single word - 'positive', 'negative', or 'neutral'. Text to analyze: {text}"
     
-    # Send the sampling request to the clients LLM (provide a hint for the model you want to use)
+    # Send the sampling request to the client's LLM (provide a hint for the model you want to use)
     response = await ctx.sample(prompt, model_preferences="claude-3-sonnet")
     
     # Process the LLM's response

--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -228,8 +228,8 @@ async def analyze_sentiment(text: str, ctx: Context) -> dict:
     # Create a sampling prompt asking for sentiment analysis
     prompt = f"Analyze the sentiment of the following text as positive, negative, or neutral. Just output a single word - 'positive', 'negative', or 'neutral'. Text to analyze: {text}"
     
-    # Send the sampling request to the client's LLM
-    response = await ctx.sample(prompt)
+    # Send the sampling request to the clients LLM (provide a hint for the model you want to use)
+    response = await ctx.sample(prompt, model_preferences="claude-3-sonnet")
     
     # Process the LLM's response
     sentiment = response.text.strip().lower()
@@ -247,11 +247,12 @@ async def analyze_sentiment(text: str, ctx: Context) -> dict:
 
 **Method signature:**
 
-- **`ctx.sample(messages: str | list[str | SamplingMessage], system_prompt: str | None = None, temperature: float | None = None, max_tokens: int | None = None) -> TextContent | ImageContent`**
+- **`ctx.sample(messages: str | list[str | SamplingMessage], system_prompt: str | None = None, temperature: float | None = None, max_tokens: int | None = None, model_preferences: ModelPreferences | str | list[str] | None = None) -> TextContent | ImageContent`**
   - `messages`: A string or list of strings/message objects to send to the LLM
   - `system_prompt`: Optional system prompt to guide the LLM's behavior
   - `temperature`: Optional sampling temperature (controls randomness)
   - `max_tokens`: Optional maximum number of tokens to generate (defaults to 512)
+  - `model_preferences`: Optional model selection preferences (e.g., a model hint string, list of hints, or a ModelPreferences object)
   - Returns the LLM's response as TextContent or ImageContent
 
 When providing a simple string, it's treated as a user message. For more complex scenarios, you can provide a list of messages with different roles.

--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -253,7 +253,9 @@ class Context:
 
         return fastmcp.server.dependencies.get_http_request()
 
-    def _parse_model_preferences(self, model_preferences) -> ModelPreferences | None:
+    def _parse_model_preferences(
+        self, model_preferences: ModelPreferences | str | list[str] | None
+    ) -> ModelPreferences | None:
         """
         Validates and converts user input for model_preferences into a ModelPreferences object.
 
@@ -273,12 +275,12 @@ class Context:
         """
         if model_preferences is None:
             return None
-        if isinstance(model_preferences, ModelPreferences):
+        elif isinstance(model_preferences, ModelPreferences):
             return model_preferences
-        if isinstance(model_preferences, str):
+        elif isinstance(model_preferences, str):
             # Single model hint
             return ModelPreferences(hints=[ModelHint(name=model_preferences)])
-        if isinstance(model_preferences, list):
+        elif isinstance(model_preferences, list):
             # List of model hints (strings)
             if not all(isinstance(h, str) for h in model_preferences):
                 raise ValueError(
@@ -288,6 +290,7 @@ class Context:
             return ModelPreferences(
                 hints=[ModelHint(name=h) for h in model_preferences]
             )
-        raise ValueError(
-            "model_preferences must be one of: ModelPreferences, str, list[str], or None."
-        )
+        else:
+            raise ValueError(
+                "model_preferences must be one of: ModelPreferences, str, list[str], or None."
+            )


### PR DESCRIPTION
This PR addresses #524 by exposing the `model_preferences` parameter in the `Context.sample` method. This allows server authors to specify model selection preferences—such as model hints or a full `ModelPreferences` object—when requesting LLM sampling from the client.

## Key changes

- Added `model_preferences` parameter to `Context.sample`, supporting:
    - A string (single model hint)
    - A list of strings (multiple model hints)
    - A `ModelPreferences` object (for [advanced use](https://modelcontextprotocol.io/specification/2025-03-26/client/sampling#model-preferences))
- Added robust input validation and conversion logic.
- Updated documentation and usage examples to reflect the new parameter.
- Added unit tests for all supported input types and error cases.

### Docs

- Updated the docs to include the new parameter

Let me know if you'd like any changes or more tests!