### PR TITLE
Fix `mcp-json` output format to include server name

### DIFF
--- a/docs/integrations/mcp-json-configuration.mdx
+++ b/docs/integrations/mcp-json-configuration.mdx
@@ -98,23 +98,25 @@ Generate configuration and output to stdout (useful for piping):
 fastmcp install mcp-json server.py
 ```
 
-This outputs the server configuration JSON that you add to the `mcpServers` object:
+This outputs the server configuration JSON with the server name as the root key:
 
 ```json
 {
-  "command": "uv",
-  "args": [
-    "run",
-    "--with",
-    "fastmcp", 
-    "fastmcp",
-    "run",
-    "/absolute/path/to/server.py"
-  ]
+  "My Server": {
+    "command": "uv",
+    "args": [
+      "run",
+      "--with",
+      "fastmcp", 
+      "fastmcp",
+      "run",
+      "/absolute/path/to/server.py"
+    ]
+  }
 }
 ```
 
-To use this in a client configuration file, add it under a server name in the `mcpServers` object:
+To use this in a client configuration file, add it to the `mcpServers` object in your client's configuration:
 
 ```json
 {
@@ -133,6 +135,10 @@ To use this in a client configuration file, add it under a server name in the `m
   }
 }
 ```
+
+<Note>
+Different MCP clients may have specific configuration requirements or formatting needs. Always consult your client's documentation to ensure proper integration.
+</Note>
 
 ## Configuration Options
 
@@ -177,8 +183,8 @@ mcp = FastMCP(
 ```bash
 # Individual environment variables
 fastmcp install mcp-json server.py \
-  --env-var API_KEY=your-secret-key \
-  --env-var DEBUG=true
+  --env API_KEY=your-secret-key \
+  --env DEBUG=true
 
 # Load from .env file
 fastmcp install mcp-json server.py --env-file .env
@@ -219,15 +225,17 @@ fastmcp install mcp-json dice_server.py
 Output:
 ```json
 {
-  "command": "uv",
-  "args": [
-    "run",
-    "--with",
-    "fastmcp",
-    "fastmcp", 
-    "run",
-    "/home/user/dice_server.py"
-  ]
+  "Dice Server": {
+    "command": "uv",
+    "args": [
+      "run",
+      "--with",
+      "fastmcp",
+      "fastmcp", 
+      "run",
+      "/home/user/dice_server.py"
+    ]
+  }
 }
 ```
 
@@ -238,29 +246,31 @@ fastmcp install mcp-json api_server.py \
   --name "Production API Server" \
   --with requests \
   --with python-dotenv \
-  --env-var API_BASE_URL=https://api.example.com \
-  --env-var TIMEOUT=30
+  --env API_BASE_URL=https://api.example.com \
+  --env TIMEOUT=30
 ```
 
 Output:
 ```json
 {
-  "command": "uv",
-  "args": [
-    "run",
-    "--with",
-    "fastmcp",
-    "--with",
-    "python-dotenv", 
-    "--with",
-    "requests",
-    "fastmcp",
-    "run", 
-    "/home/user/api_server.py"
-  ],
-  "env": {
-    "API_BASE_URL": "https://api.example.com",
-    "TIMEOUT": "30"
+  "Production API Server": {
+    "command": "uv",
+    "args": [
+      "run",
+      "--with",
+      "fastmcp",
+      "--with",
+      "python-dotenv", 
+      "--with",
+      "requests",
+      "fastmcp",
+      "run", 
+      "/home/user/api_server.py"
+    ],
+    "env": {
+      "API_BASE_URL": "https://api.example.com",
+      "TIMEOUT": "30"
+    }
   }
 }
 ```
@@ -278,7 +288,7 @@ Use in shell scripts:
 ```bash
 #!/bin/bash
 CONFIG=$(fastmcp install mcp-json server.py --name "CI Server")
-echo "$CONFIG" | jq '.command'
+echo "$CONFIG" | jq '."CI Server".command'
 # Output: "uv"
 ```
 
@@ -306,21 +316,21 @@ Use the JSON configuration with any application that supports the MCP protocol
 
 ## Configuration Format
 
-The generated configuration follows the standard MCP server specification:
+The generated configuration outputs a server object with the server name as the root key:
 
 ```json
 {
-  "mcpServers": {
-    "<server-name>": {
-      "command": "<executable>",
-      "args": ["<arg1>", "<arg2>", "..."],
-      "env": {
-        "<ENV_VAR>": "<value>"
-      }
+  "<server-name>": {
+    "command": "<executable>",
+    "args": ["<arg1>", "<arg2>", "..."],
+    "env": {
+      "<ENV_VAR>": "<value>"
     }
   }
 }
 ```
+
+To use this in an MCP client, add it to the client's `mcpServers` configuration object.
 
 **Fields:**
 - `command`: The executable to run (always `uv` for FastMCP servers)

--- a/docs/patterns/cli.mdx
+++ b/docs/patterns/cli.mdx
@@ -185,7 +185,7 @@ The `install` command supports the same `file.py:object` notation as the `run` c
 | Server Name | `--name`, `-n` | Custom name for the server (defaults to server's name attribute or file name) |
 | Editable Package | `--with-editable`, `-e` | Directory containing pyproject.toml to install in editable mode |
 | Additional Packages | `--with` | Additional packages to install (can be used multiple times) |
-| Environment Variables | `--env-var`, `-v` | Environment variables in KEY=VALUE format (can be used multiple times) |
+| Environment Variables | `--env` | Environment variables in KEY=VALUE format (can be used multiple times) |
 | Environment File | `--env-file`, `-f` | Load environment variables from a .env file |
 
 **Examples**
@@ -198,13 +198,13 @@ fastmcp install claude-desktop server.py
 fastmcp install claude-desktop server.py:my_server
 
 # With custom name and dependencies
-fastmcp install claude-desktop server.py:my_server -n "My Analysis Server" --with pandas
+fastmcp install claude-desktop server.py:my_server --name "My Analysis Server" --with pandas
 
 # Install in Claude Code with environment variables
-fastmcp install claude-code server.py --env-var API_KEY=secret --env-var DEBUG=true
+fastmcp install claude-code server.py --env API_KEY=secret --env DEBUG=true
 
 # Install in Cursor with environment variables
-fastmcp install cursor server.py --env-var API_KEY=secret --env-var DEBUG=true
+fastmcp install cursor server.py --env API_KEY=secret --env DEBUG=true
 
 # Install with environment file
 fastmcp install cursor server.py --env-file .env
@@ -225,28 +225,30 @@ The `mcp-json` subcommand generates standard MCP JSON configuration that can be 
 - Sharing server configurations with others
 - Integration with custom tooling
 
-The generated JSON follows the standard `mcpServers` format used by Claude Desktop, VS Code, Cursor, and other MCP clients:
+The generated JSON follows the standard MCP server configuration format used by Claude Desktop, VS Code, Cursor, and other MCP clients, with the server name as the root key:
 
 ```json
 {
-  "mcpServers": {
-    "server-name": {
-      "command": "uv",
-      "args": [
-        "run",
-        "--with",
-        "fastmcp",
-        "fastmcp",
-        "run",
-        "/path/to/server.py"
-      ],
-      "env": {
-        "API_KEY": "value"
-      }
+  "server-name": {
+    "command": "uv",
+    "args": [
+      "run",
+      "--with",
+      "fastmcp",
+      "fastmcp",
+      "run",
+      "/path/to/server.py"
+    ],
+    "env": {
+      "API_KEY": "value"
     }
   }
 }
 ```
+
+<Note>
+To use this configuration with your MCP client, you'll typically need to add it to the client's `mcpServers` object. Consult your client's documentation for any specific configuration requirements or formatting needs.
+</Note>
 
 **Options specific to mcp-json:**
 

--- a/src/fastmcp/cli/install/__init__.py
+++ b/src/fastmcp/cli/install/__init__.py
@@ -5,7 +5,7 @@ import cyclopts
 from .claude_code import claude_code_command
 from .claude_desktop import claude_desktop_command
 from .cursor import cursor_command
-from .mcp_config import mcp_config_command
+from .mcp_json import mcp_json_command
 
 # Create a cyclopts app for install subcommands
 install_app = cyclopts.App(
@@ -17,4 +17,4 @@ install_app = cyclopts.App(
 install_app.command(claude_code_command, name="claude-code")
 install_app.command(claude_desktop_command, name="claude-desktop")
 install_app.command(cursor_command, name="cursor")
-install_app.command(mcp_config_command, name="mcp-json")
+install_app.command(mcp_json_command, name="mcp-json")

--- a/src/fastmcp/cli/install/mcp_json.py
+++ b/src/fastmcp/cli/install/mcp_json.py
@@ -16,7 +16,7 @@ from .shared import process_common_args
 logger = get_logger(__name__)
 
 
-def install_mcp_config(
+def install_mcp_json(
     file: Path,
     server_object: str | None,
     name: str,
@@ -65,15 +65,18 @@ def install_mcp_config(
         # Add fastmcp run command
         args.extend(["fastmcp", "run", server_spec])
 
-        # Build MCP server configuration (just the server object, not the wrapper)
-        config = {
+        # Build MCP server configuration
+        server_config = {
             "command": "uv",
             "args": args,
         }
 
         # Add environment variables if provided
         if env_vars:
-            config["env"] = env_vars
+            server_config["env"] = env_vars
+
+        # Wrap with server name as root key
+        config = {name: server_config}
 
         # Convert to JSON
         json_output = json.dumps(config, indent=2)
@@ -93,13 +96,13 @@ def install_mcp_config(
         return False
 
 
-def mcp_config_command(
+def mcp_json_command(
     server_spec: str,
     *,
     server_name: Annotated[
         str | None,
         cyclopts.Parameter(
-            name=["--server-name", "-n"],
+            name=["--name", "-n"],
             help="Custom name for the server in MCP config",
         ),
     ] = None,
@@ -151,7 +154,7 @@ def mcp_config_command(
         server_spec, server_name, with_packages, env_vars, env_file
     )
 
-    success = install_mcp_config(
+    success = install_mcp_json(
         file=file,
         server_object=server_object,
         name=name,

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -124,7 +124,7 @@ class TestMcpJsonInstall:
     def test_mcp_json_basic(self):
         """Test basic mcp-json install command parsing."""
         command, bound, _ = install_app.parse_args(
-            ["mcp-json", "server.py", "--server-name", "test-server"]
+            ["mcp-json", "server.py", "--name", "test-server"]
         )
 
         assert command is not None
@@ -134,7 +134,7 @@ class TestMcpJsonInstall:
     def test_mcp_json_with_copy(self):
         """Test mcp-json install with copy to clipboard option."""
         command, bound, _ = install_app.parse_args(
-            ["mcp-json", "server.py", "--server-name", "test-server", "--copy"]
+            ["mcp-json", "server.py", "--name", "test-server", "--copy"]
         )
 
         assert bound.arguments["copy"] is True


### PR DESCRIPTION
The `fastmcp install mcp-json` command was outputting bare server configuration objects, making the `--name` parameter appear useless. This PR fixes the output to include the server name as the root key, aligning the implementation with user expectations and the documentation.

### Before
```bash
$ fastmcp install mcp-json server.py --name "My Server"
{
  "command": "uv",
  "args": ["run", "--with", "fastmcp", "fastmcp", "run", "/path/to/server.py"]
}
```

### After  
```bash
$ fastmcp install mcp-json server.py --name "My Server"
{
  "My Server": {
    "command": "uv", 
    "args": ["run", "--with", "fastmcp", "fastmcp", "run", "/path/to/server.py"]
  }
}
```

This change makes the `--name` parameter meaningful and produces output that can be directly added to an MCP client's `mcpServers` configuration object. The documentation has been updated to reflect the actual behavior and clarify that users should consult their specific client's documentation for integration details.

Also simplified the parameter from `--server-name` to `--name` for better ergonomics.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>