### PR TITLE
Fix OpenAPI tool name registration when modified by mcp_component_fn

### DIFF
--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -847,10 +847,13 @@ class FastMCPOpenAPI(FastMCP):
                     f"Using component as-is."
                 )
 
+        # Use the potentially modified tool name as the registration key
+        final_tool_name = tool.name
+
         # Register the tool by directly assigning to the tools dictionary
-        self._tool_manager._tools[tool_name] = tool
+        self._tool_manager._tools[final_tool_name] = tool
         logger.debug(
-            f"Registered TOOL: {tool_name} ({route.method} {route.path}) with tags: {route.tags}"
+            f"Registered TOOL: {final_tool_name} ({route.method} {route.path}) with tags: {route.tags}"
         )
 
     def _create_openapi_resource(
@@ -897,10 +900,13 @@ class FastMCPOpenAPI(FastMCP):
                     f"Using component as-is."
                 )
 
+        # Use the potentially modified resource URI as the registration key
+        final_resource_uri = str(resource.uri)
+
         # Register the resource by directly assigning to the resources dictionary
-        self._resource_manager._resources[str(resource.uri)] = resource
+        self._resource_manager._resources[final_resource_uri] = resource
         logger.debug(
-            f"Registered RESOURCE: {resource_uri} ({route.method} {route.path}) with tags: {route.tags}"
+            f"Registered RESOURCE: {final_resource_uri} ({route.method} {route.path}) with tags: {route.tags}"
         )
 
     def _create_openapi_template(
@@ -976,8 +982,11 @@ class FastMCPOpenAPI(FastMCP):
                     f"Using component as-is."
                 )
 
+        # Use the potentially modified template URI as the registration key
+        final_template_uri = template.uri_template
+
         # Register the template by directly assigning to the templates dictionary
-        self._resource_manager._templates[uri_template_str] = template
+        self._resource_manager._templates[final_template_uri] = template
         logger.debug(
-            f"Registered TEMPLATE: {uri_template_str} ({route.method} {route.path}) with tags: {route.tags}"
+            f"Registered TEMPLATE: {final_template_uri} ({route.method} {route.path}) with tags: {route.tags}"
         )


### PR DESCRIPTION
## Summary
Fixes the OpenAPI tool name registration bug where tools modified by `mcp_component_fn` were causing "Unknown tool" errors.

## Problem
When using `mcp_component_fn` to modify tool names in OpenAPI integration, tools were registered with their original names but accessible with modified names. This created a mismatch where:

1. Tool registered as: `v1_test_tool` 
2. Tool name modified to: `test_tool`
3. Client call to `test_tool` failed with "Unknown tool" error

## Solution  
Modified the registration flow in `FastMCPOpenAPI` to:
- Call `mcp_component_fn` **before** registering components
- Use the potentially modified name/URI as the registration key
- Apply fix to tools, resources, and templates consistently

Closes #1091

🤖 Generated with [Claude Code](https://claude.ai/code)