### PR TITLE
Expand empty parameter filtering and add comprehensive tests

### DIFF
--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -368,7 +368,7 @@ class OpenAPITool(Tool):
 
                     # Handle deepObject style for object parameters
                     if (
-                        param_style == "deepObject" 
+                        param_style == "deepObject"
                         and isinstance(param_value, dict)
                         and len(param_value) > 0
                     ):

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -367,7 +367,11 @@ class OpenAPITool(Tool):
                     )  # Default explode for query is True
 
                     # Handle deepObject style for object parameters
-                    if param_style == "deepObject" and isinstance(param_value, dict):
+                    if (
+                        param_style == "deepObject" 
+                        and isinstance(param_value, dict)
+                        and len(param_value) > 0
+                    ):
                         if param_explode:
                             # deepObject with explode=true: object properties become separate parameters
                             # e.g., target[id]=123&target[type]=user
@@ -386,6 +390,7 @@ class OpenAPITool(Tool):
                     elif (
                         isinstance(param_value, list)
                         and p.schema_.get("type") == "array"
+                        and len(param_value) > 0
                     ):
                         if param_explode:
                             # When explode=True, we pass the array directly, which HTTPX will serialize

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -344,18 +344,28 @@ class OpenAPITool(Tool):
                 suffixed_name = f"{p.name}__{p.location}"
                 param_value = None
 
+                suffixed_value = arguments.get(suffixed_name)
                 if (
                     suffixed_name in arguments
-                    and arguments.get(suffixed_name) is not None
-                    and arguments.get(suffixed_name) != ""
+                    and suffixed_value is not None
+                    and suffixed_value != ""
+                    and not (
+                        isinstance(suffixed_value, list | dict)
+                        and len(suffixed_value) == 0
+                    )
                 ):
                     param_value = arguments[suffixed_name]
-                elif (
-                    p.name in arguments
-                    and arguments.get(p.name) is not None
-                    and arguments.get(p.name) != ""
-                ):
-                    param_value = arguments[p.name]
+                else:
+                    name_value = arguments.get(p.name)
+                    if (
+                        p.name in arguments
+                        and name_value is not None
+                        and name_value != ""
+                        and not (
+                            isinstance(name_value, list | dict) and len(name_value) == 0
+                        )
+                    ):
+                        param_value = arguments[p.name]
 
                 if param_value is not None:
                     # Handle different parameter styles and types


### PR DESCRIPTION
This PR builds on the recently merged #1128 fix for empty OpenAPI parameters by expanding the filtering logic and adding comprehensive test coverage.

## Problem
PR #1128 fixed empty parameters in deep object and array handling code paths, but empty collections could still fall through to the general parameter handling logic and be included in HTTP requests.

## Solution
- **Enhanced filtering**: Added comprehensive empty collection filtering at the initial parameter selection stage, ensuring empty arrays and dicts are excluded before any processing
- **Complete coverage**: Now handles all empty parameter scenarios, not just deep objects and arrays  
- **Type safety**: Fixed type checking issues with proper value extraction

## Testing
Added two new test cases:
- `test_empty_array_parameter_exclusion`: Verifies empty arrays (`[]`) are completely excluded from query parameters
- `test_empty_deep_object_parameter_exclusion`: Verifies empty dicts (`{}`) with deepObject style are excluded

All existing tests continue to pass, ensuring no regressions.

## Result
Complete adherence to documented behavior: *"FastMCP only includes query parameters that have non-empty values"*