### PR TITLE
Resolve #1139 -- Implement include_context argument in Context.sample

### DIFF
--- a/docs/servers/sampling.mdx
+++ b/docs/servers/sampling.mdx
@@ -137,6 +137,7 @@ async def creative_writing(topic: str, ctx: Context) -> str:
     response = await ctx.sample(
         messages=f"Write a creative short story about {topic}",
         model_preferences="claude-3-sonnet",  # Prefer a specific model
+        include_context="thisServer",  # Use the server's context
         temperature=0.9,  # High creativity
         max_tokens=1000
     )

--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -16,6 +16,7 @@ from mcp.shared.context import RequestContext
 from mcp.types import (
     ContentBlock,
     CreateMessageResult,
+    IncludeContext,
     ModelHint,
     ModelPreferences,
     Root,
@@ -272,6 +273,7 @@ class Context:
         self,
         messages: str | list[str | SamplingMessage],
         system_prompt: str | None = None,
+        include_context: IncludeContext | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
         model_preferences: ModelPreferences | str | list[str] | None = None,
@@ -304,6 +306,7 @@ class Context:
         result: CreateMessageResult = await self.session.create_message(
             messages=sampling_messages,
             system_prompt=system_prompt,
+            include_context=include_context,
             temperature=temperature,
             max_tokens=max_tokens,
             model_preferences=self._parse_model_preferences(model_preferences),

--- a/tests/server/proxy/test_proxy_client.py
+++ b/tests/server/proxy/test_proxy_client.py
@@ -29,6 +29,7 @@ def fastmcp_server():
         result = await context.sample(
             "Hello, world!",
             system_prompt="You love FastMCP",
+            include_context="thisServer",
             temperature=0.5,
             max_tokens=100,
             model_preferences="gpt-4o",


### PR DESCRIPTION
Add the `include_context` argument to the `Context.sample` method. The argument is passed upstream to the [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk).

Resolve #1139