### PR TITLE
Simplify trailing slash handling for HTTP endpoints

### DIFF
--- a/src/fastmcp/server/http.py
+++ b/src/fastmcp/server/http.py
@@ -157,9 +157,8 @@ def create_sse_app(
     Returns:
         A Starlette application with RequestContextMiddleware
     """
-    
+
     # Ensure the message_path ends with a trailing slash to avoid automatic redirects
-    # when mounting the application. sse_path uses Route instead of Mount so no fix needed.
     if not message_path.endswith("/"):
         message_path = message_path + "/"
 
@@ -311,11 +310,10 @@ def create_streamable_http_app(
                 raise
 
     # Ensure the streamable_http_path ends with a trailing slash to avoid automatic redirects
-    # when mounting the application
     if not streamable_http_path.endswith("/"):
         streamable_http_path = streamable_http_path + "/"
 
-    # Add StreamableHTTP routes with or without auth  
+    # Add StreamableHTTP routes with or without auth
     if auth:
         auth_middleware, auth_routes, required_scopes = (
             setup_auth_middleware_and_routes(auth)

--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -192,9 +192,9 @@ class Settings(BaseSettings):
     # HTTP settings
     host: str = "127.0.0.1"
     port: int = 8000
-    sse_path: str = "/sse"
+    sse_path: str = "/sse/"
     message_path: str = "/messages/"
-    streamable_http_path: str = "/mcp"
+    streamable_http_path: str = "/mcp/"
     debug: bool = False
 
     # error handling


### PR DESCRIPTION
## Summary

Simplifies the trailing slash fix for HTTP endpoints by:
- Ensuring all paths have trailing slashes before mounting (prevents redirects)
- Updating default paths to `/mcp/` and `/sse/` (with trailing slashes)
- Removing complex PathNormalizingASGIApp and duplicate Route logic

## Changes

- **http.py**: Replace complex path normalization with simple trailing slash enforcement
- **settings.py**: Update default endpoints to use trailing slashes

Much simpler approach - let Starlette handle natural redirects when users request paths without trailing slashes.

🤖 Generated with [Claude Code](https://claude.ai/code)