### PR TITLE
Switch Pydantic defaults to kwargs

### DIFF
--- a/src/fastmcp/prompts/prompt.py
+++ b/src/fastmcp/prompts/prompt.py
@@ -59,7 +59,7 @@ class PromptArgument(FastMCPBaseModel):
 
     name: str = Field(description="Name of the argument")
     description: str | None = Field(
-        None, description="Description of what the argument does"
+        default=None, description="Description of what the argument does"
     )
     required: bool = Field(
         default=False, description="Whether the argument is required"
@@ -71,13 +71,13 @@ class Prompt(FastMCPBaseModel, ABC):
 
     name: str = Field(description="Name of the prompt")
     description: str | None = Field(
-        None, description="Description of what the prompt does"
+        default=None, description="Description of what the prompt does"
     )
     tags: Annotated[set[str], BeforeValidator(_convert_set_defaults)] = Field(
         default_factory=set, description="Tags for the prompt"
     )
     arguments: list[PromptArgument] | None = Field(
-        None, description="Arguments that can be passed to the prompt"
+        default=None, description="Arguments that can be passed to the prompt"
     )
 
     def __eq__(self, other: object) -> bool:

--- a/src/fastmcp/resources/resource.py
+++ b/src/fastmcp/resources/resource.py
@@ -38,9 +38,9 @@ class Resource(FastMCPBaseModel, abc.ABC):
     uri: Annotated[AnyUrl, UrlConstraints(host_required=False)] = Field(
         default=..., description="URI of the resource"
     )
-    name: str | None = Field(description="Name of the resource", default=None)
+    name: str | None = Field(default=None, description="Name of the resource")
     description: str | None = Field(
-        description="Description of the resource", default=None
+        default=None, description="Description of the resource"
     )
     tags: Annotated[set[str], BeforeValidator(_convert_set_defaults)] = Field(
         default_factory=set, description="Tags for the resource"

--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -45,14 +45,14 @@ class Tool(FastMCPBaseModel, ABC):
         default_factory=set, description="Tags for the tool"
     )
     annotations: ToolAnnotations | None = Field(
-        None, description="Additional annotations about the tool"
+        default=None, description="Additional annotations about the tool"
     )
     exclude_args: list[str] | None = Field(
-        None,
+        default=None,
         description="Arguments to exclude from the tool schema, such as State, Memory, or Credential",
     )
     serializer: Callable[[Any], str] | None = Field(
-        None, description="Optional custom serializer for tool results"
+        default=None, description="Optional custom serializer for tool results"
     )
 
     def to_mcp_tool(self, **overrides: Any) -> MCPTool:

--- a/tests/utilities/test_typeadapter.py
+++ b/tests/utilities/test_typeadapter.py
@@ -60,7 +60,7 @@ def complex_arguments_fn(
         456,
     ],
     field_with_default_via_field_annotation_before_nondefault_arg: Annotated[
-        int, Field(1)
+        int, Field(default=1)
     ],
     unannotated,
     my_model_a: SomeInputModelA,
@@ -68,7 +68,7 @@ def complex_arguments_fn(
     my_model_b: SomeInputModelB,
     an_int_annotated_with_field_default: Annotated[
         int,
-        Field(1, description="An int with a field"),
+        Field(default=1, description="An int with a field"),
     ],
     unannotated_with_default=5,
     my_model_a_with_default: SomeInputModelA = SomeInputModelA(),  # noqa: B008


### PR DESCRIPTION
Make the type checker less sad

https://github.com/jlowin/fastmcp/issues/688
<img width="735" alt="Screenshot 2025-06-05 at 11 04 25 PM" src="https://github.com/user-attachments/assets/96103972-b31f-4bd4-8d9b-4bd740a478f8" />
