### PR TITLE
Ensure the CLI accepts "streamable-http" as a valid transport

### DIFF
--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -246,7 +246,7 @@ def run(
     server_spec: str,
     *,
     transport: Annotated[
-        Literal["stdio", "http", "sse"] | None,
+        run_module.TransportType | None,
         cyclopts.Parameter(
             name=["--transport", "-t"],
             help="Transport protocol to use",

--- a/src/fastmcp/cli/run.py
+++ b/src/fastmcp/cli/run.py
@@ -11,7 +11,7 @@ from fastmcp.utilities.logging import get_logger
 logger = get_logger("cli.run")
 
 # Type aliases for better type safety
-TransportType = Literal["stdio", "http", "sse"]
+TransportType = Literal["stdio", "http", "sse", "streamable-http"]
 LogLevelType = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -236,6 +236,32 @@ class TestRunCommand:
         assert "log_level" not in bound.arguments
         assert "path" not in bound.arguments
 
+    def test_run_command_transport_aliases(self):
+        """Test that both 'http' and 'streamable-http' are accepted as valid transport options."""
+        # Test with 'http' transport
+        command, bound, _ = app.parse_args(
+            [
+                "run",
+                "server.py",
+                "--transport",
+                "http",
+            ]
+        )
+        assert command is not None
+        assert bound.arguments["transport"] == "http"
+
+        # Test with 'streamable-http' transport
+        command, bound, _ = app.parse_args(
+            [
+                "run",
+                "server.py",
+                "--transport",
+                "streamable-http",
+            ]
+        )
+        assert command is not None
+        assert bound.arguments["transport"] == "streamable-http"
+
 
 class TestWindowsSpecific:
     """Test Windows-specific functionality."""


### PR DESCRIPTION
When refactoring the CLI in #1062, the "streamable-http" alias was inadvertently dropped as a valid transport for fastmcp run, which was a breaking change (and not one we want!). "streamable-http" and "http" are interchangeable aliases. This is a high priority fix and will be released ASAP.