### PR TITLE
Scope based authorization

### DIFF
--- a/docs/servers/auth/bearer.mdx
+++ b/docs/servers/auth/bearer.mdx
@@ -236,3 +236,218 @@ async def get_my_data(ctx: Context) -> dict:
 </ParamField>
 </Card>
 
+## Scope-Based Authorization
+
+FastMCP supports scope-based authorization, allowing you to restrict access to specific tools, resources, or prompts based on the scopes present in the access token. This provides fine-grained control over what authenticated users can access.
+
+### Tool Scope Validation
+
+You can require specific scopes for tools using the `required_scope` parameter:
+
+```python
+from fastmcp import FastMCP
+from fastmcp.server.auth import BearerAuthProvider
+
+mcp = FastMCP(name="My Server", auth=auth)
+
+# Require specific scope for this tool
+@mcp.tool(required_scope="admin:write")
+async def admin_action() -> str:
+    return "Admin action completed"
+
+# Default scope is the tool name
+@mcp.tool(required_scope="user_data")  # or omit for default
+async def user_data() -> str:
+    return "User data retrieved"
+
+# No scope required (accessible to all authenticated users)
+@mcp.tool
+async def public_tool() -> str:
+    return "Public data"
+```
+
+### Default Scope Behavior
+
+When `required_scope` is not specified, FastMCP uses the tool name as the default required scope:
+
+```python
+# These two are equivalent:
+@mcp.tool
+async def get_user_profile() -> str:
+    return "Profile data"
+
+@mcp.tool(required_scope="get_user_profile")
+async def get_user_profile() -> str:
+    return "Profile data"
+```
+
+### Error Handling
+
+FastMCP provides distinct error types for authentication vs authorization failures:
+
+```python
+from fastmcp.exceptions import AuthenticationError, AuthorizationError
+
+@mcp.tool
+async def sensitive_operation() -> str:
+    # Manual scope checking (usually not needed)
+    access_token = get_access_token()
+    
+    if not access_token:
+        raise AuthenticationError("No access token provided")
+    
+    if "sensitive:read" not in access_token.scopes:
+        raise AuthorizationError("Insufficient permissions: 'sensitive:read' scope required")
+    
+    return "Sensitive data"
+```
+
+### Client Error Handling
+
+Clients can distinguish between authentication and authorization errors:
+
+```python
+from fastmcp.client import FastMCPClient
+from fastmcp.exceptions import AuthenticationError, AuthorizationError
+
+async def call_protected_tool():
+    try:
+        result = await client.call_tool("admin_action")
+        return result
+    except AuthenticationError as e:
+        # Token is invalid, expired, or missing
+        print(f"Authentication failed: {e}")
+        # Handle by refreshing token or re-authenticating
+    except AuthorizationError as e:
+        # Token is valid but lacks required scopes
+        print(f"Authorization failed: {e}")
+        # Handle by requesting additional scopes or showing permission denied
+```
+
+### Debugging Scope Validation
+
+If scope validation isn't working as expected, you can create a debugging script to troubleshoot:
+
+```python
+import logging
+from fastmcp import FastMCP
+from fastmcp.server.auth import BearerAuthProvider
+from fastmcp.server.auth.providers.bearer import RSAKeyPair
+
+# Enable debug logging
+logging.basicConfig(level=logging.DEBUG)
+
+# Create key pair for testing
+key_pair = RSAKeyPair.generate()
+
+# Configure auth provider
+auth = BearerAuthProvider(
+    public_key=key_pair.public_key,
+    issuer="https://debug.example.com",
+    audience="debug-server"
+)
+
+mcp = FastMCP(name="Debug Server", auth=auth)
+
+@mcp.tool(required_scope="admin:write")
+async def admin_tool() -> str:
+    return "Admin operation completed"
+
+@mcp.tool()  # Uses default scope: "user_tool"
+async def user_tool() -> str:
+    return "User operation completed"
+
+# Test tokens with different scopes
+test_tokens = {
+    "empty_scopes": key_pair.create_token(
+        subject="test-user",
+        issuer="https://debug.example.com",
+        audience="debug-server",
+        scopes=[]  # Empty scopes
+    ),
+    "admin_token": key_pair.create_token(
+        subject="admin-user",
+        issuer="https://debug.example.com",
+        audience="debug-server",
+        scopes=["admin:write", "admin:read"]
+    ),
+    "user_token": key_pair.create_token(
+        subject="regular-user",
+        issuer="https://debug.example.com",
+        audience="debug-server",
+        scopes=["user_tool", "profile:read"]
+    )
+}
+
+# Print tokens for testing
+for token_type, token in test_tokens.items():
+    print(f"{token_type}: {token}")
+```
+
+### Testing with cURL
+
+You can test scope validation using cURL:
+
+```bash
+# Test with empty scopes (should fail)
+curl -X POST http://localhost:8000/mcp/v1/tools/call \
+  -H "Authorization: Bearer $EMPTY_SCOPE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "admin_tool", "arguments": {}}'
+
+# Test with admin scope (should succeed)
+curl -X POST http://localhost:8000/mcp/v1/tools/call \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "admin_tool", "arguments": {}}'
+```
+
+### Common Issues
+
+<Warning>
+**Scope validation only works with HTTP transports** (`http` and `sse`). It does not apply to `stdio` transport.
+</Warning>
+
+1. **No error when scopes are missing**: Ensure `ErrorHandlingMiddleware` is included in your server configuration
+2. **Scope validation not triggered**: Verify that `auth` is properly configured on your FastMCP instance
+3. **Default scope not working**: Check that tool names match expected scope names
+4. **Token parsing issues**: Verify token format and signature validation
+
+### Advanced Debugging
+
+For detailed debugging, you can monkey-patch the validation method:
+
+```python
+import logging
+from fastmcp.server.server import FastMCPServer
+
+# Store original method
+original_validate = FastMCPServer._validate_tool_scope
+
+def debug_validate_tool_scope(self, tool_name: str, required_scope: str | None) -> None:
+    logger = logging.getLogger(__name__)
+    logger.debug(f"=== SCOPE VALIDATION DEBUG ===")
+    logger.debug(f"Tool name: {tool_name}")
+    logger.debug(f"Required scope: {required_scope}")
+    logger.debug(f"Auth provider: {self.auth}")
+    
+    try:
+        access_token = self.get_access_token()
+        logger.debug(f"Access token: {access_token}")
+        if access_token:
+            logger.debug(f"Token scopes: {access_token.scopes}")
+        
+        # Call original method
+        result = original_validate(self, tool_name, required_scope)
+        logger.debug(f"Validation result: SUCCESS")
+        return result
+    except Exception as e:
+        logger.debug(f"Validation result: FAILED - {e}")
+        raise
+
+# Apply monkey patch
+FastMCPServer._validate_tool_scope = debug_validate_tool_scope
+```
+
+This debugging approach helps identify issues with token parsing, scope extraction, or validation logic.
+

