### PR TITLE
Allow per-server timeouts in MCPConfig

### DIFF
--- a/src/fastmcp/utilities/mcp_config.py
+++ b/src/fastmcp/utilities/mcp_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 from urllib.parse import urlparse
+import datetime
 
 import httpx
 from pydantic import AnyUrl, ConfigDict, Field
@@ -65,6 +66,7 @@ class RemoteMCPServer(FastMCPBaseModel):
             description='Either a string representing a Bearer token, the literal "oauth" to use OAuth authentication, or an httpx.Auth instance for custom authentication.',
         ),
     ] = None
+    sse_read_timeout: datetime.timedelta | int | float | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -77,11 +79,19 @@ class RemoteMCPServer(FastMCPBaseModel):
             transport = self.transport
 
         if transport == "sse":
-            return SSETransport(self.url, headers=self.headers, auth=self.auth)
+            return SSETransport(
+                self.url,
+                headers=self.headers,
+                auth=self.auth,
+                sse_read_timeout=self.sse_read_timeout,
+            )
         else:
             # Both "http" and "streamable-http" map to StreamableHttpTransport
             return StreamableHttpTransport(
-                self.url, headers=self.headers, auth=self.auth
+                self.url,
+                headers=self.headers,
+                auth=self.auth,
+                sse_read_timeout=self.sse_read_timeout,
             )
 
 

--- a/src/fastmcp/utilities/mcp_config.py
+++ b/src/fastmcp/utilities/mcp_config.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import datetime
 import re
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 from urllib.parse import urlparse
-import datetime
 
 import httpx
 from pydantic import AnyUrl, ConfigDict, Field


### PR DESCRIPTION
When using an MCPConfig (with remote servers) to initialize an MCP Client, there is no way to set the sse_read_timeout for individual servers. This PR adds that ability by adding `sse_read_timeout` to the RemoteMCPServer class