### PR TITLE
Fix documentation regarding `@tool()` decorator usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ When testing or investigating FastMCP servers, **always prefer the in-memory tra
 # Create your FastMCP server
 mcp = FastMCP("TestServer")
 
-@mcp.tool
+@mcp.tool()
 def greet(name: str) -> str:
     return f"Hello, {name}!"
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("Demo 🚀")
 
-@mcp.tool
+@mcp.tool()
 def add(a: int, b: int) -> int:
     """Add two numbers"""
     return a + b
@@ -152,7 +152,7 @@ Learn more in the [**FastMCP Server Documentation**](https://gofastmcp.com/serve
 Tools allow LLMs to perform actions by executing your Python functions (sync or async). Ideal for computations, API calls, or side effects (like `POST`/`PUT`). FastMCP handles schema generation from type hints and docstrings. Tools can return various types, including text, JSON-serializable objects, and even images or audio aided by the FastMCP media helper classes.
 
 ```python
-@mcp.tool
+@mcp.tool()
 def multiply(a: float, b: float) -> float:
     """Multiplies two numbers."""
     return a * b
@@ -167,7 +167,7 @@ Resources expose read-only data sources (like `GET` requests). Use `@mcp.resourc
 ```python
 # Static resource
 @mcp.resource("config://version")
-def get_version(): 
+def get_version():
     return "2.0.1"
 
 # Dynamic resource template
@@ -210,7 +210,7 @@ from fastmcp import FastMCP, Context
 
 mcp = FastMCP("My MCP Server")
 
-@mcp.tool
+@mcp.tool()
 async def process_data(uri: str, ctx: Context):
     # Log a message to the client
     await ctx.info(f"Processing {uri}...")
@@ -330,7 +330,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("Demo 🚀")
 
-@mcp.tool
+@mcp.tool()
 def hello(name: str) -> str:
     return f"Hello, {name}!"
 
@@ -374,7 +374,7 @@ Contributions are the core of open source! We welcome improvements and features.
 1. Clone the repository:
 
    ```bash
-   git clone https://github.com/jlowin/fastmcp.git 
+   git clone https://github.com/jlowin/fastmcp.git
    cd fastmcp
    ```
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -344,7 +344,7 @@ This release adds support for audio content in MCP tools and resources, expandin
 
 ## [v2.8.0: Transform and Roll Out](https://github.com/jlowin/fastmcp/releases/tag/v2.8.0)
 
-FastMCP 2.8.0 introduces powerful new ways to customize and control your MCP servers! 
+FastMCP 2.8.0 introduces powerful new ways to customize and control your MCP servers!
 
 ### Tool Transformation
 
@@ -478,7 +478,7 @@ This is primarily a housekeeping release to remove or deprecate cruft that's acc
 Happily, this release DOES permit the use of "naked" decorators to align with Pythonic practice:
 
 ```python
-@mcp.tool
+@mcp.tool()
 def my_tool():
     ...
 ```

--- a/docs/clients/transports.mdx
+++ b/docs/clients/transports.mdx
@@ -16,7 +16,7 @@ Think of transports as configurable adapters between your client code and MCP se
 ## Choosing the Right Transport
 
 - **Use [STDIO Transport](#stdio-transport)** when you need to run local MCP servers with full control over their environment and lifecycle
-- **Use [Remote Transports](#remote-transports)** when connecting to production services or shared MCP servers running independently  
+- **Use [Remote Transports](#remote-transports)** when connecting to production services or shared MCP servers running independently
 - **Use [In-Memory Transport](#in-memory-transport)** for testing FastMCP servers without subprocess or network overhead
 - **Use [MCP JSON Configuration](#mcp-json-configuration-transport)** when you need to connect to multiple servers defined in configuration files
 
@@ -110,8 +110,8 @@ from fastmcp.client.transports import StdioTransport
 
 required_vars = ["API_KEY", "DATABASE_URL", "REDIS_HOST"]
 env = {
-    var: os.environ[var] 
-    for var in required_vars 
+    var: os.environ[var]
+    for var in required_vars
     if var in os.environ
 }
 
@@ -156,7 +156,7 @@ client = Client(transport)
 async def efficient_multiple_operations():
     async with client:
         await client.ping()
-    
+
     async with client:  # Reuses the same subprocess
         await client.call_tool("process_data", {"file": "data.csv"})
 ```
@@ -179,7 +179,7 @@ Use `keep_alive=False` when you need complete isolation (e.g., in test suites) o
 FastMCP provides convenience transports that are thin wrappers around `StdioTransport` with pre-configured commands:
 
 - **`PythonStdioTransport`** - Uses `python` command for `.py` files
-- **`NodeStdioTransport`** - Uses `node` command for `.js` files  
+- **`NodeStdioTransport`** - Uses `node` command for `.js` files
 - **`UvxStdioTransport`** - Uses `uvx` for Python packages (uses `env_vars` parameter)
 - **`NpxStdioTransport`** - Uses `npx` for Node packages (uses `env_vars` parameter)
 
@@ -233,7 +233,7 @@ client = Client(
 
 Server-Sent Events transport is maintained for backward compatibility but is superseded by Streamable HTTP for new deployments.
 
-- **Class:** `SSETransport`  
+- **Class:** `SSETransport`
 - **Server compatibility:** FastMCP servers running with `mcp run --transport sse`
 
 SSE transport supports the same configuration options as Streamable HTTP:
@@ -266,7 +266,7 @@ import os
 
 mcp = FastMCP("TestServer")
 
-@mcp.tool
+@mcp.tool()
 def greet(name: str) -> str:
     prefix = os.environ.get("GREETING_PREFIX", "Hello")
     return f"{prefix}, {name}!"

--- a/docs/deployment/running-server.mdx
+++ b/docs/deployment/running-server.mdx
@@ -22,7 +22,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="MyServer")
 
-@mcp.tool
+@mcp.tool()
 def hello(name: str) -> str:
     return f"Hello, {name}!"
 
@@ -283,7 +283,7 @@ import asyncio
 
 mcp = FastMCP(name="MyServer")
 
-@mcp.tool
+@mcp.tool()
 def hello(name: str) -> str:
     return f"Hello, {name}!"
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -9,7 +9,7 @@ If you haven't already installed FastMCP, follow the [installation instructions]
 
 ## Creating a FastMCP Server
 
-A FastMCP server is a collection of tools, resources, and other MCP components. To create a server, start by instantiating the `FastMCP` class. 
+A FastMCP server is a collection of tools, resources, and other MCP components. To create a server, start by instantiating the `FastMCP` class.
 
 Create a new file called `my_server.py` and add the following code:
 
@@ -25,14 +25,14 @@ That's it! You've created a FastMCP server, albeit a very boring one. Let's add 
 
 ## Adding a Tool
 
-To add a tool that returns a simple greeting, write a function and decorate it with `@mcp.tool` to register it with the server:
+To add a tool that returns a simple greeting, write a function and decorate it with `@mcp.tool()` to register it with the server:
 
 ```python my_server.py {5-7}
 from fastmcp import FastMCP
 
 mcp = FastMCP("My MCP Server")
 
-@mcp.tool
+@mcp.tool()
 def greet(name: str) -> str:
     return f"Hello, {name}!"
 ```
@@ -49,7 +49,7 @@ from fastmcp import FastMCP, Client
 
 mcp = FastMCP("My MCP Server")
 
-@mcp.tool
+@mcp.tool()
 def greet(name: str) -> str:
     return f"Hello, {name}!"
 
@@ -76,7 +76,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("My MCP Server")
 
-@mcp.tool
+@mcp.tool()
 def greet(name: str) -> str:
     return f"Hello, {name}!"
 
@@ -94,7 +94,7 @@ Within the FastMCP ecosystem, this line may be unnecessary. However, including i
 
 ### Interacting with the Python server
 
-Now that the server can be executed with `python my_server.py`, we can interact with it like any other MCP server. 
+Now that the server can be executed with `python my_server.py`, we can interact with it like any other MCP server.
 
 In a new file, create a client and point it at the server file:
 

--- a/docs/getting-started/welcome.mdx
+++ b/docs/getting-started/welcome.mdx
@@ -13,7 +13,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("Demo 🚀")
 
-@mcp.tool
+@mcp.tool()
 def add(a: int, b: int) -> int:
     """Add two numbers"""
     return a + b
@@ -25,7 +25,7 @@ if __name__ == "__main__":
 
 ## Beyond the Protocol
 
-FastMCP is the standard framework for working with the Model Context Protocol. FastMCP 1.0 was incorporated into the [official MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) in 2024. 
+FastMCP is the standard framework for working with the Model Context Protocol. FastMCP 1.0 was incorporated into the [official MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) in 2024.
 
 This is FastMCP 2.0, the **actively maintained version** that provides a complete toolkit for working with the MCP ecosystem.
 
@@ -67,7 +67,7 @@ FastMCP is made with 💙 by [Prefect](https://www.prefect.io/).
 
 ## LLM-Friendly Docs
 
-This documentation is also available in [llms.txt format](https://llmstxt.org/), which is a simple markdown standard that LLMs can consume easily. 
+This documentation is also available in [llms.txt format](https://llmstxt.org/), which is a simple markdown standard that LLMs can consume easily.
 
 There are two ways to access the LLM-friendly documentation:
 - [llms.txt](https://gofastmcp.com/llms.txt) is essentially a sitemap, listing all the pages in the documentation.

--- a/docs/integrations/anthropic.mdx
+++ b/docs/integrations/anthropic.mdx
@@ -24,7 +24,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="Dice Roller")
 
-@mcp.tool
+@mcp.tool()
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]
@@ -118,9 +118,9 @@ The MCP connector supports OAuth authentication through authorization tokens, wh
 
 ### Server Authentication
 
-The simplest way to add authentication to the server is to use a bearer token scheme. 
+The simplest way to add authentication to the server is to use a bearer token scheme.
 
-For this example, we'll quickly generate our own tokens with FastMCP's `RSAKeyPair` utility, but this may not be appropriate for production use. For more details, see the complete server-side [Bearer Auth](/servers/auth/bearer) documentation. 
+For this example, we'll quickly generate our own tokens with FastMCP's `RSAKeyPair` utility, but this may not be appropriate for production use. For more details, see the complete server-side [Bearer Auth](/servers/auth/bearer) documentation.
 
 We'll start by creating an RSA key pair to sign and verify tokens.
 
@@ -133,9 +133,9 @@ access_token = key_pair.create_token(audience="dice-server")
 
 <Warning>
 FastMCP's `RSAKeyPair` utility is for development and testing only.
-</Warning> 
+</Warning>
 
-Next, we'll create a `BearerAuthProvider` to authenticate the server. 
+Next, we'll create a `BearerAuthProvider` to authenticate the server.
 
 ```python
 from fastmcp import FastMCP
@@ -167,7 +167,7 @@ auth = BearerAuthProvider(
 
 mcp = FastMCP(name="Dice Roller", auth=auth)
 
-@mcp.tool
+@mcp.tool()
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]
@@ -183,9 +183,9 @@ If you try to call the authenticated server with the same Anthropic code we wrot
 
 ```python
 Error code: 400 - {
-    "type": "error", 
+    "type": "error",
     "error": {
-        "type": "invalid_request_error", 
+        "type": "invalid_request_error",
         "message": "MCP server 'dice-server' requires authentication. Please provide an authorization_token.",
     },
 }

--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -27,7 +27,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="Dice Roller")
 
-@mcp.tool
+@mcp.tool()
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]
@@ -165,9 +165,9 @@ Try asking Claude something like:
 Claude will automatically detect your `roll_dice` tool and use it to fulfill your request, returning something like:
 
 > I'll roll some dice for you! Here are your results: [4, 2, 6]
-> 
+>
 > You rolled three dice and got a 4, a 2, and a 6!
 
-Claude Code can now access all the tools, resources, and prompts you've defined in your FastMCP server. 
+Claude Code can now access all the tools, resources, and prompts you've defined in your FastMCP server.
 
 If your server provides resources, you can reference them with `@` mentions using the format `@server:protocol://resource/path`. If your server provides prompts, you can use them as slash commands with `/mcp__servername__promptname`.

--- a/docs/integrations/claude-desktop.mdx
+++ b/docs/integrations/claude-desktop.mdx
@@ -39,7 +39,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="Dice Roller")
 
