### PR TITLE
fix: add type hint to custom_route decorator

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -411,7 +411,10 @@ class FastMCP(Generic[LifespanResultT]):
         methods: list[str],
         name: str | None = None,
         include_in_schema: bool = True,
-    ):
+    ) -> Callable[
+        [Callable[[Request], Awaitable[Response]]],
+        Callable[[Request], Awaitable[Response]],
+    ]:
         """
         Decorator to register a custom HTTP route on the FastMCP server.
 


### PR DESCRIPTION
## Summary
- Adds proper return type annotation to the `custom_route` method to fix mypy strict mode compatibility
- Resolves the error: "Untyped decorator makes function untyped [misc]"

## Issue
Closes #1203

## Changes
Added return type annotation to `FastMCP.custom_route()` method:
```python
-> Callable[
    [Callable[[Request], Awaitable[Response]]],
    Callable[[Request], Awaitable[Response]],
]:
```

This tells mypy that `custom_route` returns a decorator that:
- Takes a function with signature `(Request) -> Awaitable[Response]`
- Returns the same function unchanged

## Test plan
To reproduce the issue and verify the fix:

```python
# test_typing.py
from starlette.requests import Request
from starlette.responses import JSONResponse
from fastmcp import FastMCP

mcp: FastMCP[None] = FastMCP("test")

@mcp.custom_route("/health", methods=["GET"])
async def health_check(request: Request) -> JSONResponse:
    return JSONResponse({"status": "healthy"})
```

Run mypy strict mode:
```bash
uvx mypy --strict --ignore-missing-imports test_typing.py
```

Before the fix: ❌ `error: Untyped decorator makes function "health_check" untyped [misc]`

After the fix: ✅ `Success: no issues found in 1 source file`

- [x] Verified the fix resolves the mypy strict mode error
- [x] All existing tests pass (`pytest tests/server/http/test_custom_routes.py`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)