### PR TITLE
Do not silently exclude the "context" key from JSON body

### DIFF
--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -459,9 +459,7 @@ class OpenAPITool(Tool):
                     params_to_exclude.add(p.name)
 
             body_params = {
-                k: v
-                for k, v in arguments.items()
-                if k not in params_to_exclude and k != "context"
+                k: v for k, v in arguments.items() if k not in params_to_exclude
             }
 
             if body_params:


### PR DESCRIPTION
The exclusion of the "context" key is arbitrary and makes it impossible to interface with APIs that require a "context" key in the request body.