-@mcp.tool
+@mcp.tool()
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]
@@ -189,7 +189,7 @@ When manually configuring dependencies, the recommended approach is to use `uv` 
         "run",
         "--with", "fastmcp",
         "--with", "pandas",
-        "--with", "requests", 
+        "--with", "requests",
         "fastmcp",
         "run",
         "path/to/your/server.py"
@@ -262,7 +262,7 @@ from fastmcp import FastMCP
 
 # Create a proxy to a remote server
 proxy = FastMCP.as_proxy(
-    "https://example.com/mcp/sse", 
+    "https://example.com/mcp/sse",
     name="Remote Server Proxy"
 )
 
@@ -290,4 +290,3 @@ proxy = FastMCP.as_proxy(client, name="Authenticated Proxy")
 if __name__ == "__main__":
     proxy.run()
 ```
-

--- a/docs/integrations/cursor.mdx
+++ b/docs/integrations/cursor.mdx
@@ -27,7 +27,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="Dice Roller")
 
-@mcp.tool
+@mcp.tool()
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]
@@ -188,7 +188,7 @@ When manually configuring dependencies, the recommended approach is to use `uv` 
         "run",
         "--with", "fastmcp",
         "--with", "pandas",
-        "--with", "requests", 
+        "--with", "requests",
         "fastmcp",
         "run",
         "path/to/your/server.py"
@@ -259,7 +259,7 @@ Try asking Cursor something like:
 Cursor will automatically detect your `roll_dice` tool and use it to fulfill your request, returning something like:
 
 > 🎲 Here are your dice rolls: 4, 6, 4
-> 
+>
 > You rolled 3 dice with a total of 14! The 6 was a nice high roll there!
 
 The AI assistant can now access all the tools, resources, and prompts you've defined in your FastMCP server.

--- a/docs/integrations/fastapi.mdx
+++ b/docs/integrations/fastapi.mdx
@@ -153,7 +153,7 @@ from fastmcp import FastMCP
 mcp = FastMCP.from_fastapi(app=app)
 
 # Add a new tool
-@mcp.tool
+@mcp.tool()
 def get_product(product_id: int) -> ProductResponse:
     """Get a product by ID."""
     return products_db[product_id]
@@ -185,7 +185,7 @@ async def demo():
         # List available tools
         tools = await client.list_tools()
         print(f"Available tools: {[t.name for t in tools]}")
-        
+
         # Create a product
         result = await client.call_tool(
             "create_product_products_post",
@@ -197,7 +197,7 @@ async def demo():
             }
         )
         print(f"Created product: {result.data}")
-        
+
         # List electronics under $100
         result = await client.call_tool(
             "list_products_products_get",
@@ -224,14 +224,14 @@ mcp = FastMCP.from_fastapi(
     route_maps=[
         # GET with path params → ResourceTemplates
         RouteMap(
-            methods=["GET"], 
-            pattern=r".*\{.*\}.*", 
+            methods=["GET"],
+            pattern=r".*\{.*\}.*",
             mcp_type=MCPType.RESOURCE_TEMPLATE
         ),
         # Other GETs → Resources
         RouteMap(
-            methods=["GET"], 
-            pattern=r".*", 
+            methods=["GET"],
+            pattern=r".*",
             mcp_type=MCPType.RESOURCE
         ),
         # POST/PUT/DELETE → Tools (default)
@@ -303,13 +303,13 @@ from fastapi import FastAPI
 # Create MCP server
 mcp = FastMCP("Analytics Tools")
 
-@mcp.tool
+@mcp.tool()
 def analyze_pricing(category: str) -> dict:
     """Analyze pricing for a category."""
     products = [p for p in products_db.values() if p.category == category]
     if not products:
         return {"error": f"No products in {category}"}
-    
+
     prices = [p.price for p in products]
     return {
         "category": category,

--- a/docs/integrations/gemini.mdx
+++ b/docs/integrations/gemini.mdx
@@ -31,7 +31,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="Dice Roller")
 
-@mcp.tool
+@mcp.tool()
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]
@@ -65,7 +65,7 @@ import asyncio
 mcp_client = Client("server.py")
 gemini_client = genai.Client()
 
-async def main():    
+async def main():
     async with mcp_client:
         response = await gemini_client.aio.models.generate_content(
             model="gemini-2.0-flash",
@@ -104,5 +104,3 @@ mcp_client = Client(
 ```
 
 The rest of the code remains the same.
-
-