--- a/examples/scope_example.py
+++ b/examples/scope_example.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating scope-based authorization in FastMCP.
+
+This example shows how to use the required_scope parameter in tool decorators
+to control access to specific tools based on OAuth scopes. It also demonstrates
+how clients can distinguish between authentication and authorization errors.
+"""
+
+import httpx
+from fastmcp import FastMCP
+from fastmcp.server.auth import BearerAuthProvider
+from fastmcp.server.auth.providers.bearer import RSAKeyPair
+from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
+from fastmcp.client import Client
+from fastmcp.client.auth.bearer import BearerAuth
+from fastmcp.exceptions import AuthenticationError, AuthorizationError, ToolError
+
+# Generate a key pair for testing
+key_pair = RSAKeyPair.generate()
+
+# Configure bearer auth with the public key
+auth = BearerAuthProvider(
+    public_key=key_pair.public_key,
+    issuer="https://example.com",
+    audience="scope-demo"
+)
+
+# Create FastMCP server with authentication and error handling middleware
+mcp = FastMCP(
+    name="Scope Authorization Demo", 
+    auth=auth,
+    middleware=[ErrorHandlingMiddleware()]
+)
+
+@mcp.tool
+def public_tool(message: str) -> str:
+    """A tool that anyone can use (no specific scope required)."""
+    return f"Public response: {message}"
+
+@mcp.tool(required_scope="read")
+def read_data(query: str) -> str:
+    """A tool that requires 'read' scope."""
+    return f"Reading data: {query}"
+
+@mcp.tool(required_scope="write")
+def write_data(data: str) -> str:
+    """A tool that requires 'write' scope."""
+    return f"Writing data: {data}"
+
+@mcp.tool(required_scope="admin")
+def admin_action(action: str) -> str:
+    """A tool that requires 'admin' scope."""
+    return f"Admin action: {action}"
+
+
+async def example_client_usage():
+    """Demonstrate how clients can handle authentication vs authorization errors."""
+    
+    # Start the server (in real usage, this would be running separately)
+    server_url = "http://localhost:8080/mcp/"
+    
+    print("=== Scope-based Authorization Example ===\n")
+    
+    # Example 1: Valid token with sufficient scope
+    print("1. Testing with valid token and sufficient scope:")
+    read_token = key_pair.create_token(
+        subject="user-1",
+        issuer="https://example.com",
+        audience="scope-demo",
+        scopes=["read", "write"]
+    )
+    
+    try:
+        async with Client(server_url, auth=BearerAuth(read_token)) as client:
+            result = await client.call_tool("read_data", {"query": "test"})
+            print(f"   ✓ Success: {result.data}")
+    except Exception as e:
+        print(f"   ✗ Error: {e}")
+    
+    # Example 2: Authentication error (invalid token)
+    print("\n2. Testing with invalid token (authentication error):")
+    try:
+        async with Client(server_url, auth=BearerAuth("invalid.token")) as client:
+            await client.call_tool("read_data", {"query": "test"})
+    except AuthenticationError as e:
+        print(f"   ✓ Caught authentication error: {e}")
+        print("   → Client should: Re-authenticate, refresh token, or redirect to login")
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 401:
+            print(f"   ✓ Caught HTTP 401 authentication error: {e.response.status_code} {e.response.reason_phrase}")
+            print("   → Client should: Re-authenticate, refresh token, or redirect to login")
+    except Exception as e:
+        print(f"   ✗ Unexpected error: {e}")
+    
+    # Example 3: Authorization error (valid token, insufficient scope)
+    print("\n3. Testing with valid token but insufficient scope (authorization error):")
+    read_only_token = key_pair.create_token(
+        subject="user-2",
+        issuer="https://example.com",
+        audience="scope-demo",
+        scopes=["read"]  # Only has read, not write
+    )
+    
+    try:
+        async with Client(server_url, auth=BearerAuth(read_only_token)) as client:
+            await client.call_tool("write_data", {"data": "test"})
+    except AuthorizationError as e:
+        print(f"   ✓ Caught authorization error: {e}")
+        print("   → Client should: Request additional scopes, show error to user, or disable feature")
+    except httpx.HTTPStatusError as e:
+        print(f"   ✗ Unexpected HTTP error: {e.response.status_code}")
+    except Exception as e:
+        print(f"   ✗ Unexpected error: {e}")
+    
+    # Example 4: Comprehensive error handling pattern
+    print("\n4. Comprehensive error handling pattern:")
+    
+    async def safe_tool_call(client, tool_name, arguments):
+        """Example of comprehensive error handling for tool calls."""
+        try:
+            result = await client.call_tool(tool_name, arguments)
+            return {"success": True, "data": result.data}
+        
+        except AuthenticationError as e:
+            # Token is invalid, expired, or malformed
+            return {"success": False, "error": "auth_required", "message": str(e)}
+        
+        except AuthorizationError as e:
+            # Token is valid but lacks required scope
+            return {"success": False, "error": "insufficient_scope", "message": str(e)}
+        
+        except ToolError as e:
+            # General tool execution error
+            return {"success": False, "error": "tool_error", "message": str(e)}
+        
+        except httpx.HTTPStatusError as e:
+            # HTTP-level error (network, server issues)
+            if e.response.status_code == 401:
+                return {"success": False, "error": "auth_required", "message": "Authentication required"}
+            elif e.response.status_code == 403:
+                return {"success": False, "error": "forbidden", "message": "Access forbidden"}
+            else:
+                return {"success": False, "error": "http_error", "message": f"HTTP {e.response.status_code}"}
+        
+        except Exception as e:
+            # Unexpected error
+            return {"success": False, "error": "unknown", "message": str(e)}
+    
+    # Test different error scenarios
+    test_cases = [
+        ("valid_token_sufficient_scope", read_token, "read_data", {"query": "test"}),
+        ("invalid_token", "invalid.token", "read_data", {"query": "test"}),
+        ("insufficient_scope", read_only_token, "admin_action", {"action": "delete"}),
+    ]
+    
+    for test_name, token, tool_name, arguments in test_cases:
+        print(f"\n   Testing {test_name}:")
+        try:
+            async with Client(server_url, auth=BearerAuth(token)) as client:
+                result = await safe_tool_call(client, tool_name, arguments)
+                if result["success"]:
+                    print(f"      ✓ Success: {result['data']}")
+                else:
+                    print(f"      ✗ Error ({result['error']}): {result['message']}")
+        except Exception as e:
+            print(f"      ✗ Unexpected error: {e}")
+    
+    print("\n=== Error Handling Guidelines ===")
+    print("• AuthenticationError: Invalid/expired token")
+    print("  → Actions: Re-authenticate, refresh token, redirect to login")
+    print("• AuthorizationError: Valid token, insufficient scope")
+    print("  → Actions: Request additional scopes, disable feature, show error to user")
+    print("• ToolError: General tool execution issues")
+    print("  → Actions: Show error to user, log error, retry if appropriate")
+    print("• HTTPStatusError: Network/server issues")
+    print("  → Actions: Handle by status code, implement retry logic for transient errors")
+
+
+if __name__ == "__main__":
+    print("FastMCP Scope-based Authorization Example")
+    print("=" * 50)
+    print()
+    print("This example demonstrates:")
+    print("1. How to add scope requirements to tools")
+    print("2. How to distinguish authentication vs authorization errors")
+    print("3. Best practices for error handling in MCP clients")
+    print()
+    print("To run this example:")
+    print("1. Start the server: python -m fastmcp.cli run scope_example:mcp")
+    print("2. Connect clients with appropriate tokens")
+    print("3. Observe different error types and handling patterns")
+    
+    # Uncomment to run the client example (requires running server)
+    # import asyncio
+    # asyncio.run(example_client_usage()) 

--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -863,7 +863,16 @@ class Client(Generic[ClientTransportT]):
         data = None
         if result.isError and raise_on_error:
             msg = cast(mcp.types.TextContent, result.content[0]).text
-            raise ToolError(msg)
+            
+            # Check for specific error codes in the error message to distinguish error types
+            from fastmcp.exceptions import AuthenticationError, AuthorizationError
+            
+            if "Authentication failed:" in msg:
+                raise AuthenticationError(msg.replace("Authentication failed: ", ""))
+            elif "Authorization failed:" in msg:
+                raise AuthorizationError(msg.replace("Authorization failed: ", ""))
+            else:
+                raise ToolError(msg)
         elif result.structuredContent:
             try:
                 if name not in self.session._tool_output_schemas:

--- a/src/fastmcp/contrib/mcp_mixin/mcp_mixin.py
+++ b/src/fastmcp/contrib/mcp_mixin/mcp_mixin.py
@@ -29,6 +29,7 @@ def mcp_tool(
     exclude_args: list[str] | None = None,
     serializer: Callable[[Any], str] | None = None,
     enabled: bool | None = None,
+    required_scope: str | None = None,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorator to mark a method as an MCP tool for later registration."""
 
