### PR TITLE
Fix parameter location enum handling in OpenAPI parser

### DIFF
--- a/src/fastmcp/utilities/openapi.py
+++ b/src/fastmcp/utilities/openapi.py
@@ -302,11 +302,15 @@ class OpenAPIParser(
 
                 # Extract parameter info - handle both 3.0 and 3.1 parameter models
                 param_in = parameter.param_in  # Both use param_in
-                param_location = self._convert_to_parameter_location(param_in)
+                # Handle enum or string parameter locations
+                param_in_str = (
+                    param_in.value if hasattr(param_in, "value") else param_in
+                )
+                param_location = self._convert_to_parameter_location(param_in_str)
                 param_schema_obj = parameter.param_schema  # Both use param_schema
 
                 # Skip duplicate parameters (same name and location)
-                param_key = (parameter.name, param_in)
+                param_key = (parameter.name, param_in_str)
                 if param_key in seen_params:
                     continue
                 seen_params[param_key] = True

--- a/src/fastmcp/utilities/openapi.py
+++ b/src/fastmcp/utilities/openapi.py
@@ -303,8 +303,10 @@ class OpenAPIParser(
                 # Extract parameter info - handle both 3.0 and 3.1 parameter models
                 param_in = parameter.param_in  # Both use param_in
                 # Handle enum or string parameter locations
+                from enum import Enum
+
                 param_in_str = (
-                    param_in.value if hasattr(param_in, "value") else param_in
+                    param_in.value if isinstance(param_in, Enum) else param_in
                 )
                 param_location = self._convert_to_parameter_location(param_in_str)
                 param_schema_obj = parameter.param_schema  # Both use param_schema

--- a/tests/server/openapi/test_openapi_path_parameters.py
+++ b/tests/server/openapi/test_openapi_path_parameters.py
@@ -455,3 +455,28 @@ async def test_array_query_parameter_exploded_format(mock_client):
         json=None,
         timeout=None,
     )
+
+
+def test_parameter_location_enum_handling():
+    """Test that ParameterLocation enum values are handled correctly (issue #950)."""
+    from fastapi import FastAPI, Path, Query
+
+    from fastmcp import FastMCP
+
+    # Create FastAPI app with path and query parameters
+    app = FastAPI(title="Parameter Location Test")
+
+    @app.get("/tenants/{tenant_id}/data")
+    async def get_tenant_data(
+        tenant_id: str = Path(..., description="The tenant ID"),
+        limit: int = Query(10, description="Data limit"),
+    ):
+        return {"tenant_id": tenant_id, "limit": limit}
+
+    # This should not raise a validation error about ParameterLocation
+    mcp_server = FastMCP(
+        name="Test MCP", instructions="Test server for parameter location enum handling"
+    ).from_fastapi(app, name="Test MCP", tags={"test"})
+
+    # Verify the server was created successfully
+    assert mcp_server is not None


### PR DESCRIPTION
Fixes #950 where parameter extraction fails with ParameterLocation enum validation errors.

The issue occurs when `openapi_pydantic` returns `ParameterLocation` enum values instead of strings. While we couldn't reproduce the exact error, the fix handles both enum and string cases safely using proper `isinstance(param_in, Enum)` checks.

Updated parameter extraction to convert enum values to strings before validation, preventing potential parsing failures.

🤖 Generated with [Claude Code](https://claude.ai/code)