--- a/docs/integrations/openai.mdx
+++ b/docs/integrations/openai.mdx
@@ -32,7 +32,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="Dice Roller")
 
-@mcp.tool
+@mcp.tool()
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]
@@ -116,9 +116,9 @@ The Responses API can include headers to authenticate the request, which means y
 
 #### Server Authentication
 
-The simplest way to add authentication to the server is to use a bearer token scheme. 
+The simplest way to add authentication to the server is to use a bearer token scheme.
 
-For this example, we'll quickly generate our own tokens with FastMCP's `RSAKeyPair` utility, but this may not be appropriate for production use. For more details, see the complete server-side [Bearer Auth](/servers/auth/bearer) documentation. 
+For this example, we'll quickly generate our own tokens with FastMCP's `RSAKeyPair` utility, but this may not be appropriate for production use. For more details, see the complete server-side [Bearer Auth](/servers/auth/bearer) documentation.
 
 We'll start by creating an RSA key pair to sign and verify tokens.
 
@@ -131,9 +131,9 @@ access_token = key_pair.create_token(audience="dice-server")
 
 <Warning>
 FastMCP's `RSAKeyPair` utility is for development and testing only.
-</Warning> 
+</Warning>
 
-Next, we'll create a `BearerAuthProvider` to authenticate the server. 
+Next, we'll create a `BearerAuthProvider` to authenticate the server.
 
 ```python
 from fastmcp import FastMCP
@@ -165,7 +165,7 @@ auth = BearerAuthProvider(
 
 mcp = FastMCP(name="Dice Roller", auth=auth)
 
-@mcp.tool
+@mcp.tool()
 def roll_dice(n_dice: int) -> list[int]:
     """Roll `n_dice` 6-sided dice and return the results."""
     return [random.randint(1, 6) for _ in range(n_dice)]

--- a/docs/integrations/starlette.mdx
+++ b/docs/integrations/starlette.mdx
@@ -29,7 +29,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("MyServer")
 
-@mcp.tool
+@mcp.tool()
 def hello(name: str) -> str:
     return f"Hello, {name}!"
 
@@ -104,7 +104,7 @@ from starlette.routing import Mount
 # Create your FastMCP server
 mcp = FastMCP("MyServer")
 
-@mcp.tool
+@mcp.tool()
 def analyze(data: str) -> dict:
     return {"result": f"Analyzed: {data}"}
 
@@ -210,4 +210,3 @@ The patterns shown here work with any ASGI-compatible framework. The key require
 1. Mount the FastMCP ASGI app at your desired path
 2. Pass the lifespan context to your root application
 3. Configure any necessary middleware or authentication
-

--- a/docs/patterns/cli.mdx
+++ b/docs/patterns/cli.mdx
@@ -75,7 +75,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("MyServer")
 
-@mcp.tool
+@mcp.tool()
 def hello(name: str) -> str:
     return f"Hello, {name}!"
 
@@ -161,7 +161,7 @@ Run a MCP server with the [MCP Inspector](https://github.com/modelcontextprotoco
 fastmcp dev server.py
 ```
 
-<Tip> 
+<Tip>
 This command always runs your server via `uv run` subprocess (never your local environment) to work with the MCP Inspector. All dependencies must be explicitly specified using the `--with` and/or `--with-editable` options, or be available in a uv-managed project.
 </Tip>
 
@@ -304,7 +304,7 @@ fastmcp install mcp-json server.py --copy
 The `mcp-json` subcommand generates standard MCP JSON configuration that can be used with any MCP-compatible client. This is useful when:
 
 - Working with MCP clients not directly supported by FastMCP
-- Creating configuration for CI/CD environments  
+- Creating configuration for CI/CD environments
 - Sharing server configurations with others
 - Integration with custom tooling
 

--- a/docs/patterns/decorating-methods.mdx
+++ b/docs/patterns/decorating-methods.mdx
@@ -29,7 +29,7 @@ from fastmcp import FastMCP
 mcp = FastMCP()
 
 class MyClass:
-    @mcp.tool
+    @mcp.tool()
     def my_method(self, x: int) -> int:
         return x * 2
 
@@ -53,7 +53,7 @@ from fastmcp import FastMCP
 mcp = FastMCP()
 
 class MyClass:
-    @mcp.tool  # This won't work correctly
+    @mcp.tool()  # This won't work correctly
     def add(self, x, y):
         return x + y
 ```
@@ -100,19 +100,19 @@ mcp = FastMCP()
 
 class MyClass:
     @classmethod
-    @mcp.tool  # This won't work but won't raise an error
+    @mcp.tool()  # This won't work but won't raise an error
     def from_string_v1(cls, s):
         return cls(s)
-    
-    @mcp.tool
+
+    @mcp.tool()
     @classmethod  # This will raise a helpful ValueError
     def from_string_v2(cls, s):
         return cls(s)
 ```
 </Warning>
 
-- If `@classmethod` comes first, then `@mcp.tool`: No error is raised, but it won't work correctly
-- If `@mcp.tool` comes first, then `@classmethod`: FastMCP will detect this and raise a helpful `ValueError` with guidance
+- If `@classmethod` comes first, then `@mcp.tool()`: No error is raised, but it won't work correctly
+- If `@mcp.tool()` comes first, then `@classmethod`: FastMCP will detect this and raise a helpful `ValueError` with guidance
 
 <Check>
 **Do this instead**:
@@ -150,7 +150,7 @@ from fastmcp import FastMCP
 mcp = FastMCP()
 
 class MyClass:
-    @mcp.tool
+    @mcp.tool()
     @staticmethod
     def utility(x, y):
         return x + y
@@ -193,10 +193,10 @@ class ComponentProvider:
         # Register methods
         mcp_instance.tool(self.tool_method)
         mcp_instance.resource("resource://data")(self.resource_method)
-    
+
     def tool_method(self, x):
         return x * 2
-    
+
     def resource_method(self):
         return "Resource data"
 

--- a/docs/patterns/http-requests.mdx
+++ b/docs/patterns/http-requests.mdx
@@ -25,16 +25,16 @@ from starlette.requests import Request
 
 mcp = FastMCP(name="HTTP Request Demo")
 
-@mcp.tool
+@mcp.tool()
 async def user_agent_info() -> dict:
     """Return information about the user agent."""
     # Get the HTTP request
     request: Request = get_http_request()
-    
+
     # Access request data
     user_agent = request.headers.get("user-agent", "Unknown")
     client_ip = request.client.host if request.client else "Unknown"
