### PR TITLE
Permit more flexible name generation for OpenAPI servers

### DIFF
--- a/docs/servers/openapi.mdx
+++ b/docs/servers/openapi.mdx
@@ -241,7 +241,7 @@ FastMCP automatically generates names for MCP components based on the OpenAPI sp
 
 All component names are automatically:
 - **Slugified**: Spaces and special characters are converted to underscores or removed
-- **Truncated**: Limited to 48 characters maximum to ensure compatibility
+- **Truncated**: Limited to 56 characters maximum to ensure compatibility
 - **Unique**: If multiple components have the same name, a number is automatically appended to make them unique
 
 For more control over component names, you can provide an `mcp_names` dictionary that maps `operationId` values to your desired names. The `operationId` must be exactly as it appears in the OpenAPI spec. The provided name will always be slugified and truncated.

--- a/docs/servers/openapi.mdx
+++ b/docs/servers/openapi.mdx
@@ -231,6 +231,38 @@ mcp = FastMCP.from_openapi(
 
 ## Customizing MCP Components
 
+
+
+### Component Names
+
+<VersionBadge version="2.5.0" />
+
+FastMCP automatically generates names for MCP components based on the OpenAPI specification. By default, it uses the `operationId` from your OpenAPI spec, up to the first double underscore (`__`).
+
+All component names are automatically:
+- **Slugified**: Spaces and special characters are converted to underscores or removed
+- **Truncated**: Limited to 48 characters maximum to ensure compatibility
+- **Unique**: If multiple components have the same name, a number is automatically appended to make them unique
+
+For more control over component names, you can provide an `mcp_names` dictionary that maps `operationId` values to your desired names. The `operationId` must be exactly as it appears in the OpenAPI spec. The provided name will always be slugified and truncated.
+
+```python {5-9}
+from fastmcp import FastMCP
+
+mcp = FastMCP.from_openapi(
+    ...
+    mcp_names={
+        "list_users__with_pagination": "user_list",
+        "create_user__admin_required": "create_user", 
+        "get_user_details__admin_required": "user_detail",
+    }
+)
+```
+
+Any `operationId` not found in `mcp_names` will use the default strategy (operationId up to the first `__`).
+
+
+### Advanced Customization
 <VersionBadge version="2.5.0" />
 
 By default, FastMCP creates MCP components using a variety of metadata from the OpenAPI spec, such as incorporating the OpenAPI description into the MCP component description.
@@ -271,7 +303,6 @@ mcp = FastMCP.from_openapi(
     mcp_component_fn=customize_components,
 )
 ```
-
 ## Request Parameter Handling
 
 FastMCP intelligently handles different types of parameters in OpenAPI requests:
@@ -376,15 +407,15 @@ from fastmcp import FastMCP
 # Your FastAPI app
 app = FastAPI(title="My API", version="1.0.0")
 
-@app.get("/items", tags=["items"])
+@app.get("/items", tags=["items"], operation_id="list_items")
 def list_items():
     return [{"id": 1, "name": "Item 1"}, {"id": 2, "name": "Item 2"}]
 
-@app.get("/items/{item_id}", tags=["items", "detail"])
+@app.get("/items/{item_id}", tags=["items", "detail"], operation_id="get_item")
 def get_item(item_id: int):
     return {"id": item_id, "name": f"Item {item_id}"}
 
-@app.post("/items", tags=["items", "create"])
+@app.post("/items", tags=["items", "create"], operation_id="create_item")
 def create_item(name: str):
     return {"id": 3, "name": name}
 
@@ -394,6 +425,8 @@ mcp = FastMCP.from_fastapi(app=app)
 if __name__ == "__main__":
     mcp.run()  # Run as MCP server
 ```
+
+Note that operation ids are optional, but are used to create component names. You can also provide custom names, just like with OpenAPI specs.
 
 <Warning>
 FastMCP servers are not FastAPI apps, even when created from one. To learn how to deploy them as an ASGI app, see the [ASGI Integration](/deployment/asgi) documentation.
@@ -413,6 +446,7 @@ mcp = FastMCP.from_fastapi(
     app=app,
     name="My Custom Server",
     timeout=5.0,
+    mcp_names={"operationId": "friendly_name"},  # Custom component names
     route_maps=[
         # Admin endpoints become tools
         RouteMap(methods="*", pattern=r"^/admin/.*", mcp_type=MCPType.TOOL),
@@ -421,6 +455,9 @@ mcp = FastMCP.from_fastapi(
     ],
     route_map_fn=my_route_mapper,
     mcp_component_fn=my_component_customizer,
+    mcp_names={
+        "get_user_details_users__user_id__get": "get_user_details",
+    }
 )
 ```
 
@@ -430,4 +467,3 @@ mcp = FastMCP.from_fastapi(
 - **Schema inheritance**: Pydantic models and validation are preserved  
 - **ASGI transport**: Direct in-memory communication (no HTTP overhead)
 - **Full FastAPI features**: Dependencies, middleware, authentication all work
-

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -38,7 +38,10 @@ HttpMethod = Literal["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
 
 
 def _slugify(text: str) -> str:
-    """Convert text to a URL-friendly slug format."""
+    """
+    Convert text to a URL-friendly slug format that only contains lowercase
+    letters, uppercase letters, numbers, and underscores.
+    """
     if not text:
         return ""
 
@@ -807,7 +810,7 @@ class FastMCPOpenAPI(FastMCP):
             if route.operation_id in self._mcp_names:
                 name = self._mcp_names[route.operation_id]
             else:
-                # If there's a double underscore, use the first part
+                # If there's a double underscore in the operationId, use the first part
                 name = route.operation_id.split("__")[0]
         else:
             name = route.summary or f"{route.method}_{route.path}"

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -6,6 +6,7 @@ import enum
 import json
 import re
 import warnings
+from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from re import Pattern
@@ -34,6 +35,26 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 HttpMethod = Literal["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
+
+
+def _slugify(text: str) -> str:
+    """Convert text to a URL-friendly slug format."""
+    if not text:
+        return ""
+
+    # Replace spaces and common separators with underscores
+    slug = re.sub(r"[\s\-\.]+", "_", text)
+
+    # Remove non-alphanumeric characters except underscores
+    slug = re.sub(r"[^a-zA-Z0-9_]", "", slug)
+
+    # Remove multiple consecutive underscores
+    slug = re.sub(r"_+", "_", slug)
+
+    # Remove leading/trailing underscores
+    slug = slug.strip("_")
+
+    return slug
 
 
 def _get_mcp_client_headers() -> dict[str, str]:
@@ -695,6 +716,7 @@ class FastMCPOpenAPI(FastMCP):
         route_maps: list[RouteMap] | None = None,
         route_map_fn: RouteMapFn | None = None,
         mcp_component_fn: ComponentFn | None = None,
+        mcp_names: dict[str, str] | None = None,
         timeout: float | None = None,
         **settings: Any,
     ):
@@ -712,6 +734,11 @@ class FastMCPOpenAPI(FastMCP):
             mcp_component_fn: Optional callable for component customization.
                 Receives (route, component) and can modify the component in-place.
                 Called on every created component.
+            mcp_names: Optional dictionary mapping operationId to desired component names.
+                If an operationId is not in the dictionary, falls back to using the
+                operationId up to the first double underscore. If no operationId exists,
+                falls back to slugified summary or path-based naming.
+                All names are truncated to 56 characters maximum.
             timeout: Optional timeout (in seconds) for all requests
             **settings: Additional settings for FastMCP
         """
@@ -721,9 +748,15 @@ class FastMCPOpenAPI(FastMCP):
         self._timeout = timeout
         self._route_map_fn = route_map_fn
         self._mcp_component_fn = mcp_component_fn
+        self._mcp_names = mcp_names or {}
 
         # Keep track of names to detect collisions
-        self._used_names = {"tools": set(), "resources": set(), "templates": set()}
+        self._used_names = {
+            "tool": Counter(),
+            "resource": Counter(),
+            "resource_template": Counter(),
+            "prompt": Counter(),
+        }
 
         http_routes = openapi.parse_openapi_to_http_routes(openapi_spec)
 
@@ -766,40 +799,31 @@ class FastMCPOpenAPI(FastMCP):
     def _generate_default_name(
         self, route: openapi.HTTPRoute, mcp_type: MCPType
     ) -> str:
-        """Generate a default name from the route path."""
-        # First check for OpenAPI operationId which takes precedence
+        """Generate a default name from the route using the configured strategy."""
+        name = ""
 
+        # First check if there's a custom mapping for this operationId
         if route.operation_id:
-            return route.operation_id
-
-        # For path-based naming, clean up the path
-        path_parts = route.path.strip("/").split("/")
-
-        # Remove path parameters (parts with {})
-        clean_parts = []
-        for part in path_parts:
-            if part.startswith("{") and part.endswith("}"):
-                # For templates, include parameter name without braces
-                if mcp_type == MCPType.RESOURCE_TEMPLATE:
-                    param_name = part[1:-1]  # Remove braces
-                    clean_parts.append(param_name)
+            if route.operation_id in self._mcp_names:
+                name = self._mcp_names[route.operation_id]
             else:
-                clean_parts.append(part)
+                # If there's a double underscore, use the first part
+                name = route.operation_id.split("__")[0]
+        else:
+            name = route.summary or f"{route.method}_{route.path}"
 
-        # Join the parts
-        resource_name = "_".join(clean_parts)
+        name = _slugify(name)
 
-        # For tools, might be useful to keep the method for clarity on what it does
-        if mcp_type == MCPType.TOOL:
-            # Only include method if it helps distinguish (POST, PUT, PATCH, DELETE)
-            # For GET we don't need the method as it's implied for resources
-            if route.method != "GET":
-                resource_name = f"{route.method.lower()}_{resource_name}"
+        # Truncate to 56 characters maximum
+        if len(name) > 56:
+            name = name[:56]
 
-        return resource_name
+        return name
 
     def _get_unique_name(
-        self, name: str, component_type: Literal["tools", "resources", "templates"]
+        self,
+        name: str,
+        component_type: Literal["tool", "resource", "resource_template", "prompt"],
     ) -> str:
         """
         Ensure the name is unique within its component type by appending numbers if needed.
@@ -812,23 +836,18 @@ class FastMCPOpenAPI(FastMCP):
             str: A unique name for the component
         """
         # Check if the name is already used
-        if name not in self._used_names[component_type]:
-            self._used_names[component_type].add(name)
+        self._used_names[component_type][name] += 1
+        if self._used_names[component_type][name] == 1:
             return name
 
-        # Find the next available number suffix
-        counter = 2
-        while f"{name}_{counter}" in self._used_names[component_type]:
-            counter += 1
+        else:
+            # Create the new name
+            new_name = f"{name}_{self._used_names[component_type][name]}"
+            logger.debug(
+                f"Name collision detected: '{name}' already exists as a {component_type[:-1]}. "
+                f"Using '{new_name}' instead."
+            )
 
-        # Create the new name
-        new_name = f"{name}_{counter}"
-        logger.debug(
-            f"Name collision detected: '{name}' already exists as a {component_type[:-1]}. "
-            f"Using '{new_name}' instead."
-        )
-
-        self._used_names[component_type].add(new_name)
         return new_name
 
     def _create_openapi_tool(self, route: openapi.HTTPRoute, name: str):
@@ -836,7 +855,7 @@ class FastMCPOpenAPI(FastMCP):
         combined_schema = _combine_schemas(route)
 
         # Get a unique tool name
-        tool_name = self._get_unique_name(name, "tools")
+        tool_name = self._get_unique_name(name, "tool")
 
         base_description = (
             route.description
@@ -882,7 +901,7 @@ class FastMCPOpenAPI(FastMCP):
     def _create_openapi_resource(self, route: openapi.HTTPRoute, name: str):
         """Creates and registers an OpenAPIResource with enhanced description."""
         # Get a unique resource name
-        resource_name = self._get_unique_name(name, "resources")
+        resource_name = self._get_unique_name(name, "resource")
 
         resource_uri = f"resource://{resource_name}"
         base_description = (
@@ -927,7 +946,7 @@ class FastMCPOpenAPI(FastMCP):
     def _create_openapi_template(self, route: openapi.HTTPRoute, name: str):
         """Creates and registers an OpenAPIResourceTemplate with enhanced description."""
         # Get a unique template name
-        template_name = self._get_unique_name(name, "templates")
+        template_name = self._get_unique_name(name, "resource_template")
 
         path_params = [p.name for p in route.parameters if p.location == "path"]
         path_params.sort()  # Sort for consistent URIs

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -1170,6 +1170,7 @@ class FastMCP(Generic[LifespanResultT]):
         route_maps: list[RouteMap] | None = None,
         route_map_fn: OpenAPIRouteMapFn | None = None,
         mcp_component_fn: OpenAPIComponentFn | None = None,
+        mcp_names: dict[str, str] | None = None,
         all_routes_as_tools: bool = False,
         **settings: Any,
     ) -> FastMCPOpenAPI:
@@ -1199,6 +1200,7 @@ class FastMCP(Generic[LifespanResultT]):
             route_maps=route_maps,
             route_map_fn=route_map_fn,
             mcp_component_fn=mcp_component_fn,
+            mcp_names=mcp_names,
             **settings,
         )
 
@@ -1210,6 +1212,7 @@ class FastMCP(Generic[LifespanResultT]):
         route_maps: list[RouteMap] | None = None,
         route_map_fn: OpenAPIRouteMapFn | None = None,
         mcp_component_fn: OpenAPIComponentFn | None = None,
+        mcp_names: dict[str, str] | None = None,
         all_routes_as_tools: bool = False,
         httpx_client_kwargs: dict[str, Any] | None = None,
         **settings: Any,
@@ -1253,6 +1256,7 @@ class FastMCP(Generic[LifespanResultT]):
             route_maps=route_maps,
             route_map_fn=route_map_fn,
             mcp_component_fn=mcp_component_fn,
+            mcp_names=mcp_names,
             **settings,
         )
 

--- a/tests/client/test_openapi.py
+++ b/tests/client/test_openapi.py
@@ -130,7 +130,7 @@ class TestClientHeaders:
             transport=SSETransport(sse_server, headers={"X-TEST": "test-123"})
         ) as client:
             result = await client.read_resource(
-                "resource://get_header_by_name_headers__header_name__get/x-test"
+                "resource://get_header_by_name_headers/x-test"
             )
             assert isinstance(result[0], TextResourceContents)
             header = json.loads(result[0].text)
@@ -143,7 +143,7 @@ class TestClientHeaders:
             )
         ) as client:
             result = await client.read_resource(
-                "resource://get_header_by_name_headers__header_name__get/x-test"
+                "resource://get_header_by_name_headers/x-test"
             )
             assert isinstance(result[0], TextResourceContents)
             header = json.loads(result[0].text)

--- a/tests/server/openapi/test_openapi_path_parameters.py
+++ b/tests/server/openapi/test_openapi_path_parameters.py
@@ -84,7 +84,7 @@ async def test_fastmcp_from_openapi(array_path_spec, mock_client):
     # Verify the tool was created using the MCP protocol method
     tools_result = await mcp.get_tools()
     tool_names = [tool.name for tool in tools_result.values()]
-    assert "test-operation" in tool_names
+    assert "test_operation" in tool_names
 
 
 async def test_array_path_parameter_handling(mock_client):
@@ -93,7 +93,7 @@ async def test_array_path_parameter_handling(mock_client):
     route = HTTPRoute(
         path="/select/{days}",
         method="PUT",
-        operation_id="test-operation",
+        operation_id="test_operation",
         parameters=[
             ParameterInfo(
                 name="days",
@@ -122,7 +122,7 @@ async def test_array_path_parameter_handling(mock_client):
     tool = OpenAPITool(
         client=mock_client,
         route=route,
-        name="test-operation",
+        name="test_operation",
         description="Test operation",
         parameters={},
     )
@@ -163,7 +163,7 @@ async def test_integration_array_path_parameter(array_path_spec, mock_client):
     mcp = FastMCP.from_openapi(array_path_spec, client=mock_client)
 
     # Call the tool with a single value
-    await mcp._mcp_call_tool("test-operation", {"days": ["monday"]})
+    await mcp._mcp_call_tool("test_operation", {"days": ["monday"]})
 
     # Check the request was made correctly
     mock_client.request.assert_called_with(
@@ -177,7 +177,7 @@ async def test_integration_array_path_parameter(array_path_spec, mock_client):
     mock_client.request.reset_mock()
 
     # Call the tool with multiple values
-    await mcp._mcp_call_tool("test-operation", {"days": ["monday", "tuesday"]})
+    await mcp._mcp_call_tool("test_operation", {"days": ["monday", "tuesday"]})
 
     # Check the request was made correctly
     mock_client.request.assert_called_with(


### PR DESCRIPTION
This PR changes how OpenAPI component names are generated (generally improving them) and permits name customization by providing an `mcp_names` dictionary to `from_openapi()` or `from_fastapi()`. The dictionary maps OpenAPI operation IDs to MCP component names.

In addition, it automatically slugifies and truncates all names to 56 characters.

Users can also use the mcp component fn introduced in #566 

Closes #420 
Closes #188 

