### PR TITLE
Add client method to send cancellation notifications

### DIFF
--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -210,6 +210,23 @@ class Client:
         result = await self.session.send_ping()
         return isinstance(result, mcp.types.EmptyResult)
 
+    async def cancel(
+        self,
+        request_id: str | int,
+        reason: str | None = None,
+    ) -> None:
+        """Send a cancellation notification for an in-progress request."""
+        notification = mcp.types.ClientNotification(
+            mcp.types.CancelledNotification(
+                method="notifications/cancelled",
+                params=mcp.types.CancelledNotificationParams(
+                    requestId=request_id,
+                    reason=reason,
+                ),
+            )
+        )
+        await self.session.send_notification(notification)
+
     async def progress(
         self,
         progress_token: str | int,


### PR DESCRIPTION
### Summary

- Implements `Client.cancel()` to emit `notifications/cancelled` as defined in the [spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/utilities/cancellation#cancellation)

- Allows clients to request cancellation of in-progress requests with an optional reason.

- No tests added, matching current notification method coverage.

Happy to close if there's another way to do this. Didn't see the option anywhere else.