### PR TITLE
Fix: updated variable name under Gemini remote client

### DIFF
--- a/docs/integrations/gemini.mdx
+++ b/docs/integrations/gemini.mdx
@@ -98,7 +98,7 @@ For example, to connect to a remote, authenticated server, you can use the follo
 from fastmcp import Client
 from fastmcp.client.auth import BearerAuth
 
-client = Client(
+mcp_client = Client(
     "https://my-server.com/sse",
     auth=BearerAuth("<your-token>"),
 )


### PR DESCRIPTION
Fix: updated variable name under Gemini remote client to match previous example, in order to work, the rest of the code is the same as above.