### PR TITLE
Fix optional parameter validation in OpenAPI integration

### DIFF
--- a/tests/server/openapi/test_optional_parameters.py
+++ b/tests/server/openapi/test_optional_parameters.py
@@ -5,7 +5,6 @@ import pytest
 from fastmcp.utilities.openapi import HTTPRoute, ParameterInfo, _combine_schemas
 
 
-@pytest.mark.asyncio
 async def test_optional_parameter_schema_allows_null():
     """Test that optional parameters generate schemas that allow null values."""
     # Create a minimal HTTPRoute with optional parameter
@@ -68,7 +67,6 @@ async def test_optional_parameter_schema_allows_null():
         {"type": "object", "properties": {"name": {"type": "string"}}},
     ],
 )
-@pytest.mark.asyncio
 async def test_optional_parameter_allows_null_for_type(param_schema):
     """Test that optional parameters of any type allow null values."""
     optional_param = ParameterInfo(

--- a/tests/server/openapi/test_optional_parameters.py
+++ b/tests/server/openapi/test_optional_parameters.py
@@ -1,0 +1,57 @@
+"""Test for optional parameter handling in FastMCP OpenAPI integration."""
+
+import pytest
+
+from fastmcp.utilities.openapi import HTTPRoute, ParameterInfo, _combine_schemas
+
+
+@pytest.mark.asyncio
+async def test_optional_parameter_schema_allows_null():
+    """Test that optional parameters generate schemas that allow null values."""
+    # Create a minimal HTTPRoute with optional parameter
+    optional_param = ParameterInfo(
+        name="optional_param",
+        location="query",
+        required=False,
+        schema={"type": "string"},
+        description="Optional parameter",
+    )
+
+    required_param = ParameterInfo(
+        name="required_param",
+        location="query",
+        required=True,
+        schema={"type": "string"},
+        description="Required parameter",
+    )
+
+    route = HTTPRoute(
+        method="GET",
+        path="/test",
+        parameters=[required_param, optional_param],
+        request_body=None,
+        responses={},
+        summary="Test endpoint",
+        description=None,
+        schema_definitions={},
+    )
+
+    # Generate combined schema
+    schema = _combine_schemas(route)
+
+    # Verify that optional parameter allows null values
+    optional_param_schema = schema["properties"]["optional_param"]
+
+    # Should have anyOf with string and null types
+    assert "anyOf" in optional_param_schema
+    assert {"type": "string"} in optional_param_schema["anyOf"]
+    assert {"type": "null"} in optional_param_schema["anyOf"]
+
+    # Required parameter should not allow null
+    required_param_schema = schema["properties"]["required_param"]
+    assert required_param_schema["type"] == "string"
+    assert "anyOf" not in required_param_schema
+
+    # Required list should only contain required param
+    assert "required_param" in schema["required"]
+    assert "optional_param" not in schema["required"]

--- a/tests/server/openapi/test_optional_parameters.py
+++ b/tests/server/openapi/test_optional_parameters.py
@@ -57,49 +57,48 @@ async def test_optional_parameter_schema_allows_null():
     assert "optional_param" not in schema["required"]
 
 
-@pytest.mark.asyncio
-async def test_optional_parameters_work_for_all_types():
-    """Test that optional parameters of any type (not just string) allow null values."""
-    test_cases = [
+@pytest.mark.parametrize(
+    "param_schema",
+    [
         {"type": "string"},
         {"type": "integer"},
         {"type": "number"},
         {"type": "boolean"},
         {"type": "array", "items": {"type": "string"}},
         {"type": "object", "properties": {"name": {"type": "string"}}},
-    ]
+    ],
+)
+@pytest.mark.asyncio
+async def test_optional_parameter_allows_null_for_type(param_schema):
+    """Test that optional parameters of any type allow null values."""
+    optional_param = ParameterInfo(
+        name="optional_param",
+        location="query",
+        required=False,
+        schema=param_schema,
+        description="Optional parameter",
+    )
 
-    for param_schema in test_cases:
-        optional_param = ParameterInfo(
-            name="optional_param",
-            location="query",
-            required=False,
-            schema=param_schema,
-            description="Optional parameter",
-        )
+    route = HTTPRoute(
+        method="GET",
+        path="/test",
+        parameters=[optional_param],
+        request_body=None,
+        responses={},
+        summary="Test endpoint",
+        description=None,
+        schema_definitions={},
+    )
 
-        route = HTTPRoute(
-            method="GET",
-            path="/test",
-            parameters=[optional_param],
-            request_body=None,
-            responses={},
-            summary="Test endpoint",
-            description=None,
-            schema_definitions={},
-        )
+    # Generate combined schema
+    schema = _combine_schemas(route)
+    optional_param_schema = schema["properties"]["optional_param"]
 
-        # Generate combined schema
-        schema = _combine_schemas(route)
-        optional_param_schema = schema["properties"]["optional_param"]
-
-        # Should have anyOf with the original type and null
-        assert "anyOf" in optional_param_schema, f"Failed for type: {param_schema}"
-        assert {"type": param_schema["type"]} in optional_param_schema[
-            "anyOf"
-        ] or param_schema in optional_param_schema["anyOf"], (
-            f"Original type missing for: {param_schema}"
-        )
-        assert {"type": "null"} in optional_param_schema["anyOf"], (
-            f"Null type missing for: {param_schema}"
-        )
+    # Should have anyOf with the original type and null
+    assert "anyOf" in optional_param_schema
+    assert {"type": "null"} in optional_param_schema["anyOf"]
+    # Check that original schema is preserved (either simple type or complex schema)
+    if "type" in param_schema:
+        assert {"type": param_schema["type"]} in optional_param_schema["anyOf"]
+    else:
+        assert param_schema in optional_param_schema["anyOf"]


### PR DESCRIPTION
## Summary

Fixes validation errors when calling OpenAPI tools with `None` values for optional parameters. Previously, passing `None` to an optional parameter would fail with "None is not of type 'string'". Now optional parameters properly accept null values.

## Problem

When using `FastMCP.from_openapi()` with OpenAPI specs containing optional parameters (`required: false`), users experienced validation errors when providing `None` values:

```python
# This would fail with validation error
await client.call_tool("api_endpoint", {
    "required_param": "value",
    "optional_param": None  # ❌ "None is not of type 'string'"
})
```

## Solution

Modified the schema generation in `_combine_schemas()` to make optional parameters nullable by using `anyOf` with both the original type and `null`:

```python
# Before: {"type": "string"}
# After: {"anyOf": [{"type": "string"}, {"type": "null"}]}
```

This allows optional parameters to accept both valid values of their specified type and `None` values, matching user expectations for optional parameters.

## Developer Experience

Users can now call OpenAPI tools with optional parameters using `None` naturally:

```python
# ✅ This now works as expected
await client.call_tool("api_endpoint", {
    "required_param": "value", 
    "optional_param": None  # Accepted for optional params
})
```

Closes #224

🤖 Generated with [Claude Code](https://claude.ai/code)