@@ -41,6 +42,7 @@ def mcp_tool(
             "exclude_args": exclude_args,
             "serializer": serializer,
             "enabled": enabled,
+            "required_scope": required_scope,
         }
         call_args = {k: v for k, v in call_args.items() if v is not None}
         setattr(func, _MCP_REGISTRATION_TOOL_ATTR, call_args)

--- a/src/fastmcp/exceptions.py
+++ b/src/fastmcp/exceptions.py
@@ -23,6 +23,14 @@ class PromptError(FastMCPError):
     """Error in prompt operations."""
 
 
+class AuthenticationError(FastMCPError):
+    """Error in authentication - invalid, expired, or malformed token."""
+
+
+class AuthorizationError(FastMCPError):
+    """Error in authorization - valid token but insufficient permissions/scope."""
+
+
 class InvalidSignature(Exception):
     """Invalid signature for use with FastMCP."""
 

--- a/src/fastmcp/server/middleware/error_handling.py
+++ b/src/fastmcp/server/middleware/error_handling.py
@@ -86,7 +86,18 @@ class ErrorHandlingMiddleware(Middleware):
         # Map common exceptions to appropriate MCP error codes
         error_type = type(error)
 
-        if error_type in (ValueError, TypeError):
+        # FastMCP specific error types
+        from fastmcp.exceptions import AuthenticationError, AuthorizationError
+        
+        if error_type is AuthenticationError:
+            return McpError(
+                ErrorData(code=-32001, message=f"Authentication failed: {str(error)}")
+            )
+        elif error_type is AuthorizationError:
+            return McpError(
+                ErrorData(code=-32002, message=f"Authorization failed: {str(error)}")
+            )
+        elif error_type in (ValueError, TypeError):
             return McpError(
                 ErrorData(code=-32602, message=f"Invalid params: {str(error)}")
             )

