### PR TITLE
Simplify code for running servers in processes during tests

### DIFF
--- a/src/fastmcp/utilities/tests.py
+++ b/src/fastmcp/utilities/tests.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import uvicorn
 
-import fastmcp
 from fastmcp.settings import settings
 from fastmcp.utilities.http import find_available_port
 
@@ -73,28 +72,27 @@ def _run_server(mcp_server: FastMCP, transport: Literal["sse"], port: int) -> No
 
 @contextmanager
 def run_server_in_process(
-    server_fn: FastMCP | Callable[..., None],
+    server_fn: Callable[..., None],
     *args,
     provide_host_and_port: bool = True,
     **kwargs,
 ) -> Generator[str, None, None]:
     """
-    Context manager that runs a FastMCP server (or a function that runs a FastMCP server) in a separate process and
+    Context manager that runs a FastMCP server in a separate process and
     returns the server URL. When the context manager is exited, the server process is killed.
 
     Args:
-        server_fn: The FastMCP server to run, or a function that runs a FastMCP
-            server. If a FastMCP server is provided, its .run() method is called
-            with the provided arguments and keyword arguments.
+        server_fn: The function that runs a FastMCP server. FastMCP servers are
+            not pickleable, so we need a function that creates and runs one.
+        *args: Arguments to pass to the server function.
+        provide_host_and_port: Whether to provide the host and port to the server function as kwargs.
+        **kwargs: Keyword arguments to pass to the server function.
 
     Returns:
         The server URL.
     """
     host = "127.0.0.1"
     port = find_available_port()
-
-    if isinstance(server_fn, fastmcp.FastMCP):
-        server_fn = server_fn.run
 
     if provide_host_and_port:
         kwargs |= {"host": host, "port": port}

--- a/tests/auth/test_oauth_client.py
+++ b/tests/auth/test_oauth_client.py
@@ -1,11 +1,9 @@
-import sys
 from collections.abc import Generator
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
-import uvicorn
 
 import fastmcp.client.auth  # Import module, not the function directly
 from fastmcp.client import Client
@@ -39,30 +37,13 @@ def fastmcp_server(issuer_url: str):
     return server
 
 
-def run_server(host: str, port: int, transport: str | None = None) -> None:
-    try:
-        # Configure OAuth provider with the actual server URL
-        issuer_url = f"http://{host}:{port}"
-        app = fastmcp_server(issuer_url).http_app()
-        server = uvicorn.Server(
-            config=uvicorn.Config(
-                app=app,
-                host=host,
-                port=port,
-                log_level="error",
-                lifespan="on",
-            )
-        )
-        server.run()
-    except Exception as e:
-        print(f"Server error: {e}")
-        sys.exit(1)
-    sys.exit(0)
+def run_server(host: str, port: int, **kwargs) -> None:
+    fastmcp_server(f"http://{host}:{port}").run(host=host, port=port, **kwargs)
 
 
 @pytest.fixture(scope="module")
 def streamable_http_server() -> Generator[str, None, None]:
-    with run_server_in_process(run_server) as url:
+    with run_server_in_process(run_server, transport="streamable-http") as url:
         yield f"{url}/mcp"
 
 

--- a/tests/client/test_sse.py
+++ b/tests/client/test_sse.py
@@ -63,22 +63,13 @@ def fastmcp_server():
     return server
 
 
-def run_server(host: str, port: int, path: str | None = None) -> None:
-    try:
-        app = fastmcp_server().http_app(transport="sse", path=path)
-        server = uvicorn.Server(
-            config=uvicorn.Config(app=app, host=host, port=port, log_level="error")
-        )
-        server.run()
-    except Exception as e:
-        print(f"Server error: {e}")
-        sys.exit(1)
-    sys.exit(0)
+def run_server(host: str, port: int, **kwargs) -> None:
+    fastmcp_server().run(host=host, port=port, **kwargs)
 
 
 @pytest.fixture(autouse=True, scope="module")
 def sse_server() -> Generator[str, None, None]:
-    with run_server_in_process(run_server) as url:
+    with run_server_in_process(run_server, transport="sse") as url:
         yield f"{url}/sse"
 
 
