### PR TITLE
Remove unused import from FastAPI integration documentation

### DIFF
--- a/docs/integrations/fastapi.mdx
+++ b/docs/integrations/fastapi.mdx
@@ -134,7 +134,6 @@ You can also mount an existing FastMCP server into your FastAPI application, add
 ```python
 from fastmcp import FastMCP
 from fastapi import FastAPI
-from starlette.routing import Mount
 
 # Create your FastMCP server
 mcp = FastMCP("MyServer")


### PR DESCRIPTION
This pull request makes a minor update to the `docs/integrations/fastapi.mdx` file, removing an unused import statement to clean up the example code.

* [`docs/integrations/fastapi.mdx`](diffhunk://#diff-53e2882747f27c6db0e429e457bccfab2b3405cf39b26e3e8c0d3e554788a6f4L137): Removed the unused `Mount` import from `starlette.routing` in the FastAPI integration example.