### PR TITLE
Fix OpenAPI empty parameters

### DIFF
--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -368,7 +368,7 @@ class OpenAPITool(Tool):
 
                     # Handle deepObject style for object parameters
                     if (
-                        param_style == "deepObject" 
+                        param_style == "deepObject"
                         and isinstance(param_value, dict)
                         and len(param_value) > 0
                     ):

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -367,7 +367,11 @@ class OpenAPITool(Tool):
                     )  # Default explode for query is True
 
                     # Handle deepObject style for object parameters
-                    if param_style == "deepObject" and isinstance(param_value, dict):
+                    if (
+                        param_style == "deepObject" 
+                        and isinstance(param_value, dict)
+                        and len(param_value) > 0
+                    ):
                         if param_explode:
                             # deepObject with explode=true: object properties become separate parameters
                             # e.g., target[id]=123&target[type]=user
@@ -386,6 +390,7 @@ class OpenAPITool(Tool):
                     elif (
                         isinstance(param_value, list)
                         and p.schema_.get("type") == "array"
+                        and len(param_value) > 0
                     ):
                         if param_explode:
                             # When explode=True, we pass the array directly, which HTTPX will serialize


### PR DESCRIPTION

## Summary

* Previously, when empty arrays or dictionaries were passed as parameters, they were still included in the query string as empty values.
* This pull request updates the behavior to exclude such empty parameters entirely.

For example, instead of generating query parameters like `...&arr1=&arr2=&...`, these will now be omitted.