--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -105,6 +105,10 @@ class Tool(FastMCPComponent):
         Callable[[Any], str] | None,
         Field(description="Optional custom serializer for tool results"),
     ] = None
+    required_scope: Annotated[
+        str | None,
+        Field(description="Required scope for tool authorization. If not provided, defaults to tool name"),
+    ] = None
 
     def enable(self) -> None:
         super().enable()
@@ -152,6 +156,7 @@ class Tool(FastMCPComponent):
         output_schema: dict[str, Any] | None | NotSetT | Literal[False] = NotSet,
         serializer: Callable[[Any], str] | None = None,
         enabled: bool | None = None,
+        required_scope: str | None = None,
     ) -> FunctionTool:
         """Create a Tool from a function."""
         return FunctionTool.from_function(
@@ -165,6 +170,7 @@ class Tool(FastMCPComponent):
             output_schema=output_schema,
             serializer=serializer,
             enabled=enabled,
+            required_scope=required_scope,
         )
 
     async def run(self, arguments: dict[str, Any]) -> ToolResult:
@@ -192,6 +198,7 @@ class Tool(FastMCPComponent):
         output_schema: dict[str, Any] | None | Literal[False] = None,
         serializer: Callable[[Any], str] | None = None,
         enabled: bool | None = None,
+        required_scope: str | None = None,
     ) -> TransformedTool:
         from fastmcp.tools.tool_transform import TransformedTool
 
