### PR TITLE
Fix for #346: Pass headers of XHTTP client used by the MCP server generated from OpenAPI spec to the backing API

### DIFF
--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -416,8 +416,9 @@ class OpenAPITool(Tool):
                         # Non-array, non-deepObject parameters are passed as is
                         query_params[p.name] = param_value
 
-        # Prepare headers - fix typing by ensuring all values are strings
-        headers = {}
+        # Use headers from the HTTP client for the wrapped API
+        headers = self._client.headers
+        logger.info(f"### Headers from XHTTP client in run: {headers}  ###")
 
         # Start with OpenAPI-defined header parameters
         openapi_headers = {}
@@ -595,8 +596,11 @@ class OpenAPIResource(Resource):
                     if value is not None and value != "":
                         query_params[param.name] = value
 
-            # Prepare headers from MCP client request if available
-            headers = {}
+            # Use headers from the HTTP client for the wrapped API
+            headers = self._client.headers
+            logger.info(f"### Headers from XHTTP client in read: {headers}  ###")
+
+            # Add headers from the current MCP client HTTP request
             mcp_headers = get_http_headers()
             headers.update(mcp_headers)
 

--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -418,7 +418,6 @@ class OpenAPITool(Tool):
 
         # Use headers from the HTTP client for the wrapped API
         headers = self._client.headers
-        logger.info(f"### Headers from XHTTP client in run: {headers}  ###")
 
         # Start with OpenAPI-defined header parameters
         openapi_headers = {}
@@ -598,7 +597,6 @@ class OpenAPIResource(Resource):
 
             # Use headers from the HTTP client for the wrapped API
             headers = self._client.headers
-            logger.info(f"### Headers from XHTTP client in read: {headers}  ###")
 
             # Add headers from the current MCP client HTTP request
             mcp_headers = get_http_headers()