-    
+
     return {
         "user_agent": user_agent,
         "client_ip": client_ip,
@@ -58,16 +58,16 @@ from fastmcp.server.dependencies import get_http_headers
 
 mcp = FastMCP(name="Headers Demo")
 
-@mcp.tool
+@mcp.tool()
 async def safe_header_info() -> dict:
     """Safely get header information without raising errors."""
     # Get headers (returns empty dict if no request context)
     headers = get_http_headers()
-    
+
     # Get authorization header
     auth_header = headers.get("authorization", "")
     is_bearer = auth_header.startswith("Bearer ")
-    
+
     return {
         "user_agent": headers.get("user-agent", "Unknown"),
         "content_type": headers.get("content-type", "Unknown"),

--- a/docs/patterns/tool-transformation.mdx
+++ b/docs/patterns/tool-transformation.mdx
@@ -35,7 +35,7 @@ from fastmcp.tools import Tool
 mcp = FastMCP()
 
 # The original, generic tool
-@mcp.tool
+@mcp.tool()
 def search(query: str, category: str = "all") -> list[dict]:
     """Searches for items in the database."""
     return database.search(query, category)
@@ -45,8 +45,8 @@ product_search_tool = Tool.from_tool(
     search,
     name="find_products",
     description="""
-        Search for products in the e-commerce catalog. 
-        Use this when customers ask about finding specific items, 
+        Search for products in the e-commerce catalog.
+        Use this when customers ask about finding specific items,
         checking availability, or browsing product categories.
         """,
 )
@@ -64,7 +64,7 @@ from fastmcp.tools import Tool
 mcp = FastMCP()
 
 # The original, generic tool
-@mcp.tool
+@mcp.tool()
 def search(query: str, category: str = "all") -> list[dict]:
     ...
 
@@ -135,7 +135,7 @@ from fastmcp.tools.tool_transform import ArgTransform
 
 mcp = FastMCP()
 
-@mcp.tool
+@mcp.tool()
 def find_user(user_id: str):
     """Finds a user by their ID."""
     ...
@@ -155,7 +155,7 @@ new_tool = Tool.from_tool(
 
 ### Names
 
-At times, you may want to rename an argument to make it more intuitive for an LLM. 
+At times, you may want to rename an argument to make it more intuitive for an LLM.
 
 For example, in the following example, we take a generic `q` argument and expand it to `search_query`:
 
@@ -166,7 +166,7 @@ from fastmcp.tools.tool_transform import ArgTransform
 
 mcp = FastMCP()
 
-@mcp.tool
+@mcp.tool()
 def search(q: str):
     """Searches for items in the database."""
     return database.search(q)
@@ -190,7 +190,7 @@ from fastmcp.tools.tool_transform import ArgTransform
 
 mcp = FastMCP()
 
-@mcp.tool
+@mcp.tool()
 def add(x: int, y: int) -> int:
     """Adds two numbers."""
     return x + y
@@ -221,18 +221,18 @@ from fastmcp.tools.tool_transform import ArgTransform
 
 mcp = FastMCP()
 
-@mcp.tool
+@mcp.tool()
 def send_email(to: str, subject: str, body: str, api_key: str):
     """Sends an email."""
     ...
-    
+
 # Create a simplified version that hides the API key
 new_tool = Tool.from_tool(
     send_email,
     name="send_notification",
     transform_args={
         "api_key": ArgTransform(
-            hide=True, 
+            hide=True,
             default=os.environ.get("EMAIL_API_KEY"),
         )
     }
@@ -279,7 +279,7 @@ The `from_tool()` method takes a `transform_fn` parameter, which is an async fun
 
 ### The Transform Function
 
-The `transform_fn` is an async function that **completely replaces** the parent tool's logic. 
+The `transform_fn` is an async function that **completely replaces** the parent tool's logic.
 
 Critically, the transform function's arguments are used to determine the new tool's final schema. Any arguments that are not already present in the parent tool schema OR the `transform_args` will be added to the new tool's schema. Note that when `transform_args` and your function have the same argument name, the `transform_args` metadata will take precedence, if provided.
 
@@ -317,7 +317,7 @@ from fastmcp.tools.tool_transform import forward
 
 mcp = FastMCP()
 
-@mcp.tool
+@mcp.tool()
 def add(x: int, y: int) -> int:
     """Adds two numbers."""
     return x + y
@@ -346,7 +346,7 @@ from fastmcp.tools.tool_transform import forward
 
 mcp = FastMCP()
 
-@mcp.tool
+@mcp.tool()
 def add(x: int, y: int) -> int:
     """Adds two numbers."""
     return x + y
@@ -378,7 +378,7 @@ from fastmcp.tools.tool_transform import forward
 
 mcp = FastMCP()
 
-@mcp.tool
+@mcp.tool()
 def add(x: int, y: int) -> int:
     """Adds two numbers."""
     return x + y
@@ -415,7 +415,7 @@ from fastmcp.tools.tool_transform import forward
 
 mcp = FastMCP()
 
-@mcp.tool
+@mcp.tool()
 def add(x: int, y: int) -> int:
     """Adds two numbers."""
     return x + y
@@ -491,7 +491,7 @@ The transformed tool automatically uses the parent tool's output schema and stru
 **Custom Output Schema**
 ```python
 Tool.from_tool(parent_tool, output_schema={
-    "type": "object", 
+    "type": "object",
     "properties": {"status": {"type": "string"}}
 })
 ```

--- a/docs/servers/auth/bearer.mdx
+++ b/docs/servers/auth/bearer.mdx
@@ -199,16 +199,16 @@ Once authenticated, your tools, resources, or prompts can access token informati
 from fastmcp import FastMCP, Context, ToolError
 from fastmcp.server.dependencies import get_access_token, AccessToken
 
-@mcp.tool
+@mcp.tool()
 async def get_my_data(ctx: Context) -> dict:
     access_token: AccessToken = get_access_token()
-    
+
     user_id = access_token.client_id  # From JWT 'sub' or 'client_id' claim
     user_scopes = access_token.scopes
-    
+
     if "data:read_sensitive" not in user_scopes:
         raise ToolError("Insufficient permissions: 'data:read_sensitive' scope required.")
-    
+
     return {
         "user": user_id,
         "sensitive_data": f"Private data for {user_id}",
@@ -235,4 +235,3 @@ async def get_my_data(ctx: Context) -> dict:
   Token expiration timestamp
 </ParamField>
 </Card>
-

--- a/docs/servers/context.mdx
+++ b/docs/servers/context.mdx
@@ -42,7 +42,7 @@ from fastmcp import FastMCP, Context
 
 mcp = FastMCP(name="Context Demo")
 
-@mcp.tool
+@mcp.tool()
 async def process_file(file_uri: str, ctx: Context) -> str:
     """Processes a file, using context for logging and resource access."""
     # Context is available as the ctx parameter
@@ -105,10 +105,10 @@ mcp = FastMCP(name="Dependency Demo")
 # Utility function that needs context but doesn't receive it as a parameter
 async def process_data(data: list[float]) -> dict:
     # Get the active context - only works when called within a request
-    ctx = get_context()    
+    ctx = get_context()
     await ctx.info(f"Processing {len(data)} data points")
-    
-@mcp.tool
+
+@mcp.tool()
 async def analyze_dataset(dataset_name: str) -> dict:
     # Call utility function that uses context internally
     data = load_data(dataset_name)
@@ -130,7 +130,7 @@ Send debug, info, warning, and error messages back to the MCP client for visibil
 
 ```python
 await ctx.debug("Starting analysis")
-await ctx.info(f"Processing {len(data)} items") 
+await ctx.info(f"Processing {len(data)} items")
 await ctx.warning("Deprecated parameter used")
 await ctx.error("Processing failed")
 ```
@@ -193,7 +193,7 @@ content = content_list[0].content
 FastMCP automatically sends list change notifications when components (such as tools, resources, or prompts) are added, removed, enabled, or disabled. In rare cases where you need to manually trigger these notifications, you can use the context methods:
 
 ```python
-@mcp.tool
+@mcp.tool()
 async def custom_tool_management(ctx: Context) -> str:
     """Example of manual notification after custom tool changes."""
     # After making custom changes to tools
@@ -210,7 +210,7 @@ These methods are primarily used internally by FastMCP's automatic notification 
 To access the underlying FastMCP server instance, you can use the `ctx.fastmcp` property:
 
 ```python
-@mcp.tool
+@mcp.tool()
 async def my_tool(ctx: Context) -> None:
     # Access the FastMCP server instance
     server_name = ctx.fastmcp.name
@@ -222,7 +222,7 @@ async def my_tool(ctx: Context) -> None:
 Access metadata about the current request and client.
 
 ```python
-@mcp.tool
+@mcp.tool()
 async def request_info(ctx: Context) -> dict:
     """Return information about the current request."""
     return {

--- a/docs/servers/elicitation.mdx
+++ b/docs/servers/elicitation.mdx
@@ -13,7 +13,7 @@ import { VersionBadge } from '/snippets/version-badge.mdx'
 User elicitation allows MCP servers to request structured input from users during tool execution. Instead of requiring all inputs upfront, tools can interactively ask for missing parameters, clarification, or additional context as needed.
 
 <Tip>
-Most of the examples in this document assume you have a FastMCP server instance named `mcp` and show how to use the `ctx.elicit` method to request user input from an `@mcp.tool`-decorated function.
+Most of the examples in this document assume you have a FastMCP server instance named `mcp` and show how to use the `ctx.elicit` method to request user input from an `@mcp.tool()`-decorated function.
 </Tip>
 
 ## What is Elicitation?
@@ -21,7 +21,7 @@ Most of the examples in this document assume you have a FastMCP server instance 
 Elicitation enables tools to pause execution and request specific information from users. This is particularly useful for:
 
 - **Missing parameters**: Ask for required information not provided initially
-- **Clarification requests**: Get user confirmation or choices for ambiguous scenarios  
+- **Clarification requests**: Get user confirmation or choices for ambiguous scenarios
 - **Progressive disclosure**: Collect complex information step-by-step
 - **Dynamic workflows**: Adapt tool behavior based on user responses
 
@@ -42,14 +42,14 @@ class UserInfo:
     name: str
     age: int
 
-@mcp.tool
+@mcp.tool()
 async def collect_user_info(ctx: Context) -> str:
     """Collect user information through interactive prompts."""
     result = await ctx.elicit(
         message="Please provide your information",
         response_type=UserInfo
     )
-    
+
     if result.action == "accept":
         user = result.data
         return f"Hello {user.name}, you are {user.age} years old"
@@ -67,21 +67,21 @@ async def collect_user_info(ctx: Context) -> str:
     <ResponseField name="message" type="str">
       The prompt message to display to the user
     </ResponseField>
-    
+
     <ResponseField name="response_type" type="type" default="None">
-      The Python type defining the expected response structure (dataclass, primitive type, etc.) Note that elicitation responses are subject to a restricted subset of JSON Schema types. See [Supported Response Types](#supported-response-types) for more details. 
+      The Python type defining the expected response structure (dataclass, primitive type, etc.) Note that elicitation responses are subject to a restricted subset of JSON Schema types. See [Supported Response Types](#supported-response-types) for more details.
     </ResponseField>
   </Expandable>
-  
+
   <Expandable title="Response">
     <ResponseField name="ElicitationResult" type="object">
       Result object containing the user's response
-      
+
       <Expandable title="properties">
         <ResponseField name="action" type="Literal['accept', 'decline', 'cancel']">
           How the user responded to the request
         </ResponseField>
-        
+
         <ResponseField name="data" type="response_type | None">
           The user's input data (only present when action is "accept")
         </ResponseField>
@@ -100,7 +100,7 @@ The elicitation result contains an `action` field indicating how the user respon
 - **`cancel`**: User cancelled the entire operation and the data field is `None`
 
 ```python {5, 7}
-@mcp.tool
+@mcp.tool()
 async def my_tool(ctx: Context) -> str:
     result = await ctx.elicit("Choose an action")
 
@@ -116,15 +116,15 @@ FastMCP also provides typed result classes for pattern matching on the `action` 
 
 ```python {1-5, 12, 14, 16}
 from fastmcp.server.elicitation import (
-    AcceptedElicitation, 
-    DeclinedElicitation, 
+    AcceptedElicitation,
+    DeclinedElicitation,
     CancelledElicitation,
 )
 
-@mcp.tool
+@mcp.tool()
 async def pattern_example(ctx: Context) -> str:
     result = await ctx.elicit("Enter your name:", response_type=str)
-    
+
     match result:
         case AcceptedElicitation(data=name):
             return f"Hello {name}!"
@@ -153,31 +153,31 @@ As a developer, this means you do not have to worry about creating or accessing 
 
 <CodeGroup>
 ```python {4} title="Request a string"
-@mcp.tool
+@mcp.tool()
 async def get_user_name(ctx: Context) -> str:
     """Get the user's name."""
     result = await ctx.elicit("What's your name?", response_type=str)
-    
+
     if result.action == "accept":
         return f"Hello, {result.data}!"
     return "No name provided"
 ```
 ```python {4} title="Request an integer"
-@mcp.tool
+@mcp.tool()
 async def pick_a_number(ctx: Context) -> str:
     """Pick a number."""
     result = await ctx.elicit("Pick a number!", response_type=int)
-    
+
     if result.action == "accept":
         return f"You picked {result.data}"
     return "No number provided"
 ```
 ```python {4} title="Request a boolean"
-@mcp.tool
+@mcp.tool()
 async def pick_a_boolean(ctx: Context) -> str:
     """Pick a boolean."""
     result = await ctx.elicit("True or false?", response_type=bool)
-    
+
     if result.action == "accept":
         return f"You picked {result.data}"
     return "No boolean provided"
@@ -189,7 +189,7 @@ async def pick_a_boolean(ctx: Context) -> str:
 Sometimes, the goal of an elicitation is to simply get a user to approve or reject an action. In this case, you can pass `None` as the response type to indicate that no response is expected. In order to comply with the MCP spec, the client will see a schema requesting an empty object in response. In this case, the `data` field of the `ElicitationResult` object will be `None` when the user accepts the elicitation.
 
 ```python {4} title="No response"
-@mcp.tool
+@mcp.tool()
 async def approve_action(ctx: Context) -> str:
     """Approve an action."""
     result = await ctx.elicit("Approve this action?", response_type=None)
@@ -206,28 +206,28 @@ Often you'll want to constrain the user's response to a specific set of values. 
 
 <CodeGroup>
 ```python {6} title="Using a list of strings"
-@mcp.tool
+@mcp.tool()
 async def set_priority(ctx: Context) -> str:
     """Set task priority level."""
     result = await ctx.elicit(
-        "What priority level?", 
+        "What priority level?",
         response_type=["low", "medium", "high"],
     )
-    
+
     if result.action == "accept":
         return f"Priority set to: {result.data}"
 ```
 ```python {1, 8} title="Using a Literal type"
 from typing import Literal
 
-@mcp.tool
+@mcp.tool()
 async def set_priority(ctx: Context) -> str:
     """Set task priority level."""
     result = await ctx.elicit(
-        "What priority level?", 
+        "What priority level?",
         response_type=Literal["low", "medium", "high"]
     )
-    
+
     if result.action == "accept":
         return f"Priority set to: {result.data}"
     return "No priority set"
@@ -238,13 +238,13 @@ from enum import Enum
 class Priority(Enum):
     LOW = "low"
     MEDIUM = "medium"
-    HIGH = "high"   
+    HIGH = "high"
 
-@mcp.tool
+@mcp.tool()
 async def set_priority(ctx: Context) -> str:
     """Set task priority level."""
     result = await ctx.elicit("What priority level?", response_type=Priority)
-    
+
     if result.action == "accept":
         return f"Priority set to: {result.data.value}"
     return "No priority set"
@@ -267,14 +267,14 @@ class TaskDetails:
     priority: Literal["low", "medium", "high"]
     due_date: str
 
-@mcp.tool
+@mcp.tool()
 async def create_task(ctx: Context) -> str:
     """Create a new task with user-provided details."""
     result = await ctx.elicit(
         "Please provide task details",
         response_type=TaskDetails
     )
-    
+
     if result.action == "accept":
         task = result.data
         return f"Created task: {task.title} (Priority: {task.priority})"
@@ -286,28 +286,28 @@ async def create_task(ctx: Context) -> str:
 Tools can make multiple elicitation calls to gather information progressively:
 
 ```python {6, 11, 16-19}
-@mcp.tool
+@mcp.tool()
 async def plan_meeting(ctx: Context) -> str:
     """Plan a meeting by gathering details step by step."""
-    
+
     # Get meeting title
     title_result = await ctx.elicit("What's the meeting title?", response_type=str)
     if title_result.action != "accept":
         return "Meeting planning cancelled"
-    
+
     # Get duration
     duration_result = await ctx.elicit("Duration in minutes?", response_type=int)
     if duration_result.action != "accept":
         return "Meeting planning cancelled"
-    
+
     # Get priority
     priority_result = await ctx.elicit(
-        "Is this urgent?", 
+        "Is this urgent?",
         response_type=Literal["yes", "no"]
     )
     if priority_result.action != "accept":
         return "Meeting planning cancelled"
-    
+
     urgent = priority_result.data == "yes"
     return f"Meeting '{title_result.data}' planned for {duration_result.data} minutes (Urgent: {urgent})"
 ```

--- a/docs/servers/logging.mdx
+++ b/docs/servers/logging.mdx
@@ -33,21 +33,21 @@ from fastmcp import FastMCP, Context
 
 mcp = FastMCP("LoggingDemo")
 
-@mcp.tool
+@mcp.tool()
 async def analyze_data(data: list[float], ctx: Context) -> dict:
     """Analyze numerical data with comprehensive logging."""
     await ctx.debug("Starting analysis of numerical data")
     await ctx.info(f"Analyzing {len(data)} data points")
-    
+
     try:
         if not data:
             await ctx.warning("Empty data list provided")
             return {"error": "Empty data list"}
-        
+
         result = sum(data) / len(data)
         await ctx.info(f"Analysis complete, average: {result}")
         return {"average": result, "count": len(data)}
-        
+
     except Exception as e:
         await ctx.error(f"Analysis failed: {str(e)}")
         raise
@@ -58,7 +58,7 @@ async def analyze_data(data: list[float], ctx: Context) -> dict:
 <Card icon="code" title="Context Logging Methods">
 <ResponseField name="ctx.debug" type="async method">
   Send debug-level messages for detailed execution information
-  
+
   <Expandable title="parameters">
     <ResponseField name="message" type="str">
       The debug message to send to the client
@@ -68,7 +68,7 @@ async def analyze_data(data: list[float], ctx: Context) -> dict:
 
 <ResponseField name="ctx.info" type="async method">
   Send informational messages about normal execution
-  
+
   <Expandable title="parameters">
     <ResponseField name="message" type="str">
       The information message to send to the client
@@ -78,7 +78,7 @@ async def analyze_data(data: list[float], ctx: Context) -> dict:
 
 <ResponseField name="ctx.warning" type="async method">
   Send warning messages for potential issues that didn't prevent execution
-  
+
   <Expandable title="parameters">
     <ResponseField name="message" type="str">
       The warning message to send to the client
@@ -88,7 +88,7 @@ async def analyze_data(data: list[float], ctx: Context) -> dict:
 
 <ResponseField name="ctx.error" type="async method">
   Send error messages for problems that occurred during execution
-  
+
   <Expandable title="parameters">
     <ResponseField name="message" type="str">
       The error message to send to the client
@@ -98,16 +98,16 @@ async def analyze_data(data: list[float], ctx: Context) -> dict:
 
 <ResponseField name="ctx.log" type="async method">
   Generic logging method with custom level and logger name
-  
+
   <Expandable title="parameters">
     <ResponseField name="level" type="Literal['debug', 'info', 'warning', 'error']">
       The log level for the message
     </ResponseField>
-    
+
     <ResponseField name="message" type="str">
       The message to send to the client
     </ResponseField>
-    
+
     <ResponseField name="logger_name" type="str | None" default="None">
       Optional custom logger name for categorizing messages
     </ResponseField>
@@ -120,13 +120,13 @@ async def analyze_data(data: list[float], ctx: Context) -> dict:
 ### Debug
 Use for detailed information that's typically only useful when diagnosing problems:
 
-```python 
-@mcp.tool
+```python
+@mcp.tool()
 async def process_file(file_path: str, ctx: Context) -> str:
     """Process a file with detailed debug logging."""
     await ctx.debug(f"Starting to process file: {file_path}")
     await ctx.debug("Checking file permissions")
-    
+
     # File processing logic
     await ctx.debug("File processing completed successfully")
     return "File processed"
@@ -136,7 +136,7 @@ async def process_file(file_path: str, ctx: Context) -> str:
 Use for general information about normal program execution:
 
 ```python
-@mcp.tool
+@mcp.tool()
 async def backup_database(ctx: Context) -> str:
     """Backup database with progress information."""
     await ctx.info("Starting database backup")
@@ -149,15 +149,15 @@ async def backup_database(ctx: Context) -> str:
 Use for potentially harmful situations that don't prevent execution:
 
 ```python
-@mcp.tool
+@mcp.tool()
 async def validate_config(config: dict, ctx: Context) -> dict:
     """Validate configuration with warnings for deprecated options."""
     if "old_api_key" in config:
         await ctx.warning("Using deprecated 'old_api_key' field. Please use 'api_key' instead")
-    
+
     if config.get("timeout", 30) > 300:
         await ctx.warning("Timeout value is very high (>5 minutes), this may cause issues")
-    
+
     return {"status": "valid", "warnings": "see logs"}
 ```
 
@@ -165,12 +165,12 @@ async def validate_config(config: dict, ctx: Context) -> dict:
 Use for error events that might still allow the application to continue:
 
 ```python
-@mcp.tool
+@mcp.tool()
 async def batch_process(items: list[str], ctx: Context) -> dict:
     """Process multiple items, logging errors for failed items."""
     successful = 0
     failed = 0
-    
+
     for item in items:
         try:
             # Process item
@@ -178,7 +178,7 @@ async def batch_process(items: list[str], ctx: Context) -> dict:
         except Exception as e:
             await ctx.error(f"Failed to process item '{item}': {str(e)}")
             failed += 1
-    
+
     return {"successful": successful, "failed": failed}
 ```
 

--- a/docs/servers/middleware.mdx
+++ b/docs/servers/middleware.mdx
@@ -549,7 +549,7 @@ mcp.add_middleware(RateLimitingMiddleware(max_requests_per_second=50))
 mcp.add_middleware(TimingMiddleware())  # Time actual execution
 mcp.add_middleware(LoggingMiddleware())  # Log everything
 
-@mcp.tool
+@mcp.tool()
 def my_tool(data: str) -> str:
     return f"Processed: {data}"
 ```

--- a/docs/servers/progress.mdx
+++ b/docs/servers/progress.mdx
@@ -28,7 +28,7 @@ import asyncio
 
 mcp = FastMCP("ProgressDemo")
 
-@mcp.tool
+@mcp.tool()
 async def process_items(items: list[str], ctx: Context) -> dict:
     """Process a list of items with progress updates."""
     total = len(items)
@@ -73,7 +73,7 @@ async def process_items(items: list[str], ctx: Context) -> dict:
 Report progress as a percentage (0-100):
 
 ```python {13-14}
-@mcp.tool
+@mcp.tool()
 async def download_file(url: str, ctx: Context) -> str:
     """Download a file with percentage progress."""
     total_size = 1000  # KB
@@ -98,7 +98,7 @@ async def download_file(url: str, ctx: Context) -> str:
 Report progress with absolute values:
 
 ```python {10}
-@mcp.tool
+@mcp.tool()
 async def backup_database(ctx: Context) -> str:
     """Backup database tables with absolute progress."""
     tables = ["users", "orders", "products", "inventory", "logs"]
@@ -120,7 +120,7 @@ async def backup_database(ctx: Context) -> str:
 Report progress without a known total for operations where the endpoint is unknown:
 
 ```python {11}
-@mcp.tool
+@mcp.tool()
 async def scan_directory(directory: str, ctx: Context) -> dict:
     """Scan directory with indeterminate progress."""
     files_found = 0
@@ -142,7 +142,7 @@ async def scan_directory(directory: str, ctx: Context) -> dict:
 Break complex operations into stages with progress for each:
 
 ```python
-@mcp.tool
+@mcp.tool()
 async def data_migration(source: str, destination: str, ctx: Context) -> str:
     """Migrate data with multi-stage progress reporting."""
     

--- a/docs/servers/sampling.mdx
+++ b/docs/servers/sampling.mdx
@@ -29,7 +29,7 @@ from fastmcp import FastMCP, Context
 
 mcp = FastMCP("SamplingDemo")
 
-@mcp.tool
+@mcp.tool()
 async def analyze_sentiment(text: str, ctx: Context) -> dict:
     """Analyze the sentiment of text using the client's LLM."""
     prompt = f"""Analyze the sentiment of the following text as positive, negative, or neutral. 
@@ -97,7 +97,7 @@ async def analyze_sentiment(text: str, ctx: Context) -> dict:
 Generate text with simple string prompts:
 
 ```python {6}
-@mcp.tool
+@mcp.tool()
 async def generate_summary(content: str, ctx: Context) -> str:
     """Generate a summary of the provided content."""
     prompt = f"Please provide a concise summary of the following content:\n\n{content}"
@@ -111,7 +111,7 @@ async def generate_summary(content: str, ctx: Context) -> str:
 Use system prompts to guide the LLM's behavior:
 
 ```python {4-9}
-@mcp.tool
+@mcp.tool()
 async def generate_code_example(concept: str, ctx: Context) -> str:
     """Generate a Python code example for a given concept."""
     response = await ctx.sample(
@@ -131,7 +131,7 @@ async def generate_code_example(concept: str, ctx: Context) -> str:
 Specify model preferences for different use cases:
 
 ```python {4-8, 17-22}
-@mcp.tool
+@mcp.tool()
 async def creative_writing(topic: str, ctx: Context) -> str:
     """Generate creative content using a specific model."""
     response = await ctx.sample(
@@ -144,7 +144,7 @@ async def creative_writing(topic: str, ctx: Context) -> str:
     
     return response.text
 
-@mcp.tool
+@mcp.tool()
 async def technical_analysis(data: str, ctx: Context) -> str:
     """Perform technical analysis with a reasoning-focused model."""
     response = await ctx.sample(
@@ -164,7 +164,7 @@ Use structured messages for more complex interactions:
 ```python {1, 6-10}
 from fastmcp.client.sampling import SamplingMessage
 
-@mcp.tool
+@mcp.tool()
 async def multi_turn_analysis(user_query: str, context_data: str, ctx: Context) -> str:
     """Perform analysis using multi-turn conversation structure."""
     messages = [

--- a/docs/servers/server.mdx
+++ b/docs/servers/server.mdx
@@ -65,7 +65,7 @@ FastMCP servers expose several types of components to the client:
 Tools are functions that the client can call to perform actions or access external systems.
 
 ```python
-@mcp.tool
+@mcp.tool()
 def multiply(a: float, b: float) -> float:
     """Multiplies two numbers together."""
     return a * b
@@ -167,7 +167,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="MyServer")
 
-@mcp.tool
+@mcp.tool()
 def greet(name: str) -> str:
     """Greet a user by name."""
     return f"Hello, {name}!"
@@ -372,7 +372,7 @@ def yaml_serializer(data):
 # Create a server with the custom serializer
 mcp = FastMCP(name="MyServer", tool_serializer=yaml_serializer)
 
-@mcp.tool
+@mcp.tool()
 def get_config():
     """Returns configuration in YAML format."""
     return {"api_key": "abc123", "debug": True, "rate_limit": 100}

--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -31,7 +31,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="CalculatorServer")
 
-@mcp.tool
+@mcp.tool()
 def add(a: int, b: int) -> int:
     """Adds two integer numbers together."""
     return a + b
@@ -120,7 +120,7 @@ Type annotations for parameters are essential for proper tool functionality. The
 Use standard Python type annotations for parameters:
 
 ```python
-@mcp.tool
+@mcp.tool()
 def analyze_text(
     text: str,
     max_tokens: int = 100,
@@ -138,7 +138,7 @@ You can provide additional metadata about parameters using Pydantic's `Field` cl
 from typing import Annotated
 from pydantic import Field
 
-@mcp.tool
+@mcp.tool()
 def process_image(
     image_url: Annotated[str, Field(description="URL of the image to process")],
     resize: Annotated[bool, Field(description="Whether to resize the image")] = False,
@@ -156,7 +156,7 @@ def process_image(
 You can also use the Field as a default value, though the Annotated approach is preferred:
 
 ```python
-@mcp.tool
+@mcp.tool()
 def search_database(
     query: str = Field(description="Search query string"),
     limit: int = Field(10, description="Maximum number of results", ge=1, le=100)
@@ -196,7 +196,7 @@ For additional type annotations not listed here, see the [Parameter Types](#para
 FastMCP follows Python's standard function parameter conventions. Parameters without default values are required, while those with default values are optional.
 
 ```python
-@mcp.tool
+@mcp.tool()
 def search_products(
     query: str,                   # Required - no default value
     max_results: int = 10,        # Optional - has default value
@@ -250,7 +250,7 @@ def maintenance_tool():
 You can also toggle a tool's state programmatically after it has been created:
 
 ```python
-@mcp.tool
+@mcp.tool()
 def dynamic_tool():
     return "I am a dynamic tool."
 
@@ -265,14 +265,14 @@ FastMCP seamlessly supports both standard (`def`) and asynchronous (`async def`)
 
 ```python
 # Synchronous tool (suitable for CPU-bound or quick tasks)
-@mcp.tool
+@mcp.tool()
 def calculate_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """Calculate the distance between two coordinates."""
     # Implementation...
     return 42.5
 
 # Asynchronous tool (ideal for I/O-bound operations)
-@mcp.tool
+@mcp.tool()
 async def fetch_weather(city: str) -> dict:
     """Retrieve current weather conditions for a city."""
     # Use 'async def' for operations involving network calls, file I/O, etc.
@@ -330,7 +330,7 @@ This automatic behavior enables clients to receive machine-readable data alongsi
 
 <CodeGroup>
 ```python Dict Return (No Schema Needed)
-@mcp.tool
+@mcp.tool()
 def get_user_data(user_id: str) -> dict:
     """Get user data without type annotation."""
     return {"name": "Alice", "age": 30, "active": True}
@@ -353,7 +353,7 @@ def get_user_data(user_id: str) -> dict:
 
 <CodeGroup>
 ```python Integer Return (No Schema)
-@mcp.tool  
+@mcp.tool()  
 def calculate_sum(a: int, b: int):
     """Calculate sum without return annotation."""
     return a + b  # Returns 8
@@ -364,7 +364,7 @@ def calculate_sum(a: int, b: int):
 ```
 
 ```python Integer Return (With Schema)
-@mcp.tool
+@mcp.tool()
 def calculate_sum(a: int, b: int) -> int:
     """Calculate sum with return annotation."""  
     return a + b  # Returns 8
@@ -396,7 +396,7 @@ class Person:
     age: int
     email: str
 
-@mcp.tool
+@mcp.tool()
 def get_user_profile(user_id: str) -> Person:
     """Get a user's profile information."""
     return Person(name="Alice", age=30, email="alice@example.com")
@@ -438,7 +438,7 @@ For primitive return types (like `int`, `str`, `bool`), FastMCP automatically wr
 
 <CodeGroup>
 ```python Primitive Return Type
-@mcp.tool
+@mcp.tool()
 def calculate_sum(a: int, b: int) -> int:
     """Add two numbers together."""
     return a + b
@@ -494,7 +494,7 @@ For complete control over both traditional content and structured output, return
 ```python
 from fastmcp.tools.tool import ToolResult
 
-@mcp.tool
+@mcp.tool()
 def advanced_tool() -> ToolResult:
     """Tool with full control over output."""
     return ToolResult(
@@ -532,7 +532,7 @@ mcp = FastMCP(name="SecureServer", mask_error_details=True)
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 
-@mcp.tool
+@mcp.tool()
 def divide(a: float, b: float) -> float:
     """Divide a by b."""
 
@@ -596,7 +596,7 @@ Remember that annotations help make better user experiences but should be treate
 FastMCP automatically sends `notifications/tools/list_changed` notifications to connected clients when tools are added, removed, enabled, or disabled. This allows clients to stay up-to-date with the current tool set without manually polling for changes.
 
 ```python
-@mcp.tool
+@mcp.tool()
 def example_tool() -> str:
     return "Hello!"
 
@@ -620,7 +620,7 @@ from fastmcp import FastMCP, Context
 
 mcp = FastMCP(name="ContextDemo")
 
-@mcp.tool
+@mcp.tool()
 async def process_data(data_uri: str, ctx: Context) -> dict:
     """Process data from a resource with progress reporting."""
     await ctx.info(f"Processing data from {data_uri}")
@@ -665,7 +665,7 @@ FastMCP supports **type coercion** when possible. This means that if a client se
 The most common parameter types are Python's built-in scalar types:
 
 ```python
-@mcp.tool
+@mcp.tool()
 def process_values(
     name: str,             # Text data
     count: int,            # Integer numbers
@@ -685,7 +685,7 @@ FastMCP supports various date and time types from the `datetime` module:
 ```python
 from datetime import datetime, date, timedelta
 
-@mcp.tool
+@mcp.tool()
 def process_date_time(
     event_date: date,             # ISO format date string or date object
     event_time: datetime,         # ISO format datetime string or datetime object
@@ -709,7 +709,7 @@ def process_date_time(
 FastMCP supports all standard Python collection types:
 
 ```python
-@mcp.tool
+@mcp.tool()
 def analyze_data(
     values: list[float],           # List of numbers
     properties: dict[str, str],    # Dictionary with string keys and values
@@ -734,7 +734,7 @@ Collection types can be nested and combined to represent complex data structures
 For parameters that can accept multiple types or may be omitted:
 
 ```python
-@mcp.tool
+@mcp.tool()
 def flexible_search(
     query: str | int,              # Can be either string or integer
     filters: dict[str, str] | None = None,  # Optional dictionary
@@ -757,7 +757,7 @@ Literals constrain parameters to a specific set of values:
 ```python
 from typing import Literal
 
-@mcp.tool
+@mcp.tool()
 def sort_data(
     data: list[float],
     order: Literal["ascending", "descending"] = "ascending",
@@ -785,7 +785,7 @@ class Color(Enum):
     GREEN = "green"
     BLUE = "blue"
 
-@mcp.tool
+@mcp.tool()
 def process_image(
     image_path: str, 
     color_filter: Color = Color.RED
@@ -808,7 +808,7 @@ There are two approaches to handling binary data in tool parameters:
 #### Bytes
 
 ```python
-@mcp.tool
+@mcp.tool()
 def process_binary(data: bytes):
     """Process binary data directly.
     
@@ -832,7 +832,7 @@ FastMCP does not automatically decode base64-encoded strings for bytes parameter
 from typing import Annotated
 from pydantic import Field
 
-@mcp.tool
+@mcp.tool()
 def process_image_data(
     image_data: Annotated[str, Field(description="Base64-encoded image data")]
 ):
@@ -856,7 +856,7 @@ The `Path` type from the `pathlib` module can be used for file system paths:
 ```python
 from pathlib import Path
 
-@mcp.tool
+@mcp.tool()
 def process_file(path: Path) -> str:
     """Process a file at the given path."""
     assert isinstance(path, Path)  # Path is properly converted
@@ -872,7 +872,7 @@ The `UUID` type from the `uuid` module can be used for unique identifiers:
 ```python
 import uuid
 
-@mcp.tool
+@mcp.tool()
 def process_item(
     item_id: uuid.UUID  # String UUID or UUID object
 ) -> str:
@@ -897,7 +897,7 @@ class User(BaseModel):
     age: int | None = None
     is_active: bool = True
 
-@mcp.tool
+@mcp.tool()
 def create_user(user: User):
     """Create a new user in the system."""
     # The input is automatically validated against the User model
@@ -926,7 +926,7 @@ Note that fields can be used *outside* Pydantic models to provide metadata and v
 from typing import Annotated
 from pydantic import Field
 
-@mcp.tool
+@mcp.tool()
 def analyze_metrics(
     # Numbers with range constraints
     count: Annotated[int, Field(ge=0, le=100)],         # 0 <= count <= 100
@@ -951,7 +951,7 @@ def analyze_metrics(
 You can also use `Field` as a default value, though the `Annotated` approach is preferred:
 
 ```python
-@mcp.tool
+@mcp.tool()
 def validate_data(
     # Value constraints
     age: int = Field(ge=0, lt=120),                     # 0 <= age < 120
@@ -996,7 +996,7 @@ mcp = FastMCP(
     on_duplicate_tools="error"
 )
 
-@mcp.tool
+@mcp.tool()
 def my_tool(): return "Version 1"
 
 # This will now raise a ValueError because 'my_tool' already exists
@@ -1023,7 +1023,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="DynamicToolServer")
 
-@mcp.tool
+@mcp.tool()
 def calculate_sum(a: int, b: int) -> int:
     """Add two numbers together."""
     return a + b

--- a/docs/tutorials/create-mcp-server.mdx
+++ b/docs/tutorials/create-mcp-server.mdx
@@ -50,7 +50,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="My First MCP Server")
 
-@mcp.tool
+@mcp.tool()
 def add(a: int, b: int) -> int:
     """Adds two integer numbers together."""
     return a + b
@@ -74,7 +74,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="My First MCP Server")
 
-@mcp.tool
+@mcp.tool()
 def add(a: int, b: int) -> int:
     """Adds two integer numbers together."""
     return a + b
@@ -98,7 +98,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="My First MCP Server")
 
-@mcp.tool
+@mcp.tool()
 def add(a: int, b: int) -> int:
     """Adds two integer numbers together."""
     return a + b
@@ -129,7 +129,7 @@ from fastmcp import FastMCP
 
 mcp = FastMCP(name="My First MCP Server")
 
-@mcp.tool
+@mcp.tool()
 def add(a: int, b: int) -> int:
     """Adds two integer numbers together."""
     return a + b
@@ -165,7 +165,7 @@ from fastmcp import FastMCP
 mcp = FastMCP(name="My First MCP Server")
 
 # 2. Add a tool
-@mcp.tool
+@mcp.tool()
 def add(a: int, b: int) -> int:
     """Adds two integer numbers together."""
     return a + b

--- a/docs/tutorials/mcp.mdx
+++ b/docs/tutorials/mcp.mdx
@@ -42,7 +42,7 @@ from fastmcp import FastMCP
 mcp = FastMCP()
 
 # This function is now an MCP tool named "get_weather"
-@mcp.tool
+@mcp.tool()
 def get_weather(city: str) -> dict:
     """Gets the current weather for a specific city."""
     # In a real app, this would call a weather API

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -61,7 +61,7 @@ Most notably, it introduces the highly requested (and Pythonic) "naked" decorato
 ```python {3}
 mcp = FastMCP()
 
-@mcp.tool
+@mcp.tool()
 def add(a: int, b: int) -> int:
     return a + b
 ```

--- a/examples/complex_inputs.py
+++ b/examples/complex_inputs.py
@@ -20,7 +20,7 @@ class ShrimpTank(BaseModel):
     shrimp: list[Shrimp]
 
 
-@mcp.tool
+@mcp.tool()
 def name_shrimp(
     tank: ShrimpTank,
     # You can use pydantic Field in function signatures for validation.

--- a/examples/config_server.py
+++ b/examples/config_server.py
@@ -24,7 +24,7 @@ if args.debug:
 mcp = FastMCP(server_name)
 
 
-@mcp.tool
+@mcp.tool()
 def get_status() -> dict[str, str | bool]:
     """Get the current server configuration and status."""
     return {
@@ -34,7 +34,7 @@ def get_status() -> dict[str, str | bool]:
     }
 
 
-@mcp.tool
+@mcp.tool()
 def echo_message(message: str) -> str:
     """Echo a message, with debug info if debug mode is enabled."""
     if args.debug:

--- a/examples/desktop.py
+++ b/examples/desktop.py
@@ -26,7 +26,7 @@ def get_greeting(name: str) -> str:
     return f"Hello, {name}!"
 
 
-@mcp.tool
+@mcp.tool()
 def add(a: int, b: int) -> int:
     """Add two numbers"""
     return a + b

--- a/examples/echo.py
+++ b/examples/echo.py
@@ -8,7 +8,7 @@ from fastmcp import FastMCP
 mcp = FastMCP("Echo Server")
 
 
-@mcp.tool
+@mcp.tool()
 def echo_tool(text: str) -> str:
     """Echo the input text"""
     return text

--- a/examples/memory.py
+++ b/examples/memory.py
@@ -279,7 +279,7 @@ async def display_memory_tree(deps: Deps) -> str:
     return result
 
 
-@mcp.tool
+@mcp.tool()
 async def remember(
     contents: list[str] = Field(
         description="List of observations or memories to store"
@@ -294,7 +294,7 @@ async def remember(
         await deps.pool.close()
 
 
-@mcp.tool
+@mcp.tool()
 async def read_profile() -> str:
     deps = Deps(openai=AsyncOpenAI(), pool=await get_db_pool())
     profile = await display_memory_tree(deps)

--- a/examples/sampling.py
+++ b/examples/sampling.py
@@ -15,7 +15,7 @@ from fastmcp.client.sampling import RequestContext, SamplingMessage, SamplingPar
 mcp = FastMCP("Sampling Example")
 
 
-@mcp.tool
+@mcp.tool()
 async def example_tool(prompt: str, context: Context) -> str:
     """Sample a completion from the LLM."""
     response = await context.sample(

--- a/examples/screenshot.py
+++ b/examples/screenshot.py
@@ -13,7 +13,7 @@ from fastmcp.utilities.types import Image
 mcp = FastMCP("Screenshot Demo", dependencies=["pyautogui", "Pillow"])
 
 
-@mcp.tool
+@mcp.tool()
 def take_screenshot() -> Image:
     """
     Take a screenshot of the user's screen and return it as an image. Use

--- a/examples/simple_echo.py
+++ b/examples/simple_echo.py
@@ -8,7 +8,7 @@ from fastmcp import FastMCP
 mcp = FastMCP("Echo Server")
 
 
-@mcp.tool
+@mcp.tool()
 def echo(text: str) -> str:
     """Echo the input text"""
     return text

--- a/src/fastmcp/contrib/bulk_tool_caller/example.py
+++ b/src/fastmcp/contrib/bulk_tool_caller/example.py
@@ -6,7 +6,7 @@ from fastmcp.contrib.bulk_tool_caller import BulkToolCaller
 mcp = FastMCP()
 
 
-@mcp.tool
+@mcp.tool()
 def echo_tool(text: str) -> str:
     """Echo the input text"""
     return text


### PR DESCRIPTION
We have plenty of doc examples that are failing because of the `TypeError: The @tool decorator was used incorrectly. Did you forget to call it? Use @tool() instead of @tool`

This PR:
- fixes all the places the decorator was missing parentheses
- adds missing newlines in the touched docs
- removes unnecessary whitespaces in the docs