### PR TITLE
Add global tool hooks support

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -768,6 +768,40 @@ class FastMCP(Generic[LifespanResultT]):
 
         return decorator
 
+    def before_tool_call(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        """Decorator to register a global before hook for tool execution.
+
+        The hook will be called before any tool is executed. The hook function
+        receives the tool name and arguments as parameters.
+
+        Args:
+            func: The hook function to register
+
+        Example:
+            @server.before_tool_call
+            def log_tool_calls(tool_name: str, arguments: dict):
+                print(f"Calling {tool_name}")
+        """
+        self._tool_manager.add_global_before_hook(func)
+        return func
+
+    def after_tool_call(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        """Decorator to register a global after hook for tool execution.
+
+        The hook will be called after any tool is executed. The hook function
+        receives the tool name, arguments, and result as parameters.
+
+        Args:
+            func: The hook function to register
+
+        Example:
+            @server.after_tool_call
+            def log_tool_results(tool_name: str, arguments: dict, result: Any):
+                print(f"Tool {tool_name} completed")
+        """
+        self._tool_manager.add_global_after_hook(func)
+        return func
+
     async def run_stdio_async(self) -> None:
         """Run the server using stdio transport."""
         async with stdio_server() as (read_stream, write_stream):

--- a/src/fastmcp/tools/tool_manager.py
+++ b/src/fastmcp/tools/tool_manager.py
@@ -78,10 +78,14 @@ class ToolManager:
 
     async def _call_hook(self, hook: Callable[..., Any], *args: Any) -> None:
         """Call a hook, handling both sync and async functions."""
-        if inspect.iscoroutinefunction(hook):
-            await hook(*args)
-        else:
-            hook(*args)
+        try:
+            if inspect.iscoroutinefunction(hook):
+                await hook(*args)
+            else:
+                hook(*args)
+        except Exception as e:
+            logger.exception(f"Hook {hook.__name__} failed: {e}")
+            # Continue execution - don't let hook failures break tools
 
     def has_tool(self, key: str) -> bool:
         """Check if a tool exists."""


### PR DESCRIPTION
This PR adds global hooks for tool execution. Users can now run code before and after any tool executes.

### **What's Added**
- `@mcp.before_tool_call` - decorator for before-execution hooks
- `@mcp.after_tool_call` - decorator for after-execution hooks  
- Works with sync and async functions
- Validates hook signatures to prevent errors

### **Usage**
```python
@mcp.before_tool_call
def log_start(tool_name: str, arguments: dict):
    print(f"Starting {tool_name}")

@mcp.after_tool_call  
def log_finish(tool_name: str, arguments: dict, result):
    print(f"Finished {tool_name}")
```

### **Why This Matters**

Addresses #549 - this is one approach to adding middleware capabilities.

### **Current Limitations**
1. **Global only**: No per-tool hooks yet
2. **Tools only**: Resources and prompts don't have hooks


### **What's Next**
This could establish a pattern for expanding to:
- Per-tool hooks
- Resource/prompt hooks  

Feedback welcome!