### PR TITLE
Add `state` dict to Context (#1118)

### DIFF
--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import warnings
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -83,8 +84,19 @@ class Context:
         request_id = ctx.request_id
         client_id = ctx.client_id
 
+        # Manage state across the request
+        ctx.state["user_id"] = "12345"
+        ctx.set_state_value("key", "value")
+        value = ctx.get_state_value("key")
+
         return str(x)
     ```
+
+    State Management:
+    Context objects maintain a state dictionary that can be used to store and share
+    data across middleware and tool calls within a request. When a new context
+    is created (nested contexts), it inherits a copy of its parent's state, ensuring
+    that modifications in child contexts don't affect parent contexts.
 
     The context parameter name can be anything as long as it's annotated with Context.
     The context is optional - tools that don't need it can omit the parameter.
@@ -99,6 +111,11 @@ class Context:
 
     async def __aenter__(self) -> Context:
         """Enter the context manager and set this context as the current context."""
+        parent_context = _current_context.get(None)
+        if parent_context is not None:
+            # Inherit state from parent context
+            self._state = copy.deepcopy(parent_context._state)
+
         # Always set this context and save the token
         token = _current_context.set(self)
         self._tokens.append(token)
@@ -459,9 +476,9 @@ class Context:
     def set_state_value(self, key: str, value: Any) -> None:
         """Set a value in the context state."""
         self._state[key] = value
-    
+
     def get_state_value(self, key: str) -> Any:
-        """Get a value from the context state."""
+        """Get a value from the context state. Returns None if the key is not found."""
         return self._state.get(key)
 
     def _queue_tool_list_changed(self) -> None:

--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -95,6 +95,7 @@ class Context:
         self.fastmcp = fastmcp
         self._tokens: list[Token] = []
         self._notification_queue: set[str] = set()  # Dedupe notifications
+        self._state: dict[str, Any] = {}
 
     async def __aenter__(self) -> Context:
         """Enter the context manager and set this context as the current context."""
@@ -454,6 +455,14 @@ class Context:
             )
 
         return fastmcp.server.dependencies.get_http_request()
+
+    def set_state_value(self, key: str, value: Any) -> None:
+        """Set a value in the context state."""
+        self._state[key] = value
+    
+    def get_state_value(self, key: str) -> Any:
+        """Get a value from the context state."""
+        return self._state.get(key)
 
     def _queue_tool_list_changed(self) -> None:
         """Queue a tool list changed notification."""

--- a/tests/server/test_context.py
+++ b/tests/server/test_context.py
@@ -123,3 +123,51 @@ class TestSessionId:
             "fastmcp.server.dependencies.get_http_headers", return_value=mock_headers
         ):
             assert context.session_id == ""  # Empty string is still returned as-is
+
+
+class TestContextState:
+    """Test suite for Context state functionality."""
+
+    @pytest.mark.asyncio
+    async def test_context_state(self):
+        """Test that state modifications in child contexts don't affect parent."""
+        mock_fastmcp = MagicMock()
+
+        async with Context(fastmcp=mock_fastmcp) as context:
+            assert context.get_state_value("test1") is None
+            assert context.get_state_value("test2") is None
+            context.set_state_value("test1", "value")
+            context.set_state_value("test2", 2)
+            assert context.get_state_value("test1") == "value"
+            assert context.get_state_value("test2") == 2
+            context.set_state_value("test1", "new_value")
+            assert context.get_state_value("test1") == "new_value"
+
+    @pytest.mark.asyncio
+    async def test_context_state_inheritance(self):
+        """Test that child contexts inherit parent state."""
+        mock_fastmcp = MagicMock()
+
+        async with Context(fastmcp=mock_fastmcp) as context1:
+            context1.set_state_value("key1", "key1-context1")
+            context1.set_state_value("key2", "key2-context1")
+            async with Context(fastmcp=mock_fastmcp) as context2:
+                # Override one key
+                context2.set_state_value("key1", "key1-context2")
+                assert context2.get_state_value("key1") == "key1-context2"
+                assert context1.get_state_value("key1") == "key1-context1"
+                assert context2.get_state_value("key2") == "key2-context1"
+
+                async with Context(fastmcp=mock_fastmcp) as context3:
+                    # Verify state was inherited
+                    assert context3.get_state_value("key1") == "key1-context2"
+                    assert context3.get_state_value("key2") == "key2-context1"
+
+                    # Add a new key and verify parents were not affected
+                    context3.set_state_value("key-context3-only", 1)
+                    assert context1.get_state_value("key-context3-only") is None
+                    assert context2.get_state_value("key-context3-only") is None
+                    assert context3.get_state_value("key-context3-only") == 1
+
+            assert context1.get_state_value("key1") == "key1-context1"
+            assert context1.get_state_value("key-context3-only") is None


### PR DESCRIPTION
Add an internal dict `state` inside `Context` that can be interacted with via the `get_state_value` and `set_state_value` APIs. This is intended for middleware or other stages of a request to pass information back and forth, since there is not an easy way to do that right now without using ContextVars. 

When a context is created, it inherits state from its parents. What that means is that:
* State set on a child context never affects the parent context.
* State set on a parent context after the child context is initialized is not propagated to the child context.

Proposed in https://github.com/jlowin/fastmcp/issues/1118. Tested with new tests in test_context.py. 