### PR TITLE
Ensure multi-client configurations use new ProxyClient

### DIFF
--- a/src/fastmcp/client/elicitation.py
+++ b/src/fastmcp/client/elicitation.py
@@ -53,6 +53,11 @@ def create_elicitation_callback(
             if not isinstance(result, ElicitResult):
                 result = ElicitResult(action="accept", content=result)
             content = to_jsonable_python(result.content)
+            if not isinstance(content, dict | None):
+                raise ValueError(
+                    "Elicitation responses must be serializable as a JSON object (dict). Received: "
+                    f"{result.content!r}"
+                )
             return MCPElicitResult(**result.model_dump() | {"content": content})
         except Exception as e:
             return mcp.types.ErrorData(

--- a/src/fastmcp/client/transports.py
+++ b/src/fastmcp/client/transports.py
@@ -773,8 +773,6 @@ class MCPConfigTransport(ClientTransport):
     """
 
     def __init__(self, config: MCPConfig | dict):
-        from fastmcp.client.client import Client
-
         if isinstance(config, dict):
             config = MCPConfig.from_dict(config)
         self.config = config
@@ -792,9 +790,9 @@ class MCPConfigTransport(ClientTransport):
             composite_server = FastMCP()
 
             for name, server in self.config.mcpServers.items():
-                server_client = Client(transport=server.to_transport())
                 composite_server.mount(
-                    prefix=name, server=FastMCP.as_proxy(server_client)
+                    prefix=name,
+                    server=FastMCP.as_proxy(backend=server.to_transport()),
                 )
 
             self.transport = FastMCPTransport(mcp=composite_server)

--- a/tests/client/test_openapi.py
+++ b/tests/client/test_openapi.py
@@ -48,8 +48,7 @@ def run_server(host: str, port: int, **kwargs) -> None:
 
 
 def run_proxy_server(host: str, port: int, shttp_url: str, **kwargs) -> None:
-    client = Client(transport=StreamableHttpTransport(shttp_url))
-    app = FastMCP.as_proxy(client)
+    app = FastMCP.as_proxy(StreamableHttpTransport(shttp_url))
     app.run(host=host, port=port, **kwargs)
 
 

--- a/tests/server/test_import_server.py
+++ b/tests/server/test_import_server.py
@@ -297,7 +297,7 @@ async def test_import_with_proxy_tools():
     def get_data(query: str) -> str:
         return f"Data for query: {query}"
 
-    proxy_app = FastMCP.as_proxy(Client(api_app))
+    proxy_app = FastMCP.as_proxy(api_app)
     await main_app.import_server(proxy_app, "api")
 
     async with Client(main_app) as client:
@@ -321,7 +321,7 @@ async def test_import_with_proxy_prompts():
         """Example greeting prompt."""
         return f"Hello, {name} from API!"
 
-    proxy_app = FastMCP.as_proxy(Client(api_app))
+    proxy_app = FastMCP.as_proxy(api_app)
     await main_app.import_server(proxy_app, "api")
 
     async with Client(main_app) as client:
@@ -349,7 +349,7 @@ async def test_import_with_proxy_resources():
             "base_url": "https://api.example.com",
         }
 
-    proxy_app = FastMCP.as_proxy(Client(api_app))
+    proxy_app = FastMCP.as_proxy(api_app)
     await main_app.import_server(proxy_app, "api")
 
     # Access the resource through the main app with the prefixed key
@@ -376,7 +376,7 @@ async def test_import_with_proxy_resource_templates():
     def create_user(name: str, email: str):
         return {"name": name, "email": email}
 
-    proxy_app = FastMCP.as_proxy(Client(api_app))
+    proxy_app = FastMCP.as_proxy(api_app)
     await main_app.import_server(proxy_app, "api")
 
     # Instantiate the template through the main app with the prefixed key

--- a/tests/server/test_mount.py
+++ b/tests/server/test_mount.py
@@ -777,9 +777,7 @@ class TestProxyServer:
             return f"Data for {query}"
 
         # Create proxy server
-        proxy_server = FastMCP.as_proxy(
-            Client(transport=FastMCPTransport(original_server))
-        )
+        proxy_server = FastMCP.as_proxy(FastMCPTransport(original_server))
 
         # Mount proxy server
         main_app = FastMCP("MainApp")
@@ -800,9 +798,7 @@ class TestProxyServer:
         original_server = FastMCP("OriginalServer")
 
         # Create proxy server
-        proxy_server = FastMCP.as_proxy(
-            Client(transport=FastMCPTransport(original_server))
-        )
+        proxy_server = FastMCP.as_proxy(FastMCPTransport(original_server))
 
         # Mount proxy server
         main_app = FastMCP("MainApp")
@@ -832,9 +828,7 @@ class TestProxyServer:
             return {"api_key": "12345"}
 
         # Create proxy server
-        proxy_server = FastMCP.as_proxy(
-            Client(transport=FastMCPTransport(original_server))
-        )
+        proxy_server = FastMCP.as_proxy(FastMCPTransport(original_server))
 
         # Mount proxy server
         main_app = FastMCP("MainApp")
@@ -856,9 +850,7 @@ class TestProxyServer:
             return f"Welcome, {name}!"
 
         # Create proxy server
-        proxy_server = FastMCP.as_proxy(
-            Client(transport=FastMCPTransport(original_server))
-        )
+        proxy_server = FastMCP.as_proxy(FastMCPTransport(original_server))
 
         # Mount proxy server
         main_app = FastMCP("MainApp")
@@ -914,7 +906,7 @@ class TestAsProxyKwarg:
     async def test_as_proxy_ignored_for_proxy_mounts_default(self):
         mcp = FastMCP("Main")
         sub = FastMCP("Sub")
-        sub_proxy = FastMCP.as_proxy(Client(transport=FastMCPTransport(sub)))
+        sub_proxy = FastMCP.as_proxy(FastMCPTransport(sub))
 
         mcp.mount(sub_proxy, "sub")
 
@@ -923,7 +915,7 @@ class TestAsProxyKwarg:
     async def test_as_proxy_ignored_for_proxy_mounts_false(self):
         mcp = FastMCP("Main")
         sub = FastMCP("Sub")
-        sub_proxy = FastMCP.as_proxy(Client(transport=FastMCPTransport(sub)))
+        sub_proxy = FastMCP.as_proxy(FastMCPTransport(sub))
 
         mcp.mount(sub_proxy, "sub", as_proxy=False)
 
@@ -932,7 +924,7 @@ class TestAsProxyKwarg:
     async def test_as_proxy_ignored_for_proxy_mounts_true(self):
         mcp = FastMCP("Main")
         sub = FastMCP("Sub")
-        sub_proxy = FastMCP.as_proxy(Client(transport=FastMCPTransport(sub)))
+        sub_proxy = FastMCP.as_proxy(FastMCPTransport(sub))
 
         mcp.mount(sub_proxy, "sub", as_proxy=True)
 

--- a/tests/tools/test_tool_transform.py
+++ b/tests/tools/test_tool_transform.py
@@ -725,7 +725,7 @@ class TestProxy:
     def proxy_server(self, mcp_server: FastMCP) -> FastMCP:
         from fastmcp.client.transports import FastMCPTransport
 
-        proxy = FastMCP.as_proxy(Client(transport=FastMCPTransport(mcp_server)))
+        proxy = FastMCP.as_proxy(FastMCPTransport(mcp_server))
         return proxy
 
     async def test_transform_proxy(self, proxy_server: FastMCP):


### PR DESCRIPTION
Closes #1043

Ensures that we use the new ProxyClient introduced in #1022 when creating proxies for multiple clients. This permits advanced features like logging/elicitation to be forwarded to the ultimate client.