### PR TITLE
Fix output schema generation edge case

### DIFF
--- a/src/fastmcp/tools/tool_transform.py
+++ b/src/fastmcp/tools/tool_transform.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 from mcp.types import ToolAnnotations
 from pydantic import ConfigDict
 
-from fastmcp.tools.tool import ParsedFunction, Tool, ToolResult, _wrap_schema_if_needed
+from fastmcp.tools.tool import ParsedFunction, Tool, ToolResult
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import NotSet, NotSetT, get_cached_typeadapter
 
@@ -430,7 +430,7 @@ class TransformedTool(Tool):
             # Smart fallback: try custom function, then parent, then None
             if transform_fn is not None:
                 parsed_fn = ParsedFunction.from_function(transform_fn, validate=False)
-                final_output_schema = _wrap_schema_if_needed(parsed_fn.output_schema)
+                final_output_schema = parsed_fn.output_schema
                 if final_output_schema is None:
                     # Check if function returns ToolResult - if so, don't fall back to parent
                     import inspect

--- a/tests/tools/test_tool_transform.py
+++ b/tests/tools/test_tool_transform.py
@@ -1063,7 +1063,9 @@ class TestTransformToolOutputSchema:
         # Should inherit parent's wrapped string schema
         expected_schema = {
             "type": "object",
-            "properties": {"result": {"type": "string"}},
+            "properties": {"result": {"type": "string", "title": "Result"}},
+            "required": ["result"],
+            "title": "_WrappedResult",
             "x-fastmcp-wrap-result": True,
         }
         assert new_tool.output_schema == expected_schema
@@ -1121,7 +1123,9 @@ class TestTransformToolOutputSchema:
         # Should infer string schema from custom function and wrap it
         expected_schema = {
             "type": "object",
-            "properties": {"result": {"type": "string"}},
+            "properties": {"result": {"type": "string", "title": "Result"}},
+            "required": ["result"],
+            "title": "_WrappedResult",
             "x-fastmcp-wrap-result": True,
         }
         assert new_tool.output_schema == expected_schema


### PR DESCRIPTION
## Problem

FastMCP provides excellent DX by automatically generating clean output schemas and wrapping non-object types to meet MCP requirements. However, union types like `DataClass | str` hit a rough edge where our schema wrapping caused "PointerToNowhere" errors.

The issue occurred because manual schema wrapping moved `$defs` under `properties.result.$defs` but `$ref` pointers still expected them at the root level (`#/$defs/...`).

## Solution

Replace manual schema manipulation with a cleaner approach using a generic `_WrappedResult[T]` dataclass. This lets Pydantic handle all schema generation internally, ensuring proper `$defs` and `$ref` structure.

## Example

```python
from dataclasses import dataclass
from fastmcp import FastMCP

@dataclass
class UserData:
    name: str
    age: int

mcp = FastMCP()

@mcp.tool
def get_user(user_id: str) -> UserData | str:  # This now works\!
    if user_id == "error":
        return "User not found"
    return UserData(name="Alice", age=30)
```

## Testing

Added focused unit test for union types and updated existing test expectations. All 393 tests pass.

🤖 Generated with [Claude Code](https://claude.ai/code)