### PR TITLE
Remove automatic trailing slash modification from server paths

### DIFF
--- a/src/fastmcp/server/http.py
+++ b/src/fastmcp/server/http.py
@@ -158,10 +158,6 @@ def create_sse_app(
         A Starlette application with RequestContextMiddleware
     """
 
-    # Ensure the message_path ends with a trailing slash to avoid automatic redirects
-    if not message_path.endswith("/"):
-        message_path = message_path + "/"
-
     server_routes: list[BaseRoute] = []
     server_middleware: list[Middleware] = []
 
@@ -308,10 +304,6 @@ def create_streamable_http_app(
             else:
                 # Re-raise other RuntimeErrors if they don't match the specific message
                 raise
-
-    # Ensure the streamable_http_path ends with a trailing slash to avoid automatic redirects
-    if not streamable_http_path.endswith("/"):
-        streamable_http_path = streamable_http_path + "/"
 
     # Add StreamableHTTP routes with or without auth
     if auth:


### PR DESCRIPTION
## Summary

Fixes infinite redirect loops caused by server-side URL modifications that conflict with client expectations. The server was automatically adding trailing slashes to user-provided paths, creating mismatches between what clients requested and what servers expected.

## Key Changes

- Removed automatic trailing slash addition in `create_sse_app()` for `message_path`
- Removed automatic trailing slash addition in `create_streamable_http_app()` for `streamable_http_path`
- Preserved sensible defaults (all default paths in settings still include trailing slashes)

## Before/After

**Before:** User specifies `/sse` → Server changes to `/sse/` → Deployment redirects create loops  
**After:** User specifies `/sse` → Server uses `/sse` exactly → No conflicting redirects

This aligns with the client-side philosophy of respecting exact URLs while maintaining backward compatibility through our defaults.

Closes #991

🤖 Generated with [Claude Code](https://claude.ai/code)