### PR TITLE
Support flexible @tool decorator call patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("Demo 🚀")
 
-@mcp.tool()
+@mcp.tool
 def add(a: int, b: int) -> int:
     """Add two numbers"""
     return a + b
@@ -144,7 +144,7 @@ Learn more in the [**FastMCP Server Documentation**](https://gofastmcp.com/serve
 Tools allow LLMs to perform actions by executing your Python functions (sync or async). Ideal for computations, API calls, or side effects (like `POST`/`PUT`). FastMCP handles schema generation from type hints and docstrings. Tools can return various types, including text, JSON-serializable objects, and even images using the [`fastmcp.Image`](https://gofastmcp.com/servers/tools#return-values) helper.
 
 ```python
-@mcp.tool()
+@mcp.tool
 def multiply(a: float, b: float) -> float:
     """Multiplies two numbers."""
     return a * b
@@ -201,7 +201,7 @@ from fastmcp import FastMCP, Context
 
 mcp = FastMCP("My MCP Server")
 
-@mcp.tool()
+@mcp.tool
 async def process_data(uri: str, ctx: Context):
     # Log a message to the client
     await ctx.info(f"Processing {uri}...")
@@ -321,7 +321,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("Demo 🚀")
 
-@mcp.tool()
+@mcp.tool
 def hello(name: str) -> str:
     return f"Hello, {name}!"
 

--- a/docs/clients/transports.mdx
+++ b/docs/clients/transports.mdx
@@ -359,7 +359,7 @@ import asyncio
 # 1. Create your FastMCP server instance
 server = FastMCP(name="InMemoryServer")
 
-@server.tool()
+@server.tool
 def ping(): 
     return "pong"
 

--- a/docs/deployment/asgi.mdx
+++ b/docs/deployment/asgi.mdx
@@ -32,7 +32,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("MyServer")
 
-@mcp.tool()
+@mcp.tool
 def hello(name: str) -> str:
     return f"Hello, {name}!"
 

--- a/docs/deployment/running-server.mdx
+++ b/docs/deployment/running-server.mdx
@@ -22,7 +22,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="MyServer")
 
-@mcp.tool()
+@mcp.tool
 def hello(name: str) -> str:
     return f"Hello, {name}!"
 
@@ -244,7 +244,7 @@ import asyncio
 
 mcp = FastMCP(name="MyServer")
 
-@mcp.tool()
+@mcp.tool
 def hello(name: str) -> str:
     return f"Hello, {name}!"
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -32,7 +32,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("My MCP Server")
 
-@mcp.tool()
+@mcp.tool
 def greet(name: str) -> str:
     return f"Hello, {name}!"
 ```
@@ -49,7 +49,7 @@ from fastmcp import FastMCP, Client
 
 mcp = FastMCP("My MCP Server")
 
-@mcp.tool()
+@mcp.tool
 def greet(name: str) -> str:
     return f"Hello, {name}!"
 
@@ -76,7 +76,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("My MCP Server")
 
-@mcp.tool()
+@mcp.tool
 def greet(name: str) -> str:
     return f"Hello, {name}!"
 

--- a/docs/getting-started/welcome.mdx
+++ b/docs/getting-started/welcome.mdx
@@ -14,7 +14,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("Demo 🚀")
 
-@mcp.tool()
+@mcp.tool
 def add(a: int, b: int) -> int:
     """Add two numbers"""
     return a + b

--- a/docs/integrations/anthropic.mdx
+++ b/docs/integrations/anthropic.mdx
@@ -27,7 +27,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="Dice Roller")
 
-@mcp.tool()
+@mcp.tool
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]
@@ -170,7 +170,7 @@ auth = BearerAuthProvider(
 
 mcp = FastMCP(name="Dice Roller", auth=auth)
 
-@mcp.tool()
+@mcp.tool
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]

--- a/docs/integrations/claude-desktop.mdx
+++ b/docs/integrations/claude-desktop.mdx
@@ -31,7 +31,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="Dice Roller")
 
-@mcp.tool()
+@mcp.tool
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]

--- a/docs/integrations/gemini.mdx
+++ b/docs/integrations/gemini.mdx
@@ -31,7 +31,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="Dice Roller")
 
-@mcp.tool()
+@mcp.tool
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]

--- a/docs/integrations/openai.mdx
+++ b/docs/integrations/openai.mdx
@@ -32,7 +32,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="Dice Roller")
 
-@mcp.tool()
+@mcp.tool
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]
@@ -165,7 +165,7 @@ auth = BearerAuthProvider(
 
 mcp = FastMCP(name="Dice Roller", auth=auth)
 
-@mcp.tool()
+@mcp.tool
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]

--- a/docs/patterns/cli.mdx
+++ b/docs/patterns/cli.mdx
@@ -66,7 +66,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("MyServer")
 
-@mcp.tool()
+@mcp.tool
 def hello(name: str) -> str:
     return f"Hello, {name}!"
 

--- a/docs/patterns/decorating-methods.mdx
+++ b/docs/patterns/decorating-methods.mdx
@@ -5,11 +5,11 @@ description: Properly use instance methods, class methods, and static methods wi
 icon: at
 ---
 
-FastMCP's decorator system is designed to work with functions, but you may see unexpected behavior if you try to decorate an instance or class method. This guide explains the correct approach for using methods with all FastMCP decorators (`@tool()`, `@resource()`, and `@prompt()`).
+FastMCP's decorator system is designed to work with functions, but you may see unexpected behavior if you try to decorate an instance or class method. This guide explains the correct approach for using methods with all FastMCP decorators (`@tool`, `@resource()`, and `@prompt()`).
 
 ## Why Are Methods Hard?
 
-When you apply a FastMCP decorator like `@tool()`, `@resource()`, or `@prompt()` to a method, the decorator captures the function at decoration time. For instance methods and class methods, this poses a challenge because:
+When you apply a FastMCP decorator like `@tool`, `@resource()`, or `@prompt()` to a method, the decorator captures the function at decoration time. For instance methods and class methods, this poses a challenge because:
 
 1. For instance methods: The decorator gets the unbound method before any instance exists
 2. For class methods: The decorator gets the function before it's bound to the class
@@ -28,7 +28,7 @@ from fastmcp import FastMCP
 mcp = FastMCP()
 
 class MyClass:
-    @mcp.tool()  # This won't work correctly
+    @mcp.tool  # This won't work correctly
     def add(self, x, y):
         return x + y
     
@@ -83,7 +83,7 @@ mcp = FastMCP()
 
 class MyClass:
     @classmethod
