### PR TITLE
xfail when github token is not set ('' or None)

### DIFF
--- a/tests/integration_tests/test_github_mcp_remote.py
+++ b/tests/integration_tests/test_github_mcp_remote.py
@@ -16,8 +16,8 @@ FASTMCP_GITHUB_TOKEN = os.getenv("FASTMCP_GITHUB_TOKEN")
 
 # Skip tests if no GitHub token is available
 pytestmark = pytest.mark.xfail(
-    FASTMCP_GITHUB_TOKEN is None,
-    reason="The FASTMCP_GITHUB_TOKEN environment variable is not set",
+    not FASTMCP_GITHUB_TOKEN,
+    reason="The FASTMCP_GITHUB_TOKEN environment variable is not set or empty",
 )
 
 


### PR DESCRIPTION
In #1119 integration tests are failing - I think the token is being loaded as "" but the xfail is only triggered for None, so this PR changes that logic. It is expected that PRs from forks would not be able to load the token in general.