### PR TITLE
fix: replace oneOf with anyOf in OpenAPI output schemas

### DIFF
--- a/src/fastmcp/utilities/openapi.py
+++ b/src/fastmcp/utilities/openapi.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Generic, Literal, TypeVar, cast
 
 from openapi_pydantic import (
     OpenAPI,
@@ -1150,6 +1150,20 @@ def _combine_schemas(route: HTTPRoute) -> dict[str, Any]:
     return result
 
 
+def _adjust_union_types(
+    schema: dict[str, Any] | list[Any],
+) -> dict[str, Any] | list[Any]:
+    """Recursively replace 'oneOf' with 'anyOf' in schema to handle overlapping unions."""
+    if isinstance(schema, dict):
+        if "oneOf" in schema:
+            schema["anyOf"] = schema.pop("oneOf")
+        for k, v in schema.items():
+            schema[k] = _adjust_union_types(v)
+    elif isinstance(schema, list):
+        return [_adjust_union_types(item) for item in schema]
+    return schema
+
+
 def extract_output_schema_from_responses(
     responses: dict[str, ResponseInfo], schema_definitions: dict[str, Any] | None = None
 ) -> dict[str, Any] | None:
@@ -1237,5 +1251,8 @@ def extract_output_schema_from_responses(
 
     # Use compress_schema to remove unused definitions
     output_schema = compress_schema(output_schema)
+
+    # Adjust union types to handle overlapping unions
+    output_schema = cast(dict[str, Any], _adjust_union_types(output_schema))
 
     return output_schema


### PR DESCRIPTION
# Replace `oneOf` with `anyOf`

This PR adds `_adjust_union_types`  applied in the `extract_output_schema_from_responses` function.

## Problem
The newly introduced output schema support cause validation errors for OpenAPI schemas with `oneOf` unions when data is valid under multiple schema alternatives, causing errors like:
```bash
Output validation error: {...} 
is valid under each of {'$ref': '#/$defs/TmxCompanyNewsData'}, {'$ref': '#/$defs/FMPCompanyNewsData'}, {'$ref': '#/$defs/YFinanceCompanyNewsData'}
```

## Solution
Replace `oneOf` with `anyOf` to allow overlapping matches

All other test are still passing:

```bash
tests/utilities/openapi/test_openapi_output_schemas.py::test_adjust_union_types PASSED      [ 99%]
tests/utilities/openapi/test_openapi_output_schemas.py::test_extract_output_schema_converts_oneOf_to_anyOf PASSED [100%]

======================================= 122 passed in 0.59s =======================================
```