-    @mcp.tool()  # This won't work correctly
+    @mcp.tool  # This won't work correctly
     def from_string(cls, s):
         return cls(s)
 ```
@@ -122,7 +122,7 @@ mcp = FastMCP()
 
 class MyClass:
     @staticmethod
-    @mcp.tool()  # This works!
+    @mcp.tool  # This works!
     def utility(x, y):
         return x + y
     
@@ -194,7 +194,7 @@ The class automatically registers its methods during initialization, ensuring th
 While FastMCP's decorator pattern works seamlessly with regular functions and static methods, for instance methods and class methods, you should add them after creating the instance or class. This ensures that the methods are properly bound before being registered.
 
 These patterns apply to all FastMCP decorators and registration methods:
-- `@tool()` and `add_tool()`
+- `@tool()` and `add_tool`
 - `@resource()` and `add_resource_fn()`
 - `@prompt()` and `add_prompt()`
 

--- a/docs/patterns/http-requests.mdx
+++ b/docs/patterns/http-requests.mdx
@@ -25,7 +25,7 @@ from starlette.requests import Request
 
 mcp = FastMCP(name="HTTP Request Demo")
 
-@mcp.tool()
+@mcp.tool
 async def user_agent_info() -> dict:
     """Return information about the user agent."""
     # Get the HTTP request
@@ -58,7 +58,7 @@ from fastmcp.server.dependencies import get_http_headers
 
 mcp = FastMCP(name="Headers Demo")
 
-@mcp.tool()
+@mcp.tool
 async def safe_header_info() -> dict:
     """Safely get header information without raising errors."""
     # Get headers (returns empty dict if no request context)

--- a/docs/patterns/testing.mdx
+++ b/docs/patterns/testing.mdx
@@ -22,7 +22,7 @@ from fastmcp import FastMCP, Client
 def mcp_server():
     server = FastMCP("TestServer")
     
-    @server.tool()
+    @server.tool
     def greet(name: str) -> str:
         return f"Hello, {name}!"
         

--- a/docs/servers/auth/bearer.mdx
+++ b/docs/servers/auth/bearer.mdx
@@ -159,7 +159,7 @@ Once authenticated, your tools, resources, or prompts can access token informati
 from fastmcp import FastMCP, Context, ToolError
 from fastmcp.server.dependencies import get_access_token, AccessToken
 
-@mcp.tool()
+@mcp.tool
 async def get_my_data(ctx: Context) -> dict:
     access_token: AccessToken = get_access_token()
     

--- a/docs/servers/composition.mdx
+++ b/docs/servers/composition.mdx
@@ -50,7 +50,7 @@ import asyncio
 # Define subservers
 weather_mcp = FastMCP(name="WeatherService")
 
-@weather_mcp.tool()
+@weather_mcp.tool
 def get_forecast(city: str) -> dict:
     """Get weather forecast."""
     return {"city": city, "forecast": "Sunny"}
@@ -102,7 +102,7 @@ from fastmcp import FastMCP, Client
 # Define subserver
 dynamic_mcp = FastMCP(name="DynamicService")
 
-@dynamic_mcp.tool()
+@dynamic_mcp.tool
 def initial_tool():
     """Initial tool demonstration."""
     return "Initial Tool Exists"
@@ -112,7 +112,7 @@ main_mcp = FastMCP(name="MainAppLive")
 main_mcp.mount("dynamic", dynamic_mcp)
 
 # Add a tool AFTER mounting - it will be accessible through main_mcp
-@dynamic_mcp.tool()
+@dynamic_mcp.tool
 def added_later():
     """Tool added after mounting."""
     return "Tool Added Dynamically!"

--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -41,7 +41,7 @@ from fastmcp import FastMCP, Context
 
 mcp = FastMCP(name="ContextDemo")
 
-@mcp.tool()
+@mcp.tool
 async def process_file(file_uri: str, ctx: Context) -> str:
     """Processes a file, using context for logging and resource access."""
     # Context is available as the ctx parameter
@@ -99,7 +99,7 @@ async def process_data(data: list[float]) -> dict:
     ctx = get_context()    
     await ctx.info(f"Processing {len(data)} data points")
     
-@mcp.tool()
+@mcp.tool
 async def analyze_dataset(dataset_name: str) -> dict:
     # Call utility function that uses context internally
     data = load_data(dataset_name)
@@ -118,7 +118,7 @@ async def analyze_dataset(dataset_name: str) -> dict:
 Send log messages back to the MCP client. This is useful for debugging and providing visibility into function execution during a request.
 
 ```python
-@mcp.tool()
+@mcp.tool
 async def analyze_data(data: list[float], ctx: Context) -> dict:
     """Analyze numerical data with logging."""
     await ctx.debug("Starting analysis of numerical data")
@@ -149,7 +149,7 @@ async def analyze_data(data: list[float], ctx: Context) -> dict:
 For long-running operations, notify the client about the progress. This allows clients to display progress indicators and provide a better user experience.
 
 ```python
-@mcp.tool()
+@mcp.tool
 async def process_items(items: list[str], ctx: Context) -> dict:
     """Process a list of items with progress updates."""
     total = len(items)
@@ -182,7 +182,7 @@ Progress reporting requires the client to have sent a `progressToken` in the ini
 Read data from resources registered with your FastMCP server. This allows functions to access files, configuration, or dynamically generated content.
 
 ```python
-@mcp.tool()
+@mcp.tool
 async def summarize_document(document_uri: str, ctx: Context) -> str:
     """Summarize a document by its resource URI."""
     # Read the document content
@@ -222,7 +222,7 @@ The returned content is typically accessed via `content_list[0].content` and can
 Request the client's LLM to generate text based on provided messages. This is useful when your function needs to leverage the LLM's capabilities to process data or generate responses.
 
 ```python
-@mcp.tool()
+@mcp.tool
 async def analyze_sentiment(text: str, ctx: Context) -> dict:
     """Analyze the sentiment of a text using the client's LLM."""
     # Create a sampling prompt asking for sentiment analysis
@@ -258,7 +258,7 @@ async def analyze_sentiment(text: str, ctx: Context) -> dict:
 When providing a simple string, it's treated as a user message. For more complex scenarios, you can provide a list of messages with different roles.
 
 ```python
-@mcp.tool()
+@mcp.tool
 async def generate_example(concept: str, ctx: Context) -> str:
     """Generate a Python code example for a given concept."""
     # Using a system prompt and a user message
@@ -280,7 +280,7 @@ See [Client Sampling](/clients/client#llm-sampling) for more details on how clie
 Access metadata about the current request and client.
 
 ```python
-@mcp.tool()
+@mcp.tool
 async def request_info(ctx: Context) -> dict:
     """Return information about the current request."""
     return {
@@ -300,7 +300,7 @@ async def request_info(ctx: Context) -> dict:
 #### FastMCP Server and Sessions
 
 ```python
-@mcp.tool()
+@mcp.tool
 async def advanced_tool(ctx: Context) -> str:
     """Demonstrate advanced context access."""
     # Access the FastMCP server instance
@@ -326,7 +326,7 @@ See the [HTTP Requests pattern](/patterns/http-requests) for more details.
 For web applications, you can access the underlying HTTP request:
 
 ```python
-@mcp.tool()
+@mcp.tool
 async def handle_web_request(ctx: Context) -> dict:
     """Access HTTP request information from the Starlette request."""
     request = ctx.get_http_request()

--- a/docs/servers/fastmcp.mdx
+++ b/docs/servers/fastmcp.mdx
@@ -145,7 +145,7 @@ import asyncio
 main = FastMCP(name="Main")
 sub = FastMCP(name="Sub")
 
-@sub.tool()
+@sub.tool
 def hello(): 
     return "hi"
 

--- a/docs/servers/fastmcp.mdx
+++ b/docs/servers/fastmcp.mdx
@@ -47,7 +47,7 @@ FastMCP servers expose several types of components to the client:
 Tools are functions that the client can call to perform actions or access external systems.
 
 ```python
-@mcp.tool()
+@mcp.tool
 def multiply(a: float, b: float) -> float:
     """Multiplies two numbers together."""
     return a * b
@@ -106,7 +106,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="MyServer")
 
-@mcp.tool()
+@mcp.tool
 def greet(name: str) -> str:
     """Greet a user by name."""
     return f"Hello, {name}!"
@@ -216,7 +216,7 @@ def yaml_serializer(data):
 # Create a server with the custom serializer
 mcp = FastMCP(name="MyServer", tool_serializer=yaml_serializer)
 
-@mcp.tool()
+@mcp.tool
 def get_config():
     """Returns configuration in YAML format."""
     return {"api_key": "abc123", "debug": True, "rate_limit": 100}

--- a/docs/servers/proxy.mdx
+++ b/docs/servers/proxy.mdx
@@ -90,7 +90,7 @@ from fastmcp import FastMCP
 # Original server
 original_server = FastMCP(name="Original")
 
-@original_server.tool()
+@original_server.tool
 def tool_a() -> str: 
     return "A"
 

--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -24,14 +24,14 @@ This allows LLMs to perform tasks like querying databases, calling APIs, making 
 
 ### The `@tool` Decorator
 
-Creating a tool is as simple as decorating a Python function with `@mcp.tool()`:
+Creating a tool is as simple as decorating a Python function with `@mcp.tool`:
 
 ```python
 from fastmcp import FastMCP
 
 mcp = FastMCP(name="CalculatorServer")
 
-@mcp.tool()
+@mcp.tool
 def add(a: int, b: int) -> int:
     """Adds two integer numbers together."""
     return a + b
@@ -61,7 +61,7 @@ Type annotations for parameters are essential for proper tool functionality. The
 Use standard Python type annotations for parameters:
 
 ```python
