### PR TITLE
Add Community section to documentation

### DIFF
--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -1,0 +1,22 @@
+# Community Section
+
+This directory contains community-contributed content and showcases for FastMCP.
+
+## Structure
+
+- `showcase.mdx` - Main community showcase page featuring high-quality projects and examples
+
+## Adding Content
+
+To add new community content:
+1. Create a new MDX file in this directory
+2. Update `docs.json` to include it in the navigation
+3. Follow the existing format for consistency
+
+## Guidelines
+
+Community content should:
+- Demonstrate best practices
+- Provide educational value
+- Include proper documentation
+- Be maintained and up-to-date

--- a/docs/community/showcase.mdx
+++ b/docs/community/showcase.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Community Showcase'
+description: 'High-quality projects and examples from the FastMCP community'
+icon: 'users'
+---
+
+## Featured Projects
+
+Discover exemplary MCP servers and implementations created by our community. These projects demonstrate best practices and innovative uses of FastMCP.
+
+### Learning Resources
+
+<Card title="MCP Dummy Server" icon="graduation-cap" href="https://github.com/WaiYanNyeinNaing/mcp-dummy-server">
+  A comprehensive educational example demonstrating FastMCP best practices with professional dual-transport server implementation, interactive test client, and detailed documentation.
+</Card>
+
+### Community Examples
+
+Have you built something interesting with FastMCP? We'd love to feature high-quality examples here! Start a [discussion on GitHub](https://github.com/jlowin/fastmcp/discussions) to share your project.
+
+## Contributing
+
+To get your project featured:
+
+1. Ensure your project demonstrates best practices
+2. Include comprehensive documentation
+3. Add clear usage examples
+4. Open a discussion in our [GitHub Discussions](https://github.com/jlowin/fastmcp/discussions)
+
+We review submissions regularly and feature projects that provide value to the FastMCP community.
+
+## Further Reading
+
+- [Contrib Modules](/integrations/contrib) - Community-contributed modules that are distributed with FastMCP itself

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -150,6 +150,13 @@
                 "pages": [
                     "changelog"
                 ]
+            },
+            {
+                "anchor": "Community",
+                "icon": "users",
+                "pages": [
+                    "community/showcase"
+                ]
             }
         ]
     },


### PR DESCRIPTION
## Summary
- Adds a new Community tab to the documentation navigation
- Creates a showcase page for featuring high-quality community projects
- Provides a structured way to highlight exemplary MCP implementations

## Changes
- Modified `docs/docs.json` to add Community section to navigation
- Created `docs/community/showcase.mdx` with initial content featuring the MCP Dummy Server example
- Added guidelines for community contributions and links to GitHub Discussions
- Included "Further Reading" section linking to contrib modules

This provides a nice solution for showcasing well-meaning community contributions (like the one in #795) without cluttering the main documentation.

## Test plan
- [ ] Preview docs locally to ensure Community tab appears correctly
- [ ] Verify navigation works properly
- [ ] Check that all links are functional

🤖 Generated with [Claude Code](https://claude.ai/code)