### PR TITLE
replace $ref pointing to `#/components/schemas/` with `#/$defs/`

### DIFF
--- a/src/fastmcp/utilities/openapi.py
+++ b/src/fastmcp/utilities/openapi.py
@@ -942,7 +942,8 @@ def _combine_schemas(route: HTTPRoute) -> dict[str, Any]:
         # For now, just use the first content type's schema
         content_type = next(iter(route.request_body.content_schema))
         body_schema = _replace_ref_with_defs(
-            route.request_body.content_schema[content_type].copy()
+            route.request_body.content_schema[content_type].copy(),
+            route.request_body.description,
         )
         body_props = body_schema.get("properties", {})
 

--- a/src/fastmcp/utilities/openapi.py
+++ b/src/fastmcp/utilities/openapi.py
@@ -872,6 +872,45 @@ def format_description_with_responses(
     return "\n".join(desc_parts)
 
 
+def _replace_ref_with_defs(
+    info: dict[str, Any], description: str | None = None
+) -> dict[str, Any]:
+    """
+    Replace openapi $ref with jsonschema $defs
+
+    Examples:
+    - {"type": "object", "properties": {"$ref": "#/components/schemas/..."}}
+    - {"$ref": "#/components/schemas/..."}
+    - {"items": {"$ref": "#/components/schemas/..."}}
+    - {"anyOf": [{"$ref": "#/components/schemas/..."}]}
+    - {"allOf": [{"$ref": "#/components/schemas/..."}]}
+    - {"oneOf": [{"$ref": "#/components/schemas/..."}]}
+
+    Args:
+        info: dict[str, Any]
+        description: str | None
+
+    Returns:
+        dict[str, Any]
+    """
+    schema = info.copy()
+    if properties := schema.get("properties"):
+        for prop_name, prop_schema in properties.items():
+            properties[prop_name] = _replace_ref_with_defs(prop_schema)
+    elif ref_path := schema.get("$ref"):
+        if ref_path.startswith("#/components/schemas/"):
+            schema_name = ref_path.split("/")[-1]
+            schema["$ref"] = f"#/$defs/{schema_name}"
+    elif item_schema := schema.get("items"):
+        schema["items"] = _replace_ref_with_defs(item_schema)
+    for section in ["anyOf", "allOf", "oneOf"]:
+        for i, item in enumerate(schema.get(section, [])):
+            schema[section][i] = _replace_ref_with_defs(item)
+    if info.get("description", description) and not schema.get("description"):
+        schema["description"] = description
+    return schema
+
+
 def _combine_schemas(route: HTTPRoute) -> dict[str, Any]:
     """
     Combines parameter and request body schemas into a single schema.
@@ -889,38 +928,17 @@ def _combine_schemas(route: HTTPRoute) -> dict[str, Any]:
     for param in route.parameters:
         if param.required:
             required.append(param.name)
-
-        # Copy the schema and add description if available
-        param_schema = param.schema_.copy() if isinstance(param.schema_, dict) else {}
-
-        # Convert #/components/schemas references to #/$defs references
-        if isinstance(param_schema, dict) and "$ref" in param_schema:
-            ref_path = param_schema["$ref"]
-            if ref_path.startswith("#/components/schemas/"):
-                schema_name = ref_path.split("/")[-1]
-                param_schema["$ref"] = f"#/$defs/{schema_name}"
-
-        # Also handle anyOf, allOf, oneOf references
-        for section in ["anyOf", "allOf", "oneOf"]:
-            if section in param_schema and isinstance(param_schema[section], list):
-                for i, item in enumerate(param_schema[section]):
-                    if isinstance(item, dict) and "$ref" in item:
-                        ref_path = item["$ref"]
-                        if ref_path.startswith("#/components/schemas/"):
-                            schema_name = ref_path.split("/")[-1]
-                            param_schema[section][i]["$ref"] = f"#/$defs/{schema_name}"
-
-        # Add parameter description to schema if available and not already present
-        if param.description and not param_schema.get("description"):
-            param_schema["description"] = param.description
-
-        properties[param.name] = param_schema
+        properties[param.name] = _replace_ref_with_defs(
+            param.schema_.copy(), param.description
+        )
 
     # Add request body if it exists
     if route.request_body and route.request_body.content_schema:
         # For now, just use the first content type's schema
         content_type = next(iter(route.request_body.content_schema))
-        body_schema = route.request_body.content_schema[content_type]
+        body_schema = _replace_ref_with_defs(
+            route.request_body.content_schema[content_type].copy()
+        )
         body_props = body_schema.get("properties", {})
 
         # Add request body properties
@@ -935,7 +953,6 @@ def _combine_schemas(route: HTTPRoute) -> dict[str, Any]:
         "properties": properties,
         "required": required,
     }
-
     # Add schema definitions if available
     if route.schema_definitions:
         result["$defs"] = route.schema_definitions

--- a/tests/utilities/openapi/test_openapi.py
+++ b/tests/utilities/openapi/test_openapi.py
@@ -6,7 +6,10 @@ import pytest
 from fastapi import Body, FastAPI, Path, Query
 from pydantic import BaseModel, Field
 
-from fastmcp.utilities.openapi import parse_openapi_to_http_routes
+from fastmcp.utilities.openapi import (
+    _combine_schemas,
+    parse_openapi_to_http_routes,
+)
 
 # --- Test Data: Static OpenAPI Schema Dictionaries --- #
 
@@ -1023,6 +1026,9 @@ def test_openapi_30_reference_resolution(openapi_30_with_references):
     # or it still has a $ref field
     assert "properties" in category or "$ref" in category
 
+    combined_schema = _combine_schemas(route)
+    assert "#/$defs/" in combined_schema["properties"]["category"]["$ref"]
+
 
 def test_openapi_31_reference_resolution(openapi_31_with_references):
     """Test that references are correctly resolved in OpenAPI 3.1 schemas."""
@@ -1056,6 +1062,9 @@ def test_openapi_31_reference_resolution(openapi_31_with_references):
     # Either it's directly resolved with properties
     # or it still has a $ref field
     assert "properties" in category or "$ref" in category
+
+    combined_schema = _combine_schemas(route)
+    assert "#/$defs/" in combined_schema["properties"]["category"]["$ref"]
 
 
 def test_consistent_output_across_versions(

--- a/tests/utilities/openapi/test_openapi.py
+++ b/tests/utilities/openapi/test_openapi.py
@@ -1105,65 +1105,101 @@ def test_consistent_output_across_versions(
     assert set(schema_30.keys()) == set(schema_31.keys())
 
 
-def test_replace_ref_with_defs():
-    ref_type = {
-        "$ref": "#/components/schemas/RefFoo",
-    }
-    object_type = {
-        "type": "object",
-        "properties": {"$ref": "#/components/schemas/ObjectFoo"},
-    }
-    array_type = {"type": "array", "items": {"$ref": "#/components/schemas/ArrayFoo"}}
-    any_of_type = {
-        "anyOf": [
-            {"$ref": "#/components/schemas/AnyOfFoo"},
-            {"$ref": "#/components/schemas/AnyOfBar"},
-        ]
-    }
-    all_of_type = {
-        "allOf": [
-            {"$ref": "#/components/schemas/AllOfFoo"},
-            {"$ref": "#/components/schemas/AllOfBar"},
-        ]
-    }
-    one_of_type = {
-        "oneOf": [
-            {"$ref": "#/components/schemas/OneOfFoo"},
-            {"$ref": "#/components/schemas/OneOfBar"},
-        ]
-    }
-    nested_type = {
-        "type": "object",
-        "properties": {
-            "pets": {
-                "oneOf": [
-                    {"$ref": "#/components/schemas/Cat"},
-                    {"$ref": "#/components/schemas/Dog"},
+class TestReplaceRefWithDefs:
+    @pytest.fixture(scope="class")
+    def schemas(self):
+        """Provide test schemas for _replace_ref_with_defs function."""
+        return {
+            "ref_type": {
+                "$ref": "#/components/schemas/RefFoo",
+            },
+            "object_type": {
+                "type": "object",
+                "properties": {"$ref": "#/components/schemas/ObjectFoo"},
+            },
+            "array_type": {
+                "type": "array",
+                "items": {"$ref": "#/components/schemas/ArrayFoo"},
+            },
+            "any_of_type": {
+                "anyOf": [
+                    {"$ref": "#/components/schemas/AnyOfFoo"},
+                    {"$ref": "#/components/schemas/AnyOfBar"},
                 ]
             },
-        },
-    }
-    assert _replace_ref_with_defs(object_type) == {
-        "type": "object",
-        "properties": {"$ref": "#/$defs/ObjectFoo"},
-    }
-    assert _replace_ref_with_defs(ref_type) == {"$ref": "#/$defs/RefFoo"}
-    assert _replace_ref_with_defs(array_type) == {
-        "type": "array",
-        "items": {"$ref": "#/$defs/ArrayFoo"},
-    }
-    assert _replace_ref_with_defs(any_of_type) == {
-        "anyOf": [{"$ref": "#/$defs/AnyOfFoo"}, {"$ref": "#/$defs/AnyOfBar"}]
-    }
-    assert _replace_ref_with_defs(all_of_type) == {
-        "allOf": [{"$ref": "#/$defs/AllOfFoo"}, {"$ref": "#/$defs/AllOfBar"}]
-    }
-    assert _replace_ref_with_defs(one_of_type) == {
-        "oneOf": [{"$ref": "#/$defs/OneOfFoo"}, {"$ref": "#/$defs/OneOfBar"}]
-    }
-    assert _replace_ref_with_defs(nested_type) == {
-        "type": "object",
-        "properties": {
-            "pets": {"oneOf": [{"$ref": "#/$defs/Cat"}, {"$ref": "#/$defs/Dog"}]}
-        },
-    }
+            "all_of_type": {
+                "allOf": [
+                    {"$ref": "#/components/schemas/AllOfFoo"},
+                    {"$ref": "#/components/schemas/AllOfBar"},
+                ]
+            },
+            "one_of_type": {
+                "oneOf": [
+                    {"$ref": "#/components/schemas/OneOfFoo"},
+                    {"$ref": "#/components/schemas/OneOfBar"},
+                ]
+            },
+            "nested_type": {
+                "type": "object",
+                "properties": {
+                    "pets": {
+                        "oneOf": [
+                            {"$ref": "#/components/schemas/Cat"},
+                            {"$ref": "#/components/schemas/Dog"},
+                        ]
+                    },
+                },
+            },
+        }
+
+    def test_replace_direct_ref(self, schemas):
+        """Test replacing direct $ref references."""
+        result = _replace_ref_with_defs(schemas["ref_type"])
+        assert result == {"$ref": "#/$defs/RefFoo"}
+
+    def test_replace_object_property_ref(self, schemas):
+        """Test replacing $ref in object properties."""
+        result = _replace_ref_with_defs(schemas["object_type"])
+        assert result == {
+            "type": "object",
+            "properties": {"$ref": "#/$defs/ObjectFoo"},
+        }
+
+    def test_replace_array_items_ref(self, schemas):
+        """Test replacing $ref in array items."""
+        result = _replace_ref_with_defs(schemas["array_type"])
+        assert result == {
+            "type": "array",
+            "items": {"$ref": "#/$defs/ArrayFoo"},
+        }
+
+    def test_replace_any_of_refs(self, schemas):
+        """Test replacing $ref in anyOf schemas."""
+        result = _replace_ref_with_defs(schemas["any_of_type"])
+        assert result == {
+            "anyOf": [{"$ref": "#/$defs/AnyOfFoo"}, {"$ref": "#/$defs/AnyOfBar"}]
+        }
+
+    def test_replace_all_of_refs(self, schemas):
+        """Test replacing $ref in allOf schemas."""
+        result = _replace_ref_with_defs(schemas["all_of_type"])
+        assert result == {
+            "allOf": [{"$ref": "#/$defs/AllOfFoo"}, {"$ref": "#/$defs/AllOfBar"}]
+        }
+
+    def test_replace_one_of_refs(self, schemas):
+        """Test replacing $ref in oneOf schemas."""
+        result = _replace_ref_with_defs(schemas["one_of_type"])
+        assert result == {
+            "oneOf": [{"$ref": "#/$defs/OneOfFoo"}, {"$ref": "#/$defs/OneOfBar"}]
+        }
+
+    def test_replace_nested_refs(self, schemas):
+        """Test replacing $ref in deeply nested schema structures."""
+        result = _replace_ref_with_defs(schemas["nested_type"])
+        assert result == {
+            "type": "object",
+            "properties": {
+                "pets": {"oneOf": [{"$ref": "#/$defs/Cat"}, {"$ref": "#/$defs/Dog"}]}
+            },
+        }


### PR DESCRIPTION
openapi's put resuable data structures under `#/components/schemas/`
but json schema put the same structures under `#/$defs/`

when using `FastMCP.from_fastapi(...)`, some nested pydantic model still have "$ref: #/components/schemas/ModelName" in the `inputSchema`, making it unable to resolve.

---

the `def _combine_schemas` function takes care of some scenarios (flat $ref in query params)

this PR makes query params and body support nested models