-@mcp.tool()
+@mcp.tool
 def analyze_text(
     text: str,
     max_tokens: int = 100,
@@ -79,7 +79,7 @@ You can provide additional metadata about parameters using Pydantic's `Field` cl
 from typing import Annotated
 from pydantic import Field
 
-@mcp.tool()
+@mcp.tool
 def process_image(
     image_url: Annotated[str, Field(description="URL of the image to process")],
     resize: Annotated[bool, Field(description="Whether to resize the image")] = False,
@@ -97,7 +97,7 @@ def process_image(
 You can also use the Field as a default value, though the Annotated approach is preferred:
 
 ```python
-@mcp.tool()
+@mcp.tool
 def search_database(
     query: str = Field(description="Search query string"),
     limit: int = Field(10, description="Maximum number of results", ge=1, le=100)
@@ -137,7 +137,7 @@ For additional type annotations not listed here, see the [Parameter Types](#para
 FastMCP follows Python's standard function parameter conventions. Parameters without default values are required, while those with default values are optional.
 
 ```python
-@mcp.tool()
+@mcp.tool
 def search_products(
     query: str,                   # Required - no default value
     max_results: int = 10,        # Optional - has default value
@@ -197,14 +197,14 @@ FastMCP seamlessly supports both standard (`def`) and asynchronous (`async def`)
 
 ```python
 # Synchronous tool (suitable for CPU-bound or quick tasks)
-@mcp.tool()
+@mcp.tool
 def calculate_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """Calculate the distance between two coordinates."""
     # Implementation...
     return 42.5
 
 # Asynchronous tool (ideal for I/O-bound operations)
-@mcp.tool()
+@mcp.tool
 async def fetch_weather(city: str) -> dict:
     """Retrieve current weather conditions for a city."""
     # Use 'async def' for operations involving network calls, file I/O, etc.
@@ -244,7 +244,7 @@ except ImportError:
 
 mcp = FastMCP("Image Demo")
 
-@mcp.tool()
+@mcp.tool
 def generate_image(width: int, height: int, color: str) -> Image:
     """Generates a solid color image."""
     # Create image using Pillow
@@ -258,7 +258,7 @@ def generate_image(width: int, height: int, color: str) -> Image:
     # Return using FastMCP's Image helper
     return Image(data=img_bytes, format="png")
 
-@mcp.tool()
+@mcp.tool
 def do_nothing() -> None:
     """This tool performs an action but returns no data."""
     print("Performing a side effect...")
@@ -285,7 +285,7 @@ mcp = FastMCP(name="SecureServer", mask_error_details=True)
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 
-@mcp.tool()
+@mcp.tool
 def divide(a: float, b: float) -> float:
     """Divide a by b."""
 
@@ -315,7 +315,7 @@ Annotations serve several purposes in client applications:
 - Describing the safety profile of tools (destructive vs. non-destructive)
 - Signaling if tools interact with external systems
 
-You can add annotations to a tool using the `annotations` parameter in the `@mcp.tool()` decorator:
+You can add annotations to a tool using the `annotations` parameter in the `@mcp.tool` decorator:
 
 ```python
 @mcp.tool(
@@ -351,7 +351,7 @@ from fastmcp import FastMCP, Context
 
 mcp = FastMCP(name="ContextDemo")
 
-@mcp.tool()
+@mcp.tool
 async def process_data(data_uri: str, ctx: Context) -> dict:
     """Process data from a resource with progress reporting."""
     await ctx.info(f"Processing data from {data_uri}")
@@ -396,7 +396,7 @@ FastMCP supports **type coercion** when possible. This means that if a client se
 The most common parameter types are Python's built-in scalar types:
 
 ```python
-@mcp.tool()
+@mcp.tool
 def process_values(
     name: str,             # Text data
     count: int,            # Integer numbers
@@ -416,7 +416,7 @@ FastMCP supports various date and time types from the `datetime` module:
 ```python
 from datetime import datetime, date, timedelta
 
-@mcp.tool()
+@mcp.tool
 def process_date_time(
     event_date: date,             # ISO format date string or date object
     event_time: datetime,         # ISO format datetime string or datetime object
@@ -440,7 +440,7 @@ def process_date_time(
 FastMCP supports all standard Python collection types:
 
 ```python
-@mcp.tool()
+@mcp.tool
 def analyze_data(
     values: list[float],           # List of numbers
     properties: dict[str, str],    # Dictionary with string keys and values
@@ -465,7 +465,7 @@ Collection types can be nested and combined to represent complex data structures
 For parameters that can accept multiple types or may be omitted:
 
 ```python
-@mcp.tool()
+@mcp.tool
 def flexible_search(
     query: str | int,              # Can be either string or integer
     filters: dict[str, str] | None = None,  # Optional dictionary
@@ -488,7 +488,7 @@ Literals constrain parameters to a specific set of values:
 ```python
 from typing import Literal
 
-@mcp.tool()
+@mcp.tool
 def sort_data(
     data: list[float],
     order: Literal["ascending", "descending"] = "ascending",
@@ -516,7 +516,7 @@ class Color(Enum):
     GREEN = "green"
     BLUE = "blue"
 
-@mcp.tool()
+@mcp.tool
 def process_image(
     image_path: str, 
     color_filter: Color = Color.RED
@@ -539,7 +539,7 @@ There are two approaches to handling binary data in tool parameters:
 #### Bytes
 
 ```python
-@mcp.tool()
+@mcp.tool
 def process_binary(data: bytes):
     """Process binary data directly.
     
@@ -563,7 +563,7 @@ FastMCP does not automatically decode base64-encoded strings for bytes parameter
 from typing import Annotated
 from pydantic import Field
 
-@mcp.tool()
+@mcp.tool
 def process_image_data(
     image_data: Annotated[str, Field(description="Base64-encoded image data")]
 ):
@@ -587,7 +587,7 @@ The `Path` type from the `pathlib` module can be used for file system paths:
 ```python
 from pathlib import Path
 
-@mcp.tool()
+@mcp.tool
 def process_file(path: Path) -> str:
     """Process a file at the given path."""
     assert isinstance(path, Path)  # Path is properly converted
@@ -603,7 +603,7 @@ The `UUID` type from the `uuid` module can be used for unique identifiers:
 ```python
 import uuid
 
-@mcp.tool()
+@mcp.tool
 def process_item(
     item_id: uuid.UUID  # String UUID or UUID object
 ) -> str:
@@ -628,7 +628,7 @@ class User(BaseModel):
     age: int | None = None
     is_active: bool = True
 
-@mcp.tool()
+@mcp.tool
 def create_user(user: User):
     """Create a new user in the system."""
     # The input is automatically validated against the User model
@@ -657,7 +657,7 @@ Note that fields can be used *outside* Pydantic models to provide metadata and v
 from typing import Annotated
 from pydantic import Field
 
-@mcp.tool()
+@mcp.tool
 def analyze_metrics(
     # Numbers with range constraints
     count: Annotated[int, Field(ge=0, le=100)],         # 0 <= count <= 100
@@ -682,7 +682,7 @@ def analyze_metrics(
 You can also use `Field` as a default value, though the `Annotated` approach is preferred:
 
 ```python
-@mcp.tool()
+@mcp.tool
 def validate_data(
     # Value constraints
     age: int = Field(ge=0, lt=120),                     # 0 <= age < 120
@@ -727,12 +727,12 @@ mcp = FastMCP(
     on_duplicate_tools="error"
 )
 
-@mcp.tool()
+@mcp.tool
 def my_tool(): return "Version 1"
 
 # This will now raise a ValueError because 'my_tool' already exists
 # and on_duplicate_tools is set to "error".
-# @mcp.tool()
+# @mcp.tool
 # def my_tool(): return "Version 2"
 ```
 
@@ -754,7 +754,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="DynamicToolServer")
 
-@mcp.tool()
+@mcp.tool
 def calculate_sum(a: int, b: int) -> int:
     """Add two numbers together."""
     return a + b

--- a/examples/complex_inputs.py
+++ b/examples/complex_inputs.py
@@ -20,7 +20,7 @@ class ShrimpTank(BaseModel):
     shrimp: list[Shrimp]
 
 
-@mcp.tool()
+@mcp.tool
 def name_shrimp(
     tank: ShrimpTank,
     # You can use pydantic Field in function signatures for validation.

--- a/examples/config_server.py
+++ b/examples/config_server.py
@@ -24,7 +24,7 @@ if args.debug:
 mcp = FastMCP(server_name)
 
 
-@mcp.tool()
+@mcp.tool
 def get_status() -> dict[str, str | bool]:
     """Get the current server configuration and status."""
     return {
@@ -34,7 +34,7 @@ def get_status() -> dict[str, str | bool]:
     }
 
 
-@mcp.tool()
+@mcp.tool
 def echo_message(message: str) -> str:
     """Echo a message, with debug info if debug mode is enabled."""
     if args.debug:

--- a/examples/desktop.py
+++ b/examples/desktop.py
@@ -26,7 +26,7 @@ def get_greeting(name: str) -> str:
     return f"Hello, {name}!"
 
 
-@mcp.tool()
+@mcp.tool
 def add(a: int, b: int) -> int:
     """Add two numbers"""
     return a + b

--- a/examples/echo.py
+++ b/examples/echo.py
@@ -8,7 +8,7 @@ from fastmcp import FastMCP
 mcp = FastMCP("Echo Server")
 
 
-@mcp.tool()
+@mcp.tool
 def echo_tool(text: str) -> str:
     """Echo the input text"""
     return text

--- a/examples/memory.py
+++ b/examples/memory.py
@@ -279,7 +279,7 @@ async def display_memory_tree(deps: Deps) -> str:
     return result
 
 
-@mcp.tool()
+@mcp.tool
 async def remember(
     contents: list[str] = Field(
         description="List of observations or memories to store"
@@ -294,7 +294,7 @@ async def remember(
         await deps.pool.close()
 
 
-@mcp.tool()
+@mcp.tool
 async def read_profile() -> str:
     deps = Deps(openai=AsyncOpenAI(), pool=await get_db_pool())
     profile = await display_memory_tree(deps)

--- a/examples/mount_example.py
+++ b/examples/mount_example.py
@@ -16,7 +16,7 @@ from fastmcp import FastMCP
 weather_app = FastMCP("Weather App")
 
 
-@weather_app.tool()
+@weather_app.tool
 def get_weather_forecast(location: str) -> str:
     """Get the weather forecast for a location."""
     return f"Sunny skies for {location} today!"
@@ -32,7 +32,7 @@ async def weather_data():
 news_app = FastMCP("News App")
 
 
-@news_app.tool()
+@news_app.tool
 def get_news_headlines() -> list[str]:
     """Get the latest news headlines."""
     return [
@@ -58,7 +58,7 @@ app = FastMCP(
 )
 
 
-@app.tool()
+@app.tool
 def check_app_status() -> dict[str, str]:
     """Check the status of the main application."""
     return {"status": "running", "version": "1.0.0", "uptime": "3h 24m"}

--- a/examples/sampling.py
+++ b/examples/sampling.py
@@ -15,7 +15,7 @@ from fastmcp.client.sampling import RequestContext, SamplingMessage, SamplingPar
 mcp = FastMCP("Sampling Example")
 
 
-@mcp.tool()
+@mcp.tool
 async def example_tool(prompt: str, context: Context) -> str:
     """Sample a completion from the LLM."""
     response = await context.sample(

--- a/examples/screenshot.py
+++ b/examples/screenshot.py
@@ -12,7 +12,7 @@ from fastmcp import FastMCP, Image
 mcp = FastMCP("Screenshot Demo", dependencies=["pyautogui", "Pillow"])
 
 
-@mcp.tool()
+@mcp.tool
 def take_screenshot() -> Image:
     """
     Take a screenshot of the user's screen and return it as an image. Use

--- a/examples/serializer.py
+++ b/examples/serializer.py
@@ -14,7 +14,7 @@ def custom_dict_serializer(data: Any) -> str:
 server = FastMCP(name="CustomSerializerExample", tool_serializer=custom_dict_serializer)
 
 
-@server.tool()
+@server.tool
 def get_example_data() -> dict:
     """Returns some example data."""
     return {"name": "Test", "value": 123, "status": True}

--- a/examples/simple_echo.py
+++ b/examples/simple_echo.py
@@ -8,7 +8,7 @@ from fastmcp import FastMCP
 mcp = FastMCP("Echo Server")
 
 
-@mcp.tool()
+@mcp.tool
 def echo(text: str) -> str:
     """Echo the input text"""
     return text

--- a/examples/smart_home/src/smart_home/hub.py
+++ b/examples/smart_home/src/smart_home/hub.py
@@ -16,7 +16,7 @@ hub_mcp.mount("hue", lights_mcp)
 
 
 # Add a status check for the hub
-@hub_mcp.tool()
+@hub_mcp.tool
 def hub_status() -> str:
     """Checks the status of the main hub and connections."""
     try:

--- a/examples/smart_home/src/smart_home/lights/server.py
+++ b/examples/smart_home/src/smart_home/lights/server.py
@@ -43,7 +43,7 @@ lights_mcp = FastMCP(
 )
 
 
-@lights_mcp.tool()
+@lights_mcp.tool
 def read_all_lights() -> list[str]:
     """Lists the names of all available Hue lights using phue2."""
     if not (bridge := _get_bridge()):
@@ -59,7 +59,7 @@ def read_all_lights() -> list[str]:
 # --- Tools ---
 
 
-@lights_mcp.tool()
+@lights_mcp.tool
 def toggle_light(light_name: str, state: bool) -> dict[str, Any]:
     """Turns a specific light on (true) or off (false) using phue2."""
     if not (bridge := _get_bridge()):
@@ -76,7 +76,7 @@ def toggle_light(light_name: str, state: bool) -> dict[str, Any]:
         return handle_phue_error(light_name, "toggle_light", e)
 
 
-@lights_mcp.tool()
+@lights_mcp.tool
 def set_brightness(light_name: str, brightness: int) -> dict[str, Any]:
     """Sets the brightness of a specific light (0-254) using phue2."""
     if not (bridge := _get_bridge()):
@@ -100,7 +100,7 @@ def set_brightness(light_name: str, brightness: int) -> dict[str, Any]:
         return handle_phue_error(light_name, "set_brightness", e)
 
 
-@lights_mcp.tool()
+@lights_mcp.tool
 def list_groups() -> list[str]:
     """Lists the names of all available Hue light groups."""
     if not (bridge := _get_bridge()):
@@ -113,7 +113,7 @@ def list_groups() -> list[str]:
         return [f"Error listing groups: {e}"]
 
 
-@lights_mcp.tool()
+@lights_mcp.tool
 def list_scenes() -> dict[str, list[str]] | list[str]:
     """Lists Hue scenes, grouped by the light group they belong to.
 
@@ -154,7 +154,7 @@ def list_scenes() -> dict[str, list[str]] | list[str]:
         return [f"Error listing scenes by group: {e}"]
 
 
-@lights_mcp.tool()
+@lights_mcp.tool
 def activate_scene(group_name: str, scene_name: str) -> dict[str, Any]:
     """Activates a specific scene within a specified light group, verifying the scene belongs to the group."""
     if not (bridge := _get_bridge()):
@@ -215,7 +215,7 @@ def activate_scene(group_name: str, scene_name: str) -> dict[str, Any]:
         return handle_phue_error(f"{group_name}/{scene_name}", "activate_scene", e)
 
 
-@lights_mcp.tool()
+@lights_mcp.tool
 def set_light_attributes(light_name: str, attributes: HueAttributes) -> dict[str, Any]:
     """Sets multiple attributes (e.g., hue, sat, bri, ct, xy, transitiontime) for a specific light."""
     if not (bridge := _get_bridge()):
@@ -242,7 +242,7 @@ def set_light_attributes(light_name: str, attributes: HueAttributes) -> dict[str
         return handle_phue_error(light_name, "set_light_attributes", e)
 
 
-@lights_mcp.tool()
+@lights_mcp.tool
 def set_group_attributes(group_name: str, attributes: HueAttributes) -> dict[str, Any]:
     """Sets multiple attributes for all lights within a specific group."""
     if not (bridge := _get_bridge()):
@@ -267,7 +267,7 @@ def set_group_attributes(group_name: str, attributes: HueAttributes) -> dict[str
         return handle_phue_error(group_name, "set_group_attributes", e)
 
 
-@lights_mcp.tool()
+@lights_mcp.tool
 def list_lights_by_group() -> dict[str, list[str]] | list[str]:
     """Lists Hue lights, grouped by the room/group they belong to.
 

--- a/src/fastmcp/contrib/bulk_tool_caller/example.py
+++ b/src/fastmcp/contrib/bulk_tool_caller/example.py
@@ -6,7 +6,7 @@ from fastmcp.contrib.bulk_tool_caller import BulkToolCaller
 mcp = FastMCP()
 
 
-@mcp.tool()
+@mcp.tool
 def echo_tool(text: str) -> str:
     """Echo the input text"""
     return text

--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -49,7 +49,7 @@ class Context:
     To use context in a tool function, add a parameter with the Context type annotation:
 
     ```python
-    @server.tool()
+    @server.tool
     def my_tool(x: int, ctx: Context) -> str:
         # Log messages to the client
         ctx.info(f"Processing {x}")

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -529,7 +529,7 @@ class FastMCP(Generic[LifespanResultT]):
 
         This decorator supports multiple calling patterns:
         - @server.tool (without parentheses)
-        - @server.tool() (with empty parentheses)
+        - @server.tool (with empty parentheses)
         - @server.tool("custom_name") (with name as first argument)
         - @server.tool(name="custom_name") (with name as keyword argument)
         - server.tool(function, name="custom_name") (direct function call)
@@ -547,7 +547,7 @@ class FastMCP(Generic[LifespanResultT]):
             def my_tool(x: int) -> str:
                 return str(x)
 
-            @server.tool()
+            @server.tool
             def my_tool(x: int) -> str:
                 return str(x)
 
@@ -594,7 +594,7 @@ class FastMCP(Generic[LifespanResultT]):
                 )
             tool_name = name_or_fn
         elif name_or_fn is None:
-            # Case 4: @tool() or @tool(name="something") - use keyword name
+            # Case 4: @tool or @tool(name="something") - use keyword name
             tool_name = name
         else:
             raise TypeError(

--- a/tests/auth/providers/test_bearer.py
+++ b/tests/auth/providers/test_bearer.py
@@ -53,7 +53,7 @@ def run_mcp_server(
         )
     )
 
-    @mcp.tool()
+    @mcp.tool
     def add(a: int, b: int) -> int:
         return a + b
 

--- a/tests/auth/test_oauth_client.py
+++ b/tests/auth/test_oauth_client.py
@@ -24,7 +24,7 @@ def fastmcp_server(issuer_url: str):
         ),
     )
 
-    @server.tool()
+    @server.tool
     def add(a: int, b: int) -> int:
         """Add two numbers together."""
         return a + b

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -25,18 +25,18 @@ def fastmcp_server():
     server = FastMCP("TestServer")
 
     # Add a tool
-    @server.tool()
+    @server.tool
     def greet(name: str) -> str:
         """Greet someone by name."""
         return f"Hello, {name}!"
 
     # Add a second tool
-    @server.tool()
+    @server.tool
     def add(a: int, b: int) -> int:
         """Add two numbers together."""
         return a + b
 
-    @server.tool()
+    @server.tool
     async def sleep(seconds: float) -> str:
         """Sleep for a given number of seconds."""
         await asyncio.sleep(seconds)
@@ -347,7 +347,7 @@ async def test_concurrent_client_context_managers():
     # Create a simple server
     server = FastMCP("Test Server")
 
-    @server.tool()
+    @server.tool
     def echo(text: str) -> str:
         """Echo tool"""
         return text

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -510,7 +510,7 @@ class TestErrorHandling:
     async def test_general_tool_exceptions_are_not_masked_by_default(self):
         mcp = FastMCP("TestServer")
 
-        @mcp.tool()
+        @mcp.tool
         def error_tool():
             raise ValueError("This is a test error (abc)")
 
@@ -525,7 +525,7 @@ class TestErrorHandling:
     async def test_general_tool_exceptions_are_masked_when_enabled(self):
         mcp = FastMCP("TestServer", mask_error_details=True)
 
-        @mcp.tool()
+        @mcp.tool
         def error_tool():
             raise ValueError("This is a test error (abc)")
 
@@ -540,7 +540,7 @@ class TestErrorHandling:
     async def test_specific_tool_errors_are_sent_to_client(self):
         mcp = FastMCP("TestServer")
 
-        @mcp.tool()
+        @mcp.tool
         def custom_error_tool():
             raise ToolError("This is a test error (abc)")
 

--- a/tests/client/test_logs.py
+++ b/tests/client/test_logs.py
@@ -17,11 +17,11 @@ class LogHandler:
 def fastmcp_server():
     mcp = FastMCP()
 
-    @mcp.tool()
+    @mcp.tool
     async def log(context: Context) -> None:
         await context.info(message="hello?")
 
-    @mcp.tool()
+    @mcp.tool
     async def echo_log(
         message: str,
         context: Context,

--- a/tests/client/test_progress.py
+++ b/tests/client/test_progress.py
@@ -16,7 +16,7 @@ def clear_progress_messages():
 def fastmcp_server():
     mcp = FastMCP()
 
-    @mcp.tool()
+    @mcp.tool
     async def progress_tool(context: Context) -> int:
         for i in range(3):
             await context.report_progress(

--- a/tests/client/test_roots.py
+++ b/tests/client/test_roots.py
@@ -9,7 +9,7 @@ from fastmcp import Client, Context, FastMCP
 def fastmcp_server():
     mcp = FastMCP()
 
-    @mcp.tool()
+    @mcp.tool
     async def list_roots(context: Context) -> list[str]:
         roots = await context.list_roots()
         return [str(r.uri) for r in roots]

--- a/tests/client/test_sampling.py
+++ b/tests/client/test_sampling.py
@@ -11,17 +11,17 @@ from fastmcp.client.sampling import RequestContext, SamplingMessage, SamplingPar
 def fastmcp_server():
     mcp = FastMCP()
 
-    @mcp.tool()
+    @mcp.tool
     async def simple_sample(message: str, context: Context) -> str:
         result = await context.sample("Hello, world!")
         return cast(TextContent, result).text
 
-    @mcp.tool()
+    @mcp.tool
     async def sample_with_system_prompt(message: str, context: Context) -> str:
         result = await context.sample("Hello, world!", system_prompt="You love FastMCP")
         return cast(TextContent, result).text
 
-    @mcp.tool()
+    @mcp.tool
     async def sample_with_messages(message: str, context: Context) -> str:
         result = await context.sample(
             [

--- a/tests/client/test_sse.py
+++ b/tests/client/test_sse.py
@@ -21,18 +21,18 @@ def fastmcp_server():
     server = FastMCP("TestServer")
 
     # Add a tool
-    @server.tool()
+    @server.tool
     def greet(name: str) -> str:
         """Greet someone by name."""
         return f"Hello, {name}!"
 
     # Add a second tool
-    @server.tool()
+    @server.tool
     def add(a: int, b: int) -> int:
         """Add two numbers together."""
         return a + b
 
-    @server.tool()
+    @server.tool
     async def sleep(seconds: float) -> str:
         """Sleep for a given number of seconds."""
         await asyncio.sleep(seconds)

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -17,7 +17,7 @@ class TestKeepAlive:
 
             mcp = FastMCP()
 
-            @mcp.tool()
+            @mcp.tool
             def pid() -> int:
                 """Gets PID of server"""
                 return os.getpid()

--- a/tests/client/test_streamable_http.py
+++ b/tests/client/test_streamable_http.py
@@ -21,18 +21,18 @@ def fastmcp_server():
     server = FastMCP("TestServer")
 
     # Add a tool
-    @server.tool()
+    @server.tool
     def greet(name: str) -> str:
         """Greet someone by name."""
         return f"Hello, {name}!"
 
     # Add a second tool
-    @server.tool()
+    @server.tool
     def add(a: int, b: int) -> int:
         """Add two numbers together."""
         return a + b
 
-    @server.tool()
+    @server.tool
     async def sleep(seconds: float) -> str:
         """Sleep for a given number of seconds."""
         await asyncio.sleep(seconds)

--- a/tests/deprecated/test_deprecated.py
+++ b/tests/deprecated/test_deprecated.py
@@ -100,7 +100,7 @@ def test_mount_tool_separator_deprecation_warning():
         main_app.mount("sub", sub_app, tool_separator="-")
 
     # Verify the separator is ignored and the default is used
-    @sub_app.tool()
+    @sub_app.tool
     def test_tool():
         return "test"
 

--- a/tests/deprecated/test_mount_separators.py
+++ b/tests/deprecated/test_mount_separators.py
@@ -20,7 +20,7 @@ def test_mount_tool_separator_deprecation_warning():
         main_app.mount("sub", sub_app, tool_separator="-")
 
     # Verify the separator is ignored and the default is used
-    @sub_app.tool()
+    @sub_app.tool
     def test_tool():
         return "test"
 

--- a/tests/server/http/test_http_dependencies.py
+++ b/tests/server/http/test_http_dependencies.py
@@ -14,7 +14,7 @@ def fastmcp_server():
     server = FastMCP()
 
     # Add a tool
-    @server.tool()
+    @server.tool
     def get_headers_tool() -> dict[str, str]:
         """Get the HTTP headers from the request."""
         request = get_http_request()

--- a/tests/server/test_file_server.py
+++ b/tests/server/test_file_server.py
@@ -62,7 +62,7 @@ def resources(mcp: FastMCP, test_dir: Path) -> FastMCP:
 
 @pytest.fixture(autouse=True)
 def tools(mcp: FastMCP, test_dir: Path) -> FastMCP:
-    @mcp.tool()
+    @mcp.tool
     def delete_file(path: str) -> bool:
         # ensure path is in test_dir
         if Path(path).resolve().parent != test_dir:

--- a/tests/server/test_import_server.py
+++ b/tests/server/test_import_server.py
@@ -13,7 +13,7 @@ async def test_import_basic_functionality():
     sub_app = FastMCP("SubApp")
 
     # Add a tool to the sub-app
-    @sub_app.tool()
+    @sub_app.tool
     def sub_tool() -> str:
         return "This is from the sub app"
 
@@ -40,11 +40,11 @@ async def test_import_multiple_apps():
     news_app = FastMCP("NewsApp")
 
     # Add tools to each sub-app
-    @weather_app.tool()
+    @weather_app.tool
     def get_forecast() -> str:
         return "Weather forecast"
 
-    @news_app.tool()
+    @news_app.tool
     def get_headlines() -> str:
         return "News headlines"
 
@@ -65,11 +65,11 @@ async def test_import_combines_tools():
     second_app = FastMCP("SecondApp")
 
     # Add tools to each sub-app
-    @first_app.tool()
+    @first_app.tool
     def first_tool() -> str:
         return "First app tool"
 
-    @second_app.tool()
+    @second_app.tool
     def second_tool() -> str:
         return "Second app tool"
 
@@ -294,7 +294,7 @@ async def test_import_with_proxy_tools():
     main_app = FastMCP("MainApp")
     api_app = FastMCP("APIApp")
 
-    @api_app.tool()
+    @api_app.tool
     def get_data(query: str) -> str:
         return f"Data for query: {query}"
 

--- a/tests/server/test_mount.py
+++ b/tests/server/test_mount.py
@@ -21,7 +21,7 @@ class TestBasicMount:
         sub_app = FastMCP("SubApp")
 
         # Add a tool to the sub-app
-        @sub_app.tool()
+        @sub_app.tool
         def sub_tool() -> str:
             return "This is from the sub app"
 
@@ -41,7 +41,7 @@ class TestBasicMount:
         main_app = FastMCP("MainApp")
         sub_app = FastMCP("SubApp")
 
-        @sub_app.tool()
+        @sub_app.tool
         def greet(name: str) -> str:
             return f"Hello, {name}!"
 
@@ -77,7 +77,7 @@ class TestBasicMount:
         main_app = FastMCP("MainApp")
         sub_app = FastMCP("SubApp")
 
-        @sub_app.tool()
+        @sub_app.tool
         def sub_tool() -> str:
             return "This is from the sub app"
 
@@ -103,7 +103,7 @@ class TestBasicMount:
         main_app = FastMCP("MainApp")
         sub_app = FastMCP("SubApp")
 
-        @sub_app.tool()
+        @sub_app.tool
         def sub_tool() -> str:
             return "This is from the sub app"
 
@@ -124,11 +124,11 @@ class TestMultipleServerMount:
         weather_app = FastMCP("WeatherApp")
         news_app = FastMCP("NewsApp")
 
-        @weather_app.tool()
+        @weather_app.tool
         def get_forecast() -> str:
             return "Weather forecast"
 
-        @news_app.tool()
+        @news_app.tool
         def get_headlines() -> str:
             return "News headlines"
 
@@ -154,11 +154,11 @@ class TestMultipleServerMount:
         first_app = FastMCP("FirstApp")
         second_app = FastMCP("SecondApp")
 
-        @first_app.tool()
+        @first_app.tool
         def first_tool() -> str:
             return "First app tool"
 
-        @second_app.tool()
+        @second_app.tool
         def second_tool() -> str:
             return "Second app tool"
 
@@ -186,7 +186,7 @@ class TestMultipleServerMount:
         main_app = FastMCP("MainApp")
         working_app = FastMCP("WorkingApp")
 
-        @working_app.tool()
+        @working_app.tool
         def working_tool() -> str:
             return "Working tool"
 
@@ -267,7 +267,7 @@ class TestDynamicChanges:
         assert not any(key.startswith("sub_") for key in tools)
 
         # Add a tool to the sub-app after mounting
-        @sub_app.tool()
+        @sub_app.tool
         def dynamic_tool() -> str:
             return "Added after mounting"
 
@@ -284,7 +284,7 @@ class TestDynamicChanges:
         main_app = FastMCP("MainApp")
         sub_app = FastMCP("SubApp")
 
-        @sub_app.tool()
+        @sub_app.tool
         def temp_tool() -> str:
             return "Temporary tool"
 
@@ -431,7 +431,7 @@ class TestProxyServer:
         # Create original server
         original_server = FastMCP("OriginalServer")
 
-        @original_server.tool()
+        @original_server.tool
         def get_data(query: str) -> str:
             return f"Data for {query}"
 
@@ -467,7 +467,7 @@ class TestProxyServer:
         main_app.mount("proxy", proxy_server)
 
         # Add a tool to the original server
-        @original_server.tool()
+        @original_server.tool
         def dynamic_data() -> str:
             return "Dynamic data"
 
@@ -602,7 +602,7 @@ class TestAsProxyKwarg:
 
         assert len(await mcp.get_tools()) == 0
 
-        @sub.tool()
+        @sub.tool
         def hello():
             return "hi"
 
@@ -619,7 +619,7 @@ class TestAsProxyKwarg:
         mcp = FastMCP("Main")
         sub = FastMCP("Sub", lifespan=lifespan)
 
-        @sub.tool()
+        @sub.tool
         def hello():
             return "hi"
 

--- a/tests/server/test_proxy.py
+++ b/tests/server/test_proxy.py
@@ -26,21 +26,21 @@ def fastmcp_server():
 
     # --- Tools ---
 
-    @server.tool()
+    @server.tool
     def greet(name: str) -> str:
         """Greet someone by name."""
         return f"Hello, {name}!"
 
-    @server.tool()
+    @server.tool
     def tool_without_description() -> str:
         return "Hello?"
 
-    @server.tool()
+    @server.tool
     def add(a: int, b: int) -> int:
         """Add two numbers together."""
         return a + b
 
-    @server.tool()
+    @server.tool
     def error_tool():
         """This tool always raises an error."""
         raise ValueError("This is a test error")

--- a/tests/server/test_run_server.py
+++ b/tests/server/test_run_server.py
@@ -22,17 +22,17 @@
 
 #     # --- Tools ---
 
-#     @server.tool()
+#     @server.tool
 #     def greet(name: str) -> str:
 #         """Greet someone by name."""
 #         return f"Hello, {name}!"
 
-#     @server.tool()
+#     @server.tool
 #     def add(a: int, b: int) -> int:
 #         """Add two numbers together."""
 #         return a + b
 
-#     @server.tool()
+#     @server.tool
 #     def error_tool():
 #         """This tool always raises an error."""
 #         raise ValueError("This is a test error")

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -57,7 +57,7 @@ class TestTools:
 
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def fn(x: int) -> int:
             return x + 1
 
@@ -126,7 +126,7 @@ class TestToolDecorator:
     async def test_tool_decorator(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def add(x: int, y: int) -> int:
             return x + y
 
@@ -179,7 +179,7 @@ class TestToolDecorator:
             def __init__(self, x: int):
                 self.x = x
 
-            @mcp.tool()
+            @mcp.tool
             def add(self, y: int) -> int:
                 return self.x + y
 
@@ -207,7 +207,7 @@ class TestToolDecorator:
 
         class MyClass:
             @staticmethod
-            @mcp.tool()
+            @mcp.tool
             def add(x: int, y: int) -> int:
                 return x + y
 
@@ -217,7 +217,7 @@ class TestToolDecorator:
     async def test_tool_decorator_async_function(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         async def add(x: int, y: int) -> int:
             return x + y
 
@@ -288,7 +288,7 @@ class TestToolDecorator:
         """Test that tools with annotated arguments work correctly."""
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def add(
             x: Annotated[int, Field(description="x is an int")],
             y: Annotated[str, Field(description="y is not an int")],
@@ -303,7 +303,7 @@ class TestToolDecorator:
         """Test that tools with annotated arguments work correctly."""
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def add(
             x: int = Field(description="x is an int"),
             y: str = Field(description="y is not an int"),

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -133,14 +133,22 @@ class TestToolDecorator:
         result = await mcp._mcp_call_tool("add", {"x": 1, "y": 2})
         assert result[0].text == "3"  # type: ignore[attr-defined]
 
-    async def test_tool_decorator_incorrect_usage(self):
+    async def test_tool_decorator_without_parentheses(self):
+        """Test that @tool decorator works without parentheses."""
         mcp = FastMCP()
 
-        with pytest.raises(TypeError, match="The @tool decorator was used incorrectly"):
+        # Test the @tool syntax without parentheses
+        @mcp.tool
+        def add(x: int, y: int) -> int:
+            return x + y
 
-            @mcp.tool  # Missing parentheses #type: ignore
-            def add(x: int, y: int) -> int:
-                return x + y
+        # Verify the tool was registered correctly
+        tools = await mcp.get_tools()
+        assert "add" in tools
+
+        # Verify it can be called
+        result = await mcp._mcp_call_tool("add", {"x": 1, "y": 2})
+        assert result[0].text == "3"  # type: ignore[attr-defined]
 
     async def test_tool_decorator_with_name(self):
         mcp = FastMCP()
@@ -305,6 +313,59 @@ class TestToolDecorator:
         tool = (await mcp.get_tools())["add"]
         assert tool.parameters["properties"]["x"]["description"] == "x is an int"
         assert tool.parameters["properties"]["y"]["description"] == "y is not an int"
+
+    async def test_tool_direct_function_call(self):
+        """Test that tools can be registered via direct function call."""
+        mcp = FastMCP()
+
+        def standalone_function(x: int, y: int) -> int:
+            """A standalone function to be registered."""
+            return x + y
+
+        # Register it directly using the new syntax
+        result_fn = mcp.tool(standalone_function, name="direct_call_tool")
+
+        # The function should be returned unchanged
+        assert result_fn is standalone_function
+
+        # Verify the tool was registered correctly
+        tools = await mcp.get_tools()
+        assert "direct_call_tool" in tools
+
+        # Verify it can be called
+        result = await mcp._mcp_call_tool("direct_call_tool", {"x": 5, "y": 3})
+        assert result[0].text == "8"  # type: ignore[attr-defined]
+
+    async def test_tool_decorator_with_string_name(self):
+        """Test that @tool("custom_name") syntax works correctly."""
+        mcp = FastMCP()
+
+        @mcp.tool("string_named_tool")
+        def my_function(x: int) -> str:
+            """A function with a string name."""
+            return f"Result: {x}"
+
+        # Verify the tool was registered with the custom name
+        tools = await mcp.get_tools()
+        assert "string_named_tool" in tools
+        assert "my_function" not in tools  # Original name should not be registered
+
+        # Verify it can be called
+        result = await mcp._mcp_call_tool("string_named_tool", {"x": 42})
+        assert result[0].text == "Result: 42"  # type: ignore[attr-defined]
+
+    async def test_tool_decorator_conflicting_names_error(self):
+        """Test that providing both positional and keyword name raises an error."""
+        mcp = FastMCP()
+
+        with pytest.raises(
+            TypeError,
+            match="Cannot specify both a name as first argument and as keyword argument",
+        ):
+
+            @mcp.tool("positional_name", name="keyword_name")
+            def my_function(x: int) -> str:
+                return f"Result: {x}"
 
 
 class TestResourceDecorator:

--- a/tests/server/test_server_interactions.py
+++ b/tests/server/test_server_interactions.py
@@ -30,30 +30,30 @@ from fastmcp.utilities.types import Image
 def tool_server():
     mcp = FastMCP()
 
-    @mcp.tool()
+    @mcp.tool
     def add(x: int, y: int) -> int:
         return x + y
 
-    @mcp.tool()
+    @mcp.tool
     def list_tool() -> list[str | int]:
         return ["x", 2]
 
-    @mcp.tool()
+    @mcp.tool
     def error_tool() -> None:
         raise ValueError("Test error")
 
-    @mcp.tool()
+    @mcp.tool
     def image_tool(path: str) -> Image:
         return Image(path)
 
-    @mcp.tool()
+    @mcp.tool
     def mixed_content_tool() -> list[TextContent | ImageContent]:
         return [
             TextContent(type="text", text="Hello"),
             ImageContent(type="image", data="abc", mimeType="image/png"),
         ]
 
-    @mcp.tool()
+    @mcp.tool
     def mixed_list_fn(image_path: str) -> list:
         return [
             "text message",
@@ -100,7 +100,7 @@ class TestTools:
         mcp = FastMCP()
         client = Client(transport=FastMCPTransport(mcp))
 
-        @mcp.tool()
+        @mcp.tool
         def error_tool():
             raise ValueError("Test error")
 
@@ -119,7 +119,7 @@ class TestToolReturnTypes:
     async def test_string(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def string_tool() -> str:
             return "Hello, world!"
 
@@ -130,7 +130,7 @@ class TestToolReturnTypes:
     async def test_bytes(self, tmp_path: Path):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def bytes_tool() -> bytes:
             return b"Hello, world!"
 
@@ -143,7 +143,7 @@ class TestToolReturnTypes:
 
         test_uuid = uuid.uuid4()
 
-        @mcp.tool()
+        @mcp.tool
         def uuid_tool() -> uuid.UUID:
             return test_uuid
 
@@ -156,7 +156,7 @@ class TestToolReturnTypes:
 
         test_path = Path("/tmp/test.txt")
 
-        @mcp.tool()
+        @mcp.tool
         def path_tool() -> Path:
             return test_path
 
@@ -169,7 +169,7 @@ class TestToolReturnTypes:
 
         dt = datetime.datetime(2025, 4, 25, 1, 2, 3)
 
-        @mcp.tool()
+        @mcp.tool
         def datetime_tool() -> datetime.datetime:
             return dt
 
@@ -180,7 +180,7 @@ class TestToolReturnTypes:
     async def test_image(self, tmp_path: Path):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def image_tool(path: str) -> Image:
             return Image(path)
 
@@ -243,7 +243,7 @@ class TestToolParameters:
     async def test_parameter_descriptions_with_field_annotations(self):
         mcp = FastMCP("Test Server")
 
-        @mcp.tool()
+        @mcp.tool
         def greet(
             name: Annotated[str, Field(description="The name to greet")],
             title: Annotated[str, Field(description="Optional title", default="")],
@@ -268,7 +268,7 @@ class TestToolParameters:
     async def test_parameter_descriptions_with_field_defaults(self):
         mcp = FastMCP("Test Server")
 
-        @mcp.tool()
+        @mcp.tool
         def greet(
             name: str = Field(description="The name to greet"),
             title: str = Field(description="Optional title", default=""),
@@ -293,7 +293,7 @@ class TestToolParameters:
     async def test_tool_with_bytes_input(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def process_image(image: bytes) -> Image:
             return Image(data=image)
 
@@ -308,7 +308,7 @@ class TestToolParameters:
     async def test_tool_with_invalid_input(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def my_tool(x: int) -> int:
             return x + 1
 
@@ -323,7 +323,7 @@ class TestToolParameters:
         """Test string-to-int type coercion."""
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def add_one(x: int) -> int:
             return x + 1
 
@@ -336,7 +336,7 @@ class TestToolParameters:
         """Test string-to-bool type coercion."""
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def toggle(flag: bool) -> bool:
             return not flag
 
@@ -351,7 +351,7 @@ class TestToolParameters:
     async def test_annotated_field_validation(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def analyze(x: Annotated[int, Field(ge=1)]) -> None:
             pass
 
@@ -362,7 +362,7 @@ class TestToolParameters:
     async def test_default_field_validation(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def analyze(x: int = Field(ge=1)) -> None:
             pass
 
@@ -373,7 +373,7 @@ class TestToolParameters:
     async def test_default_field_is_still_required_if_no_default_specified(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def analyze(x: int = Field()) -> None:
             pass
 
@@ -384,7 +384,7 @@ class TestToolParameters:
     async def test_literal_type_validation_error(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def analyze(x: Literal["a", "b"]) -> None:
             pass
 
@@ -395,7 +395,7 @@ class TestToolParameters:
     async def test_literal_type_validation_success(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def analyze(x: Literal["a", "b"]) -> str:
             return x
 
@@ -411,7 +411,7 @@ class TestToolParameters:
             GREEN = "green"
             BLUE = "blue"
 
-        @mcp.tool()
+        @mcp.tool
         def analyze(x: MyEnum) -> str:
             return x.value
 
@@ -427,7 +427,7 @@ class TestToolParameters:
             GREEN = "green"
             BLUE = "blue"
 
-        @mcp.tool()
+        @mcp.tool
         def analyze(x: MyEnum) -> str:
             return x.value
 
@@ -438,7 +438,7 @@ class TestToolParameters:
     async def test_union_type_validation(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def analyze(x: int | float) -> str:
             return str(x)
 
@@ -455,7 +455,7 @@ class TestToolParameters:
     async def test_path_type(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def send_path(path: Path) -> str:
             assert isinstance(path, Path)
             return str(path)
@@ -470,7 +470,7 @@ class TestToolParameters:
     async def test_path_type_error(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def send_path(path: Path) -> str:
             return str(path)
 
@@ -481,7 +481,7 @@ class TestToolParameters:
     async def test_uuid_type(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def send_uuid(x: uuid.UUID) -> str:
             assert isinstance(x, uuid.UUID)
             return str(x)
@@ -495,7 +495,7 @@ class TestToolParameters:
     async def test_uuid_type_error(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def send_uuid(x: uuid.UUID) -> str:
             return str(x)
 
@@ -506,7 +506,7 @@ class TestToolParameters:
     async def test_datetime_type(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def send_datetime(x: datetime.datetime) -> str:
             return x.isoformat()
 
@@ -519,7 +519,7 @@ class TestToolParameters:
     async def test_datetime_type_parse_string(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def send_datetime(x: datetime.datetime) -> str:
             return x.isoformat()
 
@@ -532,7 +532,7 @@ class TestToolParameters:
     async def test_datetime_type_error(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def send_datetime(x: datetime.datetime) -> str:
             return x.isoformat()
 
@@ -543,7 +543,7 @@ class TestToolParameters:
     async def test_date_type(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def send_date(x: datetime.date) -> str:
             return x.isoformat()
 
@@ -554,7 +554,7 @@ class TestToolParameters:
     async def test_date_type_parse_string(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def send_date(x: datetime.date) -> str:
             return x.isoformat()
 
@@ -565,7 +565,7 @@ class TestToolParameters:
     async def test_timedelta_type(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def send_timedelta(x: datetime.timedelta) -> str:
             return str(x)
 
@@ -578,7 +578,7 @@ class TestToolParameters:
     async def test_timedelta_type_parse_int(self):
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def send_timedelta(x: datetime.timedelta) -> str:
             return str(x)
 
@@ -594,7 +594,7 @@ class TestToolContextInjection:
         """Test that context parameters are properly detected."""
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def tool_with_context(x: int, ctx: Context) -> str:
             return f"Request {ctx.request_id}: {x}"
 
@@ -607,7 +607,7 @@ class TestToolContextInjection:
         """Test that context is properly injected into tool calls."""
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def tool_with_context(x: int, ctx: Context) -> str:
             assert isinstance(ctx, Context)
             assert ctx.request_id is not None
@@ -623,7 +623,7 @@ class TestToolContextInjection:
         """Test that context works in async functions."""
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         async def async_tool(x: int, ctx: Context) -> str:
             assert ctx.request_id is not None
             return f"Async request {ctx.request_id}: {x}"
@@ -638,7 +638,7 @@ class TestToolContextInjection:
         """Test that context is optional."""
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def no_context(x: int) -> int:
             return x * 2
 
@@ -656,7 +656,7 @@ class TestToolContextInjection:
         def test_resource() -> str:
             return "resource data"
 
-        @mcp.tool()
+        @mcp.tool
         async def tool_with_resource(ctx: Context) -> str:
             r_iter = await ctx.read_resource("test://data")
             r_list = list(r_iter)

--- a/tests/test_servers/fastmcp_server.py
+++ b/tests/test_servers/fastmcp_server.py
@@ -14,19 +14,19 @@ server = FastMCP("TestServer")
 # --- Tools ---
 
 
-@server.tool()
+@server.tool
 def greet(name: str) -> str:
     """Greet someone by name."""
     return f"Hello, {name}!"
 
 
-@server.tool()
+@server.tool
 def add(a: int, b: int) -> int:
     """Add two numbers together."""
     return a + b
 
 
-@server.tool()
+@server.tool
 def error_tool():
     """This tool always raises an error."""
     raise ValueError("This is a test error")

--- a/tests/tools/test_tool.py
+++ b/tests/tools/test_tool.py
@@ -320,7 +320,7 @@ class TestLegacyToolJsonParsing:
         """Test JSON string to collection type coercion."""
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def process_list(items: list[int]) -> int:
             return sum(items)
 
@@ -335,7 +335,7 @@ class TestLegacyToolJsonParsing:
         """Test that a list coercion error is raised if the input is not a valid list."""
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def process_list(items: list[int]) -> int:
             return sum(items)
 
@@ -350,7 +350,7 @@ class TestLegacyToolJsonParsing:
         """Test JSON string to dict type coercion."""
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def process_dict(data: dict[str, int]) -> int:
             return sum(data.values())
 
@@ -365,7 +365,7 @@ class TestLegacyToolJsonParsing:
         """Test JSON string to set type coercion."""
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def process_set(items: set[int]) -> int:
             assert isinstance(items, set)
             return sum(items)
@@ -378,7 +378,7 @@ class TestLegacyToolJsonParsing:
         """Test JSON string to tuple type coercion."""
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def process_tuple(items: tuple[int, str]) -> int:
             assert isinstance(items, tuple)
             return items[0] + len(items[1])

--- a/tests/tools/test_tool_manager.py
+++ b/tests/tools/test_tool_manager.py
@@ -519,7 +519,7 @@ class TestCallTools:
         mcp = FastMCP(tool_serializer=custom_serializer)
         manager = mcp._tool_manager
 
-        @mcp.tool()
+        @mcp.tool
         def get_data() -> dict:
             return {"key": "value", "number": 123}
 
@@ -537,7 +537,7 @@ class TestCallTools:
         mcp = FastMCP(tool_serializer=custom_serializer)
         manager = mcp._tool_manager
 
-        @mcp.tool()
+        @mcp.tool
         def get_data() -> list[dict]:
             return [
                 {"key": "value", "number": 123},
@@ -561,7 +561,7 @@ class TestCallTools:
         mcp = FastMCP(tool_serializer=custom_serializer)
         manager = mcp._tool_manager
 
-        @mcp.tool()
+        @mcp.tool
         def get_data() -> uuid.UUID:
             return uuid_result
 

--- a/tests/utilities/test_mcp_config.py
+++ b/tests/utilities/test_mcp_config.py
@@ -102,7 +102,7 @@ async def test_multi_client(tmp_path: Path):
 
         mcp = FastMCP()
 
-        @mcp.tool()
+        @mcp.tool
         def add(a: int, b: int) -> int:
             return a + b
 


### PR DESCRIPTION
This change allows the server.tool decorator to be used in all common invocation forms, including:
	•	`@server.tool` (bare decorator)
	•	`@server.tool()` (empty call)
	•	`@server.tool("name")` (positional name)
	•	`@server.tool(name="name")` (keyword name)
	•	`server.tool(func, name="name")` (direct function call)

Also supports optional description, tags, annotations, and exclude_args for richer tool metadata.

This is far more Pythonic, in particular the bare decorator.