### PR TITLE
Fix JWT issuer validation to support string values per RFC 7519

### DIFF
--- a/src/fastmcp/server/auth/providers/bearer.py
+++ b/src/fastmcp/server/auth/providers/bearer.py
@@ -17,7 +17,7 @@ from mcp.shared.auth import (
     OAuthClientInformationFull,
     OAuthToken,
 )
-from pydantic import AnyHttpUrl, SecretStr
+from pydantic import AnyHttpUrl, SecretStr, ValidationError
 
 from fastmcp.server.auth.auth import (
     ClientRegistrationOptions,
@@ -183,7 +183,7 @@ class BearerAuthProvider(OAuthProvider):
         # This allows the issuer claim validation to work with string issuers per RFC 7519
         try:
             issuer_url = AnyHttpUrl(issuer) if issuer else "https://fastmcp.example.com"
-        except Exception:
+        except ValidationError:
             # Issuer is not a valid URL, use default for parent class
             issuer_url = "https://fastmcp.example.com"
 

--- a/src/fastmcp/server/auth/providers/bearer.py
+++ b/src/fastmcp/server/auth/providers/bearer.py
@@ -17,7 +17,7 @@ from mcp.shared.auth import (
     OAuthClientInformationFull,
     OAuthToken,
 )
-from pydantic import SecretStr
+from pydantic import AnyHttpUrl, SecretStr
 
 from fastmcp.server.auth.auth import (
     ClientRegistrationOptions,
@@ -179,8 +179,16 @@ class BearerAuthProvider(OAuthProvider):
         if public_key and jwks_uri:
             raise ValueError("Provide either public_key or jwks_uri, not both")
 
+        # Only pass issuer to parent if it's a valid URL, otherwise use default
+        # This allows the issuer claim validation to work with string issuers per RFC 7519
+        try:
+            issuer_url = AnyHttpUrl(issuer) if issuer else "https://fastmcp.example.com"
+        except Exception:
+            # Issuer is not a valid URL, use default for parent class
+            issuer_url = "https://fastmcp.example.com"
+
         super().__init__(
-            issuer_url=issuer or "https://fastmcp.example.com",
+            issuer_url=issuer_url,
             client_registration_options=ClientRegistrationOptions(enabled=False),
             revocation_options=RevocationOptions(enabled=False),
             required_scopes=required_scopes,


### PR DESCRIPTION
## Summary
Fixes JWT issuer validation to allow string values in addition to URLs, per RFC 7519 specification. Resolves #890 where `BearerAuthProvider` rejected valid tokens with non-URL issuer claims like `"my-service"`.

## Solution
Works around the underlying MCP SDK's URL validation requirement by using a default URL for the parent class while preserving the original string for JWT claim validation. This maintains RFC 7519 compliance without breaking existing functionality.

## Test Plan
- ✅ String issuers work correctly
- ✅ URL issuers continue to work as before  
- ✅ All existing authentication tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)