--- a/tests/client/test_openapi.py
+++ b/tests/client/test_openapi.py
@@ -53,17 +53,17 @@ def run_proxy_server(host: str, port: int, shttp_url: str, **kwargs) -> None:
 
 
 class TestClientHeaders:
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="function")
     def shttp_server(self) -> Generator[str, None, None]:
         with run_server_in_process(run_server, transport="http") as url:
             yield f"{url}/mcp/"
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="function")
     def sse_server(self) -> Generator[str, None, None]:
         with run_server_in_process(run_server, transport="sse") as url:
             yield f"{url}/sse/"
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="function")
     def proxy_server(self, shttp_server: str) -> Generator[str, None, None]:
         with run_server_in_process(
             run_proxy_server,
@@ -158,7 +158,7 @@ class TestClientHeaders:
 
     async def test_client_headers_proxy(self, proxy_server: str):
         """
-        Test that client headers are passed through the proxy to the remove server.
+        Test that client headers are passed through the proxy to the remote server.
         """
         async with Client(transport=StreamableHttpTransport(proxy_server)) as client:
             result = await client.read_resource("resource://get_headers_headers_get")

--- a/tests/server/openapi/conftest.py
+++ b/tests/server/openapi/conftest.py
@@ -101,8 +101,8 @@ def fastapi_app(users_db: dict[int, User]) -> FastAPI:
         user.name = name
         return user
 
-    @app.get("/headers", tags=["headers"])
-    async def get_headers(request: Request) -> dict[str, str]:
+    @app.get("/echo_headers", tags=["headers"])
+    async def echo_headers(request: Request) -> dict[str, str]:
         """Get all request headers as a JSON dictionary."""
         return dict(request.headers)
 

--- a/tests/server/openapi/conftest.py
+++ b/tests/server/openapi/conftest.py
@@ -1,6 +1,6 @@
 import httpx
 import pytest
-from fastapi import FastAPI, HTTPException, Response
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import PlainTextResponse
 from httpx import ASGITransport, AsyncClient
 from pydantic import BaseModel
@@ -100,6 +100,11 @@ def fastapi_app(users_db: dict[int, User]) -> FastAPI:
             raise HTTPException(status_code=404, detail="User not found")
         user.name = name
         return user
+
+    @app.get("/headers", tags=["headers"])
+    async def get_headers(request: Request) -> dict[str, str]:
+        """Get all request headers as a JSON dictionary."""
+        return dict(request.headers)
 
     @app.get("/ping", response_class=PlainTextResponse)
     async def ping() -> str:

--- a/tests/server/openapi/test_basic_functionality.py
+++ b/tests/server/openapi/test_basic_functionality.py
@@ -83,7 +83,7 @@ class TestTools:
         By default, tools exclude GET methods
         """
         server = FastMCPOpenAPI.from_fastapi(fastapi_app)
-        assert len(await server.get_tools()) == 8
+        assert len(await server.get_tools()) == 9
         assert len(await server.get_resources()) == 0
         assert len(await server.get_resource_templates()) == 0
 
@@ -242,7 +242,7 @@ class TestResources:
         """
         async with Client(fastmcp_openapi_server) as client:
             resources = await client.list_resources()
-        assert len(resources) == 4
+        assert len(resources) == 5
         assert resources[0].uri == AnyUrl("resource://get_users_users_get")
         assert resources[0].name == "get_users_users_get"
 

--- a/tests/server/openapi/test_headers.py
+++ b/tests/server/openapi/test_headers.py
@@ -1,10 +1,9 @@
-import pytest
 import httpx
+import pytest
 from fastapi import FastAPI, Request
 
 from fastmcp import Client
 from fastmcp.server.openapi import FastMCPOpenAPI
-from fastmcp.tools.tool import ToolResult
 
 
 @pytest.fixture

--- a/tests/server/openapi/test_headers.py
+++ b/tests/server/openapi/test_headers.py
@@ -1,0 +1,57 @@
+import pytest
+import httpx
+from fastapi import FastAPI, Request
+
+from fastmcp import Client
+from fastmcp.server.openapi import FastMCPOpenAPI
+from fastmcp.tools.tool import ToolResult
+
+
+@pytest.fixture
+def header_echo_app() -> FastAPI:
+    """A simple FastAPI app that echoes headers."""
+    app = FastAPI(title="Header Echo App")
+
+    @app.get("/echo_headers")
+    async def echo_headers(request: Request):
+        """Returns all request headers as JSON."""
+        return request.headers
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_with_client_headers(header_echo_app: FastAPI):
+    """
+    Tests that headers from the FastMCP server's internal client are passed
+    to the backend API when a tool is called.
+    """
+    # Define a random auth header value
+    auth_token = "basic Zm9vOmJhcg=="  # "foo:bar"
+    auth_header = {"Authorization": auth_token}
+
+    # Create an httpx client with the default header. This client will be used
+    # by the FastMCP server to communicate with the backend API.
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=header_echo_app),
+        base_url="http://test",
+        headers=auth_header,
+    ) as http_client:
+        mcp_server = FastMCPOpenAPI(
+            openapi_spec=header_echo_app.openapi(),
+            client=http_client,
+        )
+
+        async with Client(mcp_server) as mcp_client:
+            tools = await mcp_client.list_tools()
+            assert len(tools) == 1
+            echo_tool_name = tools[0].name
+            assert "echo_headers" in echo_tool_name
+
+            result = await mcp_client.call_tool(echo_tool_name, {})
+
+            assert result.data is not None
+            response_headers = result.data
+
+            assert "authorization" in response_headers
+            assert response_headers["authorization"] == auth_token

--- a/tests/server/openapi/test_openapi_path_parameters.py
+++ b/tests/server/openapi/test_openapi_path_parameters.py
@@ -596,12 +596,6 @@ async def test_empty_deep_object_parameter_exclusion(mock_client):
     )
 
 
-# Update mock call counts to account for the new headers endpoint
-# The headers endpoint will be called once in addition to the existing endpoints
-
-
-# Update all the mock assertions to account for the additional endpoint call
-# Most tests will need to expect one more call due to the new /headers endpoint
 def test_parameter_location_enum_handling():
     """Test that ParameterLocation enum values are handled correctly (issue #950)."""
     from enum import Enum

--- a/tests/server/openapi/test_openapi_path_parameters.py
+++ b/tests/server/openapi/test_openapi_path_parameters.py
@@ -599,6 +599,7 @@ async def test_empty_deep_object_parameter_exclusion(mock_client):
 # Update mock call counts to account for the new headers endpoint
 # The headers endpoint will be called once in addition to the existing endpoints
 
