### PR TITLE
feat: Add `--path` Option to CLI for HTTP/SSE Route

### DIFF
--- a/docs/patterns/cli.mdx
+++ b/docs/patterns/cli.mdx
@@ -45,6 +45,7 @@ This command runs the server directly in your current Python environment. You ar
 | Transport | `--transport`, `-t` | Transport protocol to use (`stdio`, `http`, or `sse`) |
 | Host | `--host` | Host to bind to when using http transport (default: 127.0.0.1) |
 | Port | `--port`, `-p` | Port to bind to when using http transport (default: 8000) |
+| Path | `--path` | Path to bind to when using http transport (default: `/mcp/` or `/sse/` for SSE) |
 | Log Level | `--log-level`, `-l` | Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL) |
 | No Banner | `--no-banner` | Disable the startup banner display |
 

--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -266,6 +266,13 @@ def run(
             help="Port to bind to when using http transport (default: 8000)",
         ),
     ] = None,
+    path: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            "--path",
+            help="The route path for the server (default: /mcp/ for http transport, /sse/ for sse transport)",
+        ),
+    ] = None,
     log_level: Annotated[
         Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] | None,
         cyclopts.Parameter(
@@ -305,6 +312,7 @@ def run(
             "transport": transport,
             "host": host,
             "port": port,
+            "path": path,
             "log_level": log_level,
             "server_args": server_args,
         },
@@ -316,6 +324,7 @@ def run(
             transport=transport,
             host=host,
             port=port,
+            path=path,
             log_level=log_level,
             server_args=server_args,
             show_banner=not no_banner,

--- a/src/fastmcp/cli/run.py
+++ b/src/fastmcp/cli/run.py
@@ -171,6 +171,7 @@ def run_command(
     transport: TransportType | None = None,
     host: str | None = None,
     port: int | None = None,
+    path: str | None = None,
     log_level: LogLevelType | None = None,
     server_args: list[str] | None = None,
     show_banner: bool = True,
@@ -182,6 +183,7 @@ def run_command(
         transport: Transport protocol to use
         host: Host to bind to when using http transport
         port: Port to bind to when using http transport
+        path: Path to bind to when using http transport
         log_level: Log level
         server_args: Additional arguments to pass to the server
         show_banner: Whether to show the server banner
@@ -204,6 +206,8 @@ def run_command(
         kwargs["host"] = host
     if port:
         kwargs["port"] = port
+    if path:
+        kwargs["path"] = path
     if log_level:
         kwargs["log_level"] = log_level
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -181,6 +181,7 @@ class TestRunCommand:
         assert "transport" not in bound.arguments
         assert "host" not in bound.arguments
         assert "port" not in bound.arguments
+        assert "path" not in bound.arguments
         assert "log_level" not in bound.arguments
         assert "no_banner" not in bound.arguments
 
@@ -196,6 +197,8 @@ class TestRunCommand:
                 "localhost",
                 "--port",
                 "8080",
+                "--path",
+                "/v1/mcp",
                 "--log-level",
                 "DEBUG",
                 "--no-banner",
@@ -207,6 +210,7 @@ class TestRunCommand:
         assert bound.arguments["transport"] == "http"
         assert bound.arguments["host"] == "localhost"
         assert bound.arguments["port"] == 8080
+        assert bound.arguments["path"] == "/v1/mcp"
         assert bound.arguments["log_level"] == "DEBUG"
         assert bound.arguments["no_banner"] is True
 
@@ -230,6 +234,7 @@ class TestRunCommand:
         assert "host" not in bound.arguments
         assert "port" not in bound.arguments
         assert "log_level" not in bound.arguments
+        assert "path" not in bound.arguments
 
 
 class TestWindowsSpecific:


### PR DESCRIPTION
Add `--path` CLI option to allow users to specify the route path when running the server with HTTP or SSE transport. The default remains `/mcp/` for HTTP and `/sse/` for SSE, but users can now override this as needed.