### PR TITLE
Add httpx.Auth Support to RemoteMCPServer for Custom Authentication methods to multiple MCP Servers

### DIFF
--- a/src/fastmcp/utilities/mcp_config.py
+++ b/src/fastmcp/utilities/mcp_config.py
@@ -4,7 +4,8 @@ import re
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 from urllib.parse import urlparse
 
-from pydantic import AnyUrl, Field
+import httpx
+from pydantic import AnyUrl, ConfigDict, Field
 
 from fastmcp.utilities.types import FastMCPBaseModel
 
@@ -59,11 +60,13 @@ class RemoteMCPServer(FastMCPBaseModel):
     headers: dict[str, str] = Field(default_factory=dict)
     transport: Literal["streamable-http", "sse"] | None = None
     auth: Annotated[
-        str | Literal["oauth"] | None,
+        str | Literal["oauth"] | httpx.Auth | None,
         Field(
-            description='Either a string representing a Bearer token or the literal "oauth" to use OAuth authentication.'
+            description='Either a string representing a Bearer token, the literal "oauth" to use OAuth authentication, or an httpx.Auth instance for custom authentication.',
         ),
     ] = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def to_transport(self) -> StreamableHttpTransport | SSETransport:
         from fastmcp.client.transports import SSETransport, StreamableHttpTransport


### PR DESCRIPTION
## Overview
This PR enhances the RemoteMCPServer class to support custom authentication via the httpx.Auth interface. This allows users to provide advanced or non-standard authentication mechanisms when connecting to multiple MCP servers, especially in environments where servers are secured behind API gateways using [Envoy with OPA (Open Policy Agent) sidecars](https://www.openpolicyagent.org/docs/envoy).

## Motivation
In some deployments, MCP servers are not directly exposed but are instead protected by API gateways and policy enforcement layers (e.g., Envoy + OPA). These setups often require custom authentication logic that cannot be satisfied by simple bearer tokens or OAuth flows. By allowing a user-supplied httpx.Auth instance, we enable seamless integration with these advanced security environments.

For example, as described in the [OPA Envoy integration docs](https://www.openpolicyagent.org/docs/envoy), requests may need to be signed, have custom headers injected, or use other dynamic authentication strategies.

## Changes
- The RemoteMCPServer class now accepts an auth parameter that can be:
  - A string (Bearer token)
  - The literal "oauth" (for OAuth)
  - An httpx.Auth instance (for custom authentication)
  - None
- The `to_transport` method passes the auth object directly to the underlying transport, enabling custom authentication logic.

### Example Usage
```python
import httpx
import asyncio
from fastmcp import Client
from fastmcp.utilities.mcp_config import MCPConfig, RemoteMCPServer

class MyCustomAuth(httpx.Auth):
    def auth_flow(self, request):
        # Custom logic here
        request.headers["X-Custom-Auth"] = "my-value"
        yield request

client = Client(
    MCPConfig(
        mcpServers={
            "calendar": RemoteMCPServer(
                url="http://localhost:8000/mcp",
                transport="streamable-http"
            ),
            "authenticated_calendar": RemoteMCPServer(
                url="http://localhost:8001/mcp",
                transport="streamable-http",
                auth=MyCustomAuth(),
            ),
        }
    )
)


server = RemoteMCPServer(
    url="https://my-mcp.example.com",
    auth=MyCustomAuth(),
)

async def main():
    async with client:
        print(await client.list_tools())

if __name__ == "__main__":
    asyncio.run(main())
```

### Impact
- Backwards compatible: existing usages with bearer tokens or OAuth are unaffected.
- Enables advanced authentication scenarios for users operating in secure, policy-driven environments.
