### PR TITLE
Add no-commit-to-branch hook

### DIFF
--- a/.github/workflows/run-static.yml
+++ b/.github/workflows/run-static.yml
@@ -44,3 +44,5 @@ jobs:
         run: uv sync --dev
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: no-commit-to-branch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,9 @@ repos:
     hooks:
       - id: pyright-pretty
         files: ^src/|^tests/
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: no-commit-to-branch
+        args: [--branch, main]


### PR DESCRIPTION
## Summary

Adds a pre-commit hook to prevent accidental direct commits to the main branch.

## Changes

- Added `no-commit-to-branch` hook in `.pre-commit-config.yaml` to block commits to main
- Added `SKIP: no-commit-to-branch` environment variable in CI workflow to allow automated processes

🤖 Generated with [Claude Code](https://claude.ai/code)