+
 # Update all the mock assertions to account for the additional endpoint call
 # Most tests will need to expect one more call due to the new /headers endpoint
 def test_parameter_location_enum_handling():

--- a/tests/server/openapi/test_openapi_path_parameters.py
+++ b/tests/server/openapi/test_openapi_path_parameters.py
@@ -136,7 +136,7 @@ async def test_array_path_parameter_handling(mock_client):
         method="PUT",
         url="/select/monday",  # This is the expected format
         params={},
-        headers={},
+        headers=mock_client.headers,
         json=None,
         timeout=None,
     )
@@ -151,7 +151,7 @@ async def test_array_path_parameter_handling(mock_client):
         method="PUT",
         url="/select/monday,tuesday",  # This is the expected format
         params={},
-        headers={},
+        headers=mock_client.headers,
         json=None,
         timeout=None,
     )
@@ -170,7 +170,7 @@ async def test_integration_array_path_parameter(array_path_spec, mock_client):
         method="PUT",
         url="/select/monday",
         params={},
-        headers={},
+        headers=mock_client.headers,
         json=None,
         timeout=None,
     )
@@ -184,7 +184,7 @@ async def test_integration_array_path_parameter(array_path_spec, mock_client):
         method="PUT",
         url="/select/monday,tuesday",
         params={},
-        headers={},
+        headers=mock_client.headers,
         json=None,
         timeout=None,
     )
@@ -357,7 +357,7 @@ async def test_array_query_parameter_format(mock_client):
         method="GET",
         url="/select",
         params={"days": "monday"},  # Should be formatted as a string, not a list
-        headers={},
+        headers=mock_client.headers,
         json=None,
         timeout=None,
     )
@@ -372,7 +372,7 @@ async def test_array_query_parameter_format(mock_client):
         method="GET",
         url="/select",
         params={"days": "monday,tuesday"},  # Should be comma-separated
-        headers={},
+        headers=mock_client.headers,
         json=None,
         timeout=None,
     )
@@ -427,7 +427,7 @@ async def test_array_query_parameter_exploded_format(mock_client):
         method="GET",
         url="/select-exploded",
         params={"days": ["monday"]},  # Should be passed as a list for explode=True
-        headers={},
+        headers=mock_client.headers,
         json=None,
         timeout=None,
     )
@@ -442,7 +442,7 @@ async def test_array_query_parameter_exploded_format(mock_client):
         method="GET",
         url="/select-exploded",
         params={"days": ["monday", "tuesday"]},  # Should be passed as a list
-        headers={},
+        headers=mock_client.headers,
         json=None,
         timeout=None,
     )
@@ -509,7 +509,7 @@ async def test_empty_array_parameter_exclusion(mock_client):
             "categories": ["tech", "news"],  # Only non-empty array included
             "limit": 10,
         },
-        headers={},
+        headers=mock_client.headers,
         json=None,
         timeout=None,
     )
@@ -590,12 +590,17 @@ async def test_empty_deep_object_parameter_exclusion(mock_client):
             "options[order]": "asc",
             "page": 1,
         },
-        headers={},
+        headers=mock_client.headers,
         json=None,
         timeout=None,
     )
 
 
+# Update mock call counts to account for the new headers endpoint
+# The headers endpoint will be called once in addition to the existing endpoints
+
+# Update all the mock assertions to account for the additional endpoint call
+# Most tests will need to expect one more call due to the new /headers endpoint
 def test_parameter_location_enum_handling():
     """Test that ParameterLocation enum values are handled correctly (issue #950)."""
     from enum import Enum


### PR DESCRIPTION
Hi @jlowin ,

This PR is a fix for the issue https://github.com/jlowin/fastmcp/issues/346, so the MCP server created using `FastMCP.from_openapi` passes the headers of the XHTTP client parameter to the backing API represented by the OpenAPI spec.

I didn't want to change the function signature of `FastMCP.from_openapi` to use the `httpx_client_kwargs` parameter as in `FastMCP.from_fastapi`, it would break existing code for many users.

Duplicate issue:
https://github.com/jlowin/fastmcp/issues/590

Please review and comment.