### PR TITLE
Fix issue with global OpenAPI tags

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -121,7 +121,6 @@ class FastMCP(Generic[LifespanResultT]):
             ]
             | None
         ) = None,
-        tags: set[str] | None = None,
         tool_serializer: Callable[[Any], str] | None = None,
         cache_expiration_seconds: float | None = None,
         on_duplicate_tools: DuplicateBehavior | None = None,
@@ -151,8 +150,6 @@ class FastMCP(Generic[LifespanResultT]):
         self.resource_prefix_format: Literal["protocol", "path"] = (
             resource_prefix_format or fastmcp.settings.resource_prefix_format
         )
-
-        self.tags: set[str] = tags or set()
 
         self._cache = TimedCache(
             expiration=datetime.timedelta(seconds=cache_expiration_seconds or 0)

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -1561,6 +1561,7 @@ class FastMCP(Generic[LifespanResultT]):
         route_map_fn: OpenAPIRouteMapFn | None = None,
         mcp_component_fn: OpenAPIComponentFn | None = None,
         mcp_names: dict[str, str] | None = None,
+        tags: set[str] | None = None,
         **settings: Any,
     ) -> FastMCPOpenAPI:
         """
@@ -1575,6 +1576,7 @@ class FastMCP(Generic[LifespanResultT]):
             route_map_fn=route_map_fn,
             mcp_component_fn=mcp_component_fn,
             mcp_names=mcp_names,
+            tags=tags,
             **settings,
         )
 
@@ -1588,6 +1590,7 @@ class FastMCP(Generic[LifespanResultT]):
         mcp_component_fn: OpenAPIComponentFn | None = None,
         mcp_names: dict[str, str] | None = None,
         httpx_client_kwargs: dict[str, Any] | None = None,
+        tags: set[str] | None = None,
         **settings: Any,
     ) -> FastMCPOpenAPI:
         """
@@ -1615,6 +1618,7 @@ class FastMCP(Generic[LifespanResultT]):
             route_map_fn=route_map_fn,
             mcp_component_fn=mcp_component_fn,
             mcp_names=mcp_names,
+            tags=tags,
             **settings,
         )
 

--- a/tests/deprecated/test_settings.py
+++ b/tests/deprecated/test_settings.py
@@ -175,7 +175,6 @@ class TestDeprecatedServerInitKwargs:
             server = FastMCP(
                 name="TestServer",
                 instructions="Test instructions",
-                tags={"test", "server"},
                 cache_expiration_seconds=60.0,
                 on_duplicate_tools="warn",
                 on_duplicate_resources="error",
@@ -193,7 +192,6 @@ class TestDeprecatedServerInitKwargs:
         # Verify server was created successfully
         assert server.name == "TestServer"
         assert server.instructions == "Test instructions"
-        assert server.tags == {"test", "server"}
 
     def test_none_values_no_warnings(self):
         """Test that None values for deprecated kwargs don't raise warnings."""

--- a/tests/server/openapi/test_openapi.py
+++ b/tests/server/openapi/test_openapi.py
@@ -2709,25 +2709,22 @@ class TestGlobalTagsParameter:
         )
 
         # Check tool has both original and global tags
-        tools = server._tool_manager.list_tools()
-        create_item_tool = next((t for t in tools if "create_item" in t.name), None)
-        assert create_item_tool is not None
+        tools = await server.get_tools()
+        create_item_tool = tools["create_item_items_post"]
         assert "items" in create_item_tool.tags  # Original OpenAPI tag
         assert "global" in create_item_tool.tags  # Global tag
         assert "api-v1" in create_item_tool.tags  # Global tag
 
         # Check resource has both original and global tags
-        resources = list(server._resource_manager.get_resources().values())
-        get_items_resource = next((r for r in resources if "get_items" in r.name), None)
-        assert get_items_resource is not None
+        resources = await server.get_resources()
+        get_items_resource = resources["resource://get_items_items_get"]
         assert "items" in get_items_resource.tags  # Original OpenAPI tag
         assert "global" in get_items_resource.tags  # Global tag
         assert "api-v1" in get_items_resource.tags  # Global tag
 
         # Check resource template has both original and global tags
-        templates = list(server._resource_manager.get_templates().values())
-        get_item_template = next((t for t in templates if "get_item" in t.name), None)
-        assert get_item_template is not None
+        templates = await server.get_resource_templates()
+        get_item_template = templates["resource://get_item_items/{item_id}"]
         assert "items" in get_item_template.tags  # Original OpenAPI tag
         assert "global" in get_item_template.tags  # Global tag
         assert "api-v1" in get_item_template.tags  # Global tag
@@ -2754,25 +2751,22 @@ class TestGlobalTagsParameter:
         )
 
         # Check tool has both original and global tags
-        tools = server._tool_manager.list_tools()
-        create_item_tool = next((t for t in tools if "create_item" in t.name), None)
-        assert create_item_tool is not None
+        tools = await server.get_tools()
+        create_item_tool = tools["create_item_items_post"]
         assert "items" in create_item_tool.tags  # Original OpenAPI tag
         assert "openapi-global" in create_item_tool.tags  # Global tag
         assert "service" in create_item_tool.tags  # Global tag
 
         # Check resource has both original and global tags
-        resources = list(server._resource_manager.get_resources().values())
-        get_items_resource = next((r for r in resources if "get_items" in r.name), None)
-        assert get_items_resource is not None
+        resources = await server.get_resources()
+        get_items_resource = resources["resource://get_items_items_get"]
         assert "items" in get_items_resource.tags  # Original OpenAPI tag
         assert "openapi-global" in get_items_resource.tags  # Global tag
         assert "service" in get_items_resource.tags  # Global tag
 
         # Check resource template has both original and global tags
-        templates = list(server._resource_manager.get_templates().values())
-        get_item_template = next((t for t in templates if "get_item" in t.name), None)
-        assert get_item_template is not None
+        templates = await server.get_resource_templates()
+        get_item_template = templates["resource://get_item_items/{item_id}"]
         assert "items" in get_item_template.tags  # Original OpenAPI tag
         assert "openapi-global" in get_item_template.tags  # Global tag
         assert "service" in get_item_template.tags  # Global tag
@@ -2800,17 +2794,15 @@ class TestGlobalTagsParameter:
         )
 
         # Check that all three types of tags are present on the tool
-        tools = server._tool_manager.list_tools()
-        create_item_tool = next((t for t in tools if "create_item" in t.name), None)
-        assert create_item_tool is not None
+        tools = await server.get_tools()
+        create_item_tool = tools["create_item_items_post"]
         assert "items" in create_item_tool.tags  # Original OpenAPI tag
         assert "global" in create_item_tool.tags  # Global tag
         assert "route-specific" in create_item_tool.tags  # RouteMap mcp_tag
 
         # Check that resource only has OpenAPI and global tags (no route-specific since different RouteMap)
-        resources = list(server._resource_manager.get_resources().values())
-        get_items_resource = next((r for r in resources if "get_items" in r.name), None)
-        assert get_items_resource is not None
+        resources = await server.get_resources()
+        get_items_resource = resources["resource://get_items_items_get"]
         assert "items" in get_items_resource.tags  # Original OpenAPI tag
         assert "global" in get_items_resource.tags  # Global tag
         assert "route-specific" not in get_items_resource.tags  # Not from this RouteMap


### PR DESCRIPTION
in #791, the `tags` parameter of the FastMCP class (which was unused!) shadowed the functionality nominally implemented. This PR fixes that.