### PR TITLE
Support for uppercase letters at the log level

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -802,7 +802,7 @@ class FastMCP(Generic[LifespanResultT]):
         """
         host = host or self.settings.host
         port = port or self.settings.port
-        default_log_level_to_use = log_level or self.settings.log_level.lower()
+        default_log_level_to_use = (log_level or self.settings.log_level).lower()
 
         app = self.http_app(path=path, transport=transport, middleware=middleware)
 


### PR DESCRIPTION
Previously, fastmcp commands using uppercase log levels would fail to execute.

This update adds support for uppercase letters in log level specifications.

e.g.
fastmcp run --transport streamable-http --host 0.0.0.0 -p 8000 --log-level DEBUG examples/echo.py