### PR TITLE
Fix nesting when making OpenAPI arrays and objects optional

### DIFF
--- a/tests/server/openapi/test_optional_parameters.py
+++ b/tests/server/openapi/test_optional_parameters.py
@@ -95,8 +95,6 @@ async def test_optional_parameter_allows_null_for_type(param_schema):
     # Should have anyOf with the original type and null
     assert "anyOf" in optional_param_schema
     assert {"type": "null"} in optional_param_schema["anyOf"]
-    # Check that original schema is preserved (either simple type or complex schema)
-    if "type" in param_schema:
-        assert {"type": param_schema["type"]} in optional_param_schema["anyOf"]
-    else:
-        assert param_schema in optional_param_schema["anyOf"]
+
+    # Check that original schema is fully preserved under anyOf
+    assert param_schema in optional_param_schema["anyOf"]


### PR DESCRIPTION
Prior to this change, the mangling of optional arrays and objects misses "related" properties. For example, given this OAS:

```json
  {
    "name": "someProperty",
    "required": false,
    "schema": {
      "type": "array",
      "items": {
        "type": "string"
      }
    }
  }
```

The resulting MCP tool schema would be:

```json
  {
    "someProperty": {
      "items": {
        "type": "string"
      },
      "anyOf": [
        {
          "type": "array"
        },
        {
          "type": "null"
        }
      ]
    }
  }
```

This is invalid (and e.g. OpenAI fails on it). Instead, the "items" property should be a part of the now-nested "array" type:

```json
  {
    "someProperty": {
      "anyOf": [
        {
          "type": "array",
          "items": {
            "type": "string"
          },
        },
        {
          "type": "null"
        }
      ]
    }
  }
```

This commit looks at all the properties defined in the JSON schema to belong to either array or object type and nests them.