@@ -101,22 +92,17 @@ async def test_http_headers(sse_server: str):
 
 
 def run_nested_server(host: str, port: int) -> None:
-    try:
-        app = fastmcp_server().sse_app(path="/mcp/sse", message_path="/mcp/messages")
-        mount = Starlette(routes=[Mount("/nest-inner", app=app)])
-        mount2 = Starlette(routes=[Mount("/nest-outer", app=mount)])
-        server = uvicorn.Server(
-            config=uvicorn.Config(app=mount2, host=host, port=port, log_level="error")
-        )
-        server.run()
-    except Exception as e:
-        print(f"Server error: {e}")
-        sys.exit(1)
-    sys.exit(0)
+    app = fastmcp_server().sse_app(path="/mcp/sse", message_path="/mcp/messages")
+    mount = Starlette(routes=[Mount("/nest-inner", app=app)])
+    mount2 = Starlette(routes=[Mount("/nest-outer", app=mount)])
+    server = uvicorn.Server(
+        config=uvicorn.Config(app=mount2, host=host, port=port, log_level="error")
+    )
+    server.run()
 
 
 async def test_run_server_on_path():
-    with run_server_in_process(run_server, "/help") as url:
+    with run_server_in_process(run_server, transport="sse", path="/help") as url:
         async with Client(transport=SSETransport(f"{url}/help")) as client:
             result = await client.ping()
             assert result is True

--- a/tests/server/http/test_http_dependencies.py
+++ b/tests/server/http/test_http_dependencies.py
@@ -1,9 +1,7 @@
 import json
-import sys
 from collections.abc import Generator
 
 import pytest
-import uvicorn
 
 from fastmcp.client import Client
 from fastmcp.client.transports import SSETransport, StreamableHttpTransport
@@ -40,53 +38,19 @@ def fastmcp_server():
     return server
 
 
-def run_shttp_server(host: str, port: int) -> None:
-    try:
-        app = fastmcp_server().http_app(transport="streamable-http")
-        server = uvicorn.Server(
-            config=uvicorn.Config(
-                app=app,
-                host=host,
-                port=port,
-                log_level="error",
-                lifespan="on",
-            )
-        )
-        server.run()
-    except Exception as e:
-        print(f"Server error: {e}")
-        sys.exit(1)
-    sys.exit(0)
-
-
-def run_sse_server(host: str, port: int) -> None:
-    try:
-        app = fastmcp_server().http_app(transport="sse")
-        server = uvicorn.Server(
-            config=uvicorn.Config(
-                app=app,
-                host=host,
-                port=port,
-                log_level="error",
-                lifespan="on",
-            )
-        )
-        server.run()
-    except Exception as e:
-        print(f"Server error: {e}")
-        sys.exit(1)
-    sys.exit(0)
+def run_server(host: str, port: int, **kwargs) -> None:
+    fastmcp_server().run(host=host, port=port, **kwargs)
 
 
 @pytest.fixture(autouse=True, scope="module")
 def shttp_server() -> Generator[str, None, None]:
-    with run_server_in_process(run_shttp_server) as url:
+    with run_server_in_process(run_server, transport="streamable-http") as url:
         yield f"{url}/mcp"
 
 
 @pytest.fixture(autouse=True, scope="module")
 def sse_server() -> Generator[str, None, None]:
-    with run_server_in_process(run_sse_server) as url:
+    with run_server_in_process(run_server, transport="sse") as url:
         yield f"{url}/sse"
 
 


### PR DESCRIPTION
Since servers aren't pickleable, we want a very clean and minimal DX (but still customizable) for running them for tests. We already had a few good steps in this direction, this goes farther. Now this is recommended:

```python
def run_server(host: str, port: int, **kwargs) -> None:
    # define a server either from a function, inline, or any other way. 
    # It just has to be created AFTER the process starts since servers aren't pickleable.
    server = FastMCP()
    fastmcp_server().run(host=host, port=port, **kwargs)

@pytest.fixture(scope='module')
def shttp_server() → str:
    with run_server_in_process(run_server) as url:
        yield url

def my_test(shttp_server: str):
    async with fastmcp.Client(shttp_server) as client:
        ...
```