@@ -206,6 +213,7 @@ class Tool(FastMCPComponent):
             output_schema=output_schema,
             serializer=serializer,
             enabled=enabled,
+            required_scope=required_scope,
         )
 
 
@@ -225,6 +233,7 @@ class FunctionTool(Tool):
         output_schema: dict[str, Any] | None | NotSetT | Literal[False] = NotSet,
         serializer: Callable[[Any], str] | None = None,
         enabled: bool | None = None,
+        required_scope: str | None = None,
     ) -> FunctionTool:
         """Create a Tool from a function."""
 
@@ -257,6 +266,7 @@ class FunctionTool(Tool):
             tags=tags or set(),
             serializer=serializer,
             enabled=enabled if enabled is not None else True,
+            required_scope=required_scope,
         )
 
     async def run(self, arguments: dict[str, Any]) -> ToolResult:

--- a/src/fastmcp/tools/tool_transform.py
+++ b/src/fastmcp/tools/tool_transform.py
@@ -333,6 +333,7 @@ class TransformedTool(Tool):
         output_schema: dict[str, Any] | None | Literal[False] = None,
         serializer: Callable[[Any], str] | None = None,
         enabled: bool | None = None,
+        required_scope: str | None = None,
     ) -> TransformedTool:
         """Create a transformed tool from a parent tool.
 
@@ -521,6 +522,7 @@ class TransformedTool(Tool):
             serializer=serializer or tool.serializer,
             transform_args=transform_args,
             enabled=enabled if enabled is not None else True,
+            required_scope=required_scope,
         )
 
         return transformed_tool

--- a/tests/server/test_scope_authorization.py
+++ b/tests/server/test_scope_authorization.py
@@ -1,0 +1,232 @@
+"""Test scope-based authorization for tools."""
+from collections.abc import Generator
+from typing import Any
+
+import httpx
+import pytest
+
+from fastmcp import FastMCP
+from fastmcp.client import Client
+from fastmcp.client.auth.bearer import BearerAuth
+from fastmcp.server.auth.providers.bearer import BearerAuthProvider, RSAKeyPair
+from fastmcp.utilities.tests import run_server_in_process
+from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
+
+
+@pytest.fixture(scope="module")
+def rsa_key_pair() -> RSAKeyPair:
+    """Generate a key pair for testing."""
+    return RSAKeyPair.generate()
+
+
+def run_mcp_server_with_scopes(
+    public_key: str,
+    host: str,
+    port: int,
+    auth_kwargs: dict[str, Any] | None = None,
+    run_kwargs: dict[str, Any] | None = None,
+) -> None:
+    """Run an MCP server with scope-based authorization."""
+    auth_provider = BearerAuthProvider(
+        public_key=public_key,
+        issuer="https://test.example.com",
+        audience="test-scope",
+        **(auth_kwargs or {}),
+    )
+    
+    # Create server with error handling middleware
+    mcp = FastMCP(
+        name="Scope Test Server",
+        auth=auth_provider,
+        middleware=[ErrorHandlingMiddleware()],
+    )
+    
+    @mcp.tool
+    def public_tool(message: str) -> str:
+        """A tool that anyone can use (no specific scope required)."""
+        return f"Public: {message}"
+    
+    @mcp.tool(required_scope="read")
+    def read_tool(data: str) -> str:
+        """A tool that requires 'read' scope."""
+        return f"Read: {data}"
+    
+    @mcp.tool(required_scope="write")
+    def write_tool(data: str) -> str:
+        """A tool that requires 'write' scope."""
+        return f"Write: {data}"
+    
+    @mcp.tool(required_scope="admin")
+    def admin_tool(action: str) -> str:
+        """A tool that requires 'admin' scope."""
+        return f"Admin: {action}"
+    
+    # Run the server
+    mcp.run(host=host, port=port, **(run_kwargs or {}))
+
+
+@pytest.fixture(scope="module")
+def scope_server_url(rsa_key_pair: RSAKeyPair) -> Generator[str]:
+    """Create a running MCP server with scope-based authorization."""
+    with run_server_in_process(
+        run_mcp_server_with_scopes,
+        public_key=rsa_key_pair.public_key,
+        run_kwargs=dict(transport="http"),
+    ) as url:
+        yield f"{url}/mcp/"
+
+
+class TestScopeBasedAuthorization:
+    """Test scope-based authorization for tool execution."""
+
+    @pytest.mark.asyncio
+    async def test_tool_with_sufficient_scope(self, scope_server_url: str, rsa_key_pair: RSAKeyPair):
+        """Test that tools work when user has sufficient scope."""
+        # Create a token with read scope
+        token = rsa_key_pair.create_token(
+            subject="test-user",
+            issuer="https://test.example.com",
+            audience="test-scope",
+            scopes=["read"]
+        )
+
+        # Test that we can call the read tool
+        async with Client(scope_server_url, auth=BearerAuth(token)) as client:
+            result = await client.call_tool("read_tool", {"data": "test"})
+            assert result.data == "Read: test"
+
+    @pytest.mark.asyncio
+    async def test_tool_with_insufficient_scope(self, scope_server_url: str, rsa_key_pair: RSAKeyPair):
+        """Test that tools fail when user lacks required scope."""
+        # Create a token with only read scope
+        token = rsa_key_pair.create_token(
+            subject="test-user",
+            issuer="https://test.example.com",
+            audience="test-scope",
+            scopes=["read"]
+        )
+
+        # Test that we cannot call the write tool
+        from fastmcp.exceptions import AuthorizationError
+        
+        with pytest.raises(AuthorizationError) as exc_info:
+            async with Client(scope_server_url, auth=BearerAuth(token)) as client:
+                await client.call_tool("write_tool", {"data": "test"})
+        
+        assert "Access denied" in str(exc_info.value)
+        assert "requires scope 'write'" in str(exc_info.value)
+        assert "only scopes ['read'] are available" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_tool_with_multiple_scopes(self, scope_server_url: str, rsa_key_pair: RSAKeyPair):
+        """Test that tools work when user has multiple scopes."""
+        # Create a token with read and write scopes
+        token = rsa_key_pair.create_token(
+            subject="test-user",
+            issuer="https://test.example.com",
+            audience="test-scope",
+            scopes=["read", "write"]
+        )
+
+        # Test that we can call both read and write tools
+        async with Client(scope_server_url, auth=BearerAuth(token)) as client:
+            read_result = await client.call_tool("read_tool", {"data": "test"})
+            assert read_result.data == "Read: test"
+            
+            write_result = await client.call_tool("write_tool", {"data": "test"})
+            assert write_result.data == "Write: test"
+
+    @pytest.mark.asyncio
+    async def test_tool_with_admin_scope(self, scope_server_url: str, rsa_key_pair: RSAKeyPair):
+        """Test that admin tools require admin scope."""
+        # Create a token with admin scope
+        token = rsa_key_pair.create_token(
+            subject="admin-user",
+            issuer="https://test.example.com",
+            audience="test-scope",
+            scopes=["admin"]
+        )
+
+        # Test that we can call the admin tool
+        async with Client(scope_server_url, auth=BearerAuth(token)) as client:
+            result = await client.call_tool("admin_tool", {"action": "delete"})
+            assert result.data == "Admin: delete"
+
+    @pytest.mark.asyncio
+    async def test_tool_scope_defaults_to_tool_name(self, scope_server_url: str, rsa_key_pair: RSAKeyPair):
+        """Test that default scope is the tool name."""
+        # Create a token with 'public_tool' scope (matches the tool name)
+        token = rsa_key_pair.create_token(
+            subject="test-user",
+            issuer="https://test.example.com",
+            audience="test-scope",
+            scopes=["public_tool"]
+        )
+
+        # Test that we can call the public tool
+        async with Client(scope_server_url, auth=BearerAuth(token)) as client:
+            result = await client.call_tool("public_tool", {"message": "test"})
+            assert result.data == "Public: test"
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_access_denied(self, scope_server_url: str):
+        """Test that unauthorized access is denied."""
+        # Test without any authentication
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            async with Client(scope_server_url) as client:
+                await client.call_tool("read_tool", {"data": "test"})
+        
+        assert exc_info.value.response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_authentication_vs_authorization_errors(self, scope_server_url: str, rsa_key_pair: RSAKeyPair):
+        """Test that authentication errors are distinct from authorization errors."""
+        from fastmcp.exceptions import AuthorizationError
+        
+        # Test 1: Authentication error (invalid token)
+        invalid_token = "invalid.jwt.token"
+        with pytest.raises(httpx.HTTPStatusError) as auth_exc_info:
+            async with Client(scope_server_url, auth=BearerAuth(invalid_token)) as client:
+                await client.call_tool("read_tool", {"data": "test"})
+        
+        # Should be 401 Unauthorized for authentication failure
+        assert auth_exc_info.value.response.status_code == 401
+        
+        # Test 2: Authorization error (valid token, insufficient scope)
+        valid_token_wrong_scope = rsa_key_pair.create_token(
+            subject="test-user",
+            issuer="https://test.example.com",
+            audience="test-scope",
+            scopes=["read"]  # Has read but trying to call write
+        )
+        
+        with pytest.raises(AuthorizationError) as authz_exc_info:
+            async with Client(scope_server_url, auth=BearerAuth(valid_token_wrong_scope)) as client:
+                await client.call_tool("write_tool", {"data": "test"})
+        
+        # Should be AuthorizationError with specific message
+        assert "Access denied" in str(authz_exc_info.value)
+        assert "requires scope 'write'" in str(authz_exc_info.value)
+        
+        # Test 3: Verify client can catch errors differently
+        try:
+            async with Client(scope_server_url, auth=BearerAuth("invalid")) as client:
+                await client.call_tool("read_tool", {"data": "test"})
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                auth_error_caught = True
+            else:
+                auth_error_caught = False
+        except AuthorizationError:
+            auth_error_caught = False
+        
+        try:
+            async with Client(scope_server_url, auth=BearerAuth(valid_token_wrong_scope)) as client:
+                await client.call_tool("write_tool", {"data": "test"})
+        except httpx.HTTPStatusError:
+            authz_error_caught = False
+        except AuthorizationError:
+            authz_error_caught = True
+        
+        assert auth_error_caught, "Should catch authentication error as HTTPStatusError 401"
+        assert authz_error_caught, "Should catch authorization error as AuthorizationError" 


### PR DESCRIPTION
This PR adds scope-based authorization.

Required scope is configurable:

```python
# Method 1: Tool without explicit required_scope (should default to tool name)
@mcp.tool
def my_tool():
    pass

# Method 2: Tool with explicit required_scope  
@mcp.tool(required_scope="admin")
def admin_tool():
    pass
```

It's only enabled when authentication is enabled and is backward compatible.

Added errorhandling to help distinguish authentication and authorization errors:

```python 
from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware

mcp = FastMCP(
    name="My Server",
    auth=auth_provider,
    middleware=[ErrorHandlingMiddleware()]  # ← This is crucial!
)
```

Added docs to document the process. I have a POC and working demo here: https://github.com/gallettilance/agentic-auth