### PR TITLE
Fix duplicate error logging in exception handlers

### DIFF
--- a/src/fastmcp/prompts/prompt.py
+++ b/src/fastmcp/prompts/prompt.py
@@ -339,6 +339,6 @@ class FunctionPrompt(Prompt):
                     raise PromptError("Could not convert prompt result to message.")
 
             return messages
-        except Exception as e:
-            logger.exception(f"Error rendering prompt {self.name}: {e}")
+        except Exception:
+            logger.exception(f"Error rendering prompt {self.name}")
             raise PromptError(f"Error rendering prompt {self.name}.")

--- a/src/fastmcp/prompts/prompt_manager.py
+++ b/src/fastmcp/prompts/prompt_manager.py
@@ -172,12 +172,12 @@ class PromptManager:
 
             # Pass through PromptErrors as-is
             except PromptError as e:
-                logger.exception(f"Error rendering prompt {name!r}: {e}")
+                logger.exception(f"Error rendering prompt {name!r}")
                 raise e
 
             # Handle other exceptions
             except Exception as e:
-                logger.exception(f"Error rendering prompt {name!r}: {e}")
+                logger.exception(f"Error rendering prompt {name!r}")
                 if self.mask_error_details:
                     # Mask internal details
                     raise PromptError(f"Error rendering prompt {name!r}") from e

--- a/src/fastmcp/resources/resource_manager.py
+++ b/src/fastmcp/resources/resource_manager.py
@@ -422,12 +422,12 @@ class ResourceManager:
 
             # raise ResourceErrors as-is
             except ResourceError as e:
-                logger.exception(f"Error reading resource {uri_str!r}: {e}")
+                logger.exception(f"Error reading resource {uri_str!r}")
                 raise e
 
             # Handle other exceptions
             except Exception as e:
-                logger.exception(f"Error reading resource {uri_str!r}: {e}")
+                logger.exception(f"Error reading resource {uri_str!r}")
                 if self.mask_error_details:
                     # Mask internal details
                     raise ResourceError(f"Error reading resource {uri_str!r}") from e
@@ -445,12 +445,12 @@ class ResourceManager:
                     return await resource.read()
                 except ResourceError as e:
                     logger.exception(
-                        f"Error reading resource from template {uri_str!r}: {e}"
+                        f"Error reading resource from template {uri_str!r}"
                     )
                     raise e
                 except Exception as e:
                     logger.exception(
-                        f"Error reading resource from template {uri_str!r}: {e}"
+                        f"Error reading resource from template {uri_str!r}"
                     )
                     if self.mask_error_details:
                         raise ResourceError(

--- a/src/fastmcp/tools/tool_manager.py
+++ b/src/fastmcp/tools/tool_manager.py
@@ -186,12 +186,12 @@ class ToolManager:
 
             # raise ToolErrors as-is
             except ToolError as e:
-                logger.exception(f"Error calling tool {key!r}: {e}")
+                logger.exception(f"Error calling tool {key!r}")
                 raise e
 
             # Handle other exceptions
             except Exception as e:
-                logger.exception(f"Error calling tool {key!r}: {e}")
+                logger.exception(f"Error calling tool {key!r}")
                 if self.mask_error_details:
                     # Mask internal details
                     raise ToolError(f"Error calling tool {key!r}") from e


### PR DESCRIPTION
## Summary

Fixes duplicate error logging in exception handlers. Removes redundant `{e}` interpolation from logger.exception() calls since the method already logs full exception tracebacks automatically.

Closes #936

🤖 Generated with [Claude Code](https://claude.ai/code)