### PR TITLE
Add path expansion to image/audio/file

### DIFF
--- a/src/fastmcp/utilities/types.py
+++ b/src/fastmcp/utilities/types.py
@@ -3,6 +3,7 @@
 import base64
 import inspect
 import mimetypes
+import os
 from collections.abc import Callable
 from functools import lru_cache
 from pathlib import Path
@@ -101,7 +102,7 @@ class Image:
         if path is not None and data is not None:
             raise ValueError("Only one of path or data can be provided")
 
-        self.path = Path(path) if path else None
+        self.path = Path(os.path.expandvars(str(path))).expanduser() if path else None
         self.data = data
         self._format = format
         self._mime_type = self._get_mime_type()
@@ -160,7 +161,7 @@ class Audio:
         if path is not None and data is not None:
             raise ValueError("Only one of path or data can be provided")
 
-        self.path = Path(path) if path else None
+        self.path = Path(os.path.expandvars(str(path))).expanduser() if path else None
         self.data = data
         self._format = format
         self._mime_type = self._get_mime_type()
@@ -219,7 +220,7 @@ class File:
         if path is not None and data is not None:
             raise ValueError("Only one of path or data can be provided")
 
-        self.path = Path(path) if path else None
+        self.path = Path(os.path.expandvars(str(path))).expanduser() if path else None
         self.data = data
         self._format = format
         self._mime_type = self._get_mime_type()

--- a/tests/utilities/test_types.py
+++ b/tests/utilities/test_types.py
@@ -1,4 +1,5 @@
 import base64
+import os
 from types import EllipsisType
 from typing import Annotated, Any
 
@@ -131,6 +132,21 @@ class TestImage:
         assert image.data is None
         assert image._mime_type == "image/png"
 
+    def test_image_path_expansion_with_tilde(self):
+        """Test that ~ is expanded to the user's home directory."""
+        image = Image(path="~/test.png")
+        assert image.path is not None
+        assert not str(image.path).startswith("~")
+        assert str(image.path).startswith(os.path.expanduser("~"))
+
+    def test_image_path_expansion_with_env_var(self, monkeypatch):
+        """Test that environment variables are expanded."""
+        monkeypatch.setenv("TEST_PATH", "/tmp/test")
+        image = Image(path="$TEST_PATH/test.png")
+        assert image.path is not None
+        assert not str(image.path).startswith("$TEST_PATH")
+        assert str(image.path) == "/tmp/test/test.png"
+
     def test_image_initialization_with_data(self):
         """Test image initialization with data."""
         image = Image(data=b"test")
@@ -214,6 +230,21 @@ class TestAudio:
         assert audio.path is not None
         assert audio.data is None
         assert audio._mime_type == "audio/wav"
+
+    def test_audio_path_expansion_with_tilde(self):
+        """Test that ~ is expanded to the user's home directory."""
+        audio = Audio(path="~/test.wav")
+        assert audio.path is not None
+        assert not str(audio.path).startswith("~")
+        assert str(audio.path).startswith(os.path.expanduser("~"))
+
+    def test_audio_path_expansion_with_env_var(self, monkeypatch):
+        """Test that environment variables are expanded."""
+        monkeypatch.setenv("TEST_AUDIO_PATH", "/tmp/audio")
+        audio = Audio(path="$TEST_AUDIO_PATH/test.wav")
+        assert audio.path is not None
+        assert not str(audio.path).startswith("$TEST_AUDIO_PATH")
+        assert str(audio.path) == "/tmp/audio/test.wav"
 
     def test_audio_initialization_with_data(self):
         """Test audio initialization with data."""
@@ -311,6 +342,21 @@ class TestFile:
         assert file.path is not None
         assert file.data is None
         assert file._mime_type == "text/plain"
+
+    def test_file_path_expansion_with_tilde(self):
+        """Test that ~ is expanded to the user's home directory."""
+        file = File(path="~/test.txt")
+        assert file.path is not None
+        assert not str(file.path).startswith("~")
+        assert str(file.path).startswith(os.path.expanduser("~"))
+
+    def test_file_path_expansion_with_env_var(self, monkeypatch):
+        """Test that environment variables are expanded."""
+        monkeypatch.setenv("TEST_FILE_PATH", "/tmp/files")
+        file = File(path="$TEST_FILE_PATH/test.txt")
+        assert file.path is not None
+        assert not str(file.path).startswith("$TEST_FILE_PATH")
+        assert str(file.path) == "/tmp/files/test.txt"
 
     def test_file_initialization_with_data(self):
         """Test initialization with data and format."""


### PR DESCRIPTION
Handles expansion for both users (`~`) and env vars.

```python
@mcp.tool
def return_image() → Image:
    return Image(path='~/$DIR/image.png')
```