### PR TITLE
RFC: Expose initialization requests to middleware, and provide session storage

### DIFF
--- a/src/fastmcp/server/low_level.py
+++ b/src/fastmcp/server/low_level.py
@@ -1,5 +1,8 @@
-from typing import Any
+from contextlib import AsyncExitStack
+from typing import TYPE_CHECKING, Any
 
+import anyio
+import mcp.types as types
 from mcp.server.lowlevel.server import (
     LifespanResultT,
     NotificationOptions,
@@ -9,6 +12,66 @@ from mcp.server.lowlevel.server import (
     Server as _Server,
 )
 from mcp.server.models import InitializationOptions
+from mcp.server.session import ServerSession
+from mcp.shared.session import RequestResponder
+
+if TYPE_CHECKING:
+    from fastmcp.server.middleware.middleware import MiddlewareContext
+    from fastmcp.server.server import FastMCP
+
+
+class MiddlewareExposedServerSession(ServerSession):
+    """ServerSession that routes initialization requests through FastMCP middleware."""
+
+    def __init__(self, fastmcp_server: "FastMCP", *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fastmcp_server = fastmcp_server
+
+    async def _received_request(
+        self, responder: RequestResponder[types.ClientRequest, types.ServerResult]
+    ):
+        # Check if this is an initialization request and if middleware should handle it
+        if (
+            isinstance(responder.request.root, types.InitializeRequest)
+            and self.fastmcp_server
+            and hasattr(self.fastmcp_server, "_apply_middleware")
+        ):
+            # Import here to avoid circular imports
+            from fastmcp.server.middleware.middleware import MiddlewareContext
+
+            # HACK: Pass session object directly to middleware context for proof-of-concept
+            context = MiddlewareContext(
+                message=responder.request.root.params,
+                method="initialize",
+                type="request",
+                source="client",
+                session=self,  # Pass session so middleware can store data on it
+            )
+
+            # Create a continuation that calls the original initialization handler
+            async def call_original_handler(
+                ctx: "MiddlewareContext",
+            ) -> types.InitializeResult:
+                # Call the original handler by continuing to the parent implementation
+                await super(MiddlewareExposedServerSession, self)._received_request(
+                    responder
+                )
+                # The response will be handled by the parent, we just need to extract the result
+                # This is a bit tricky since the parent handles the response internally
+                # For now, we'll call the parent and assume it handles the response correctly
+                return None  # Parent handles the actual response
+
+            # Apply middleware chain, but still let parent handle the actual response
+            try:
+                await self.fastmcp_server._apply_middleware(
+                    context, call_original_handler
+                )
+            except Exception:
+                # If middleware fails, fall back to original handling
+                await super()._received_request(responder)
+        else:
+            # For non-initialization requests or when no middleware, use original handling
+            await super()._received_request(responder)
 
 
 class LowLevelServer(_Server[LifespanResultT, RequestT]):
@@ -20,6 +83,8 @@ class LowLevelServer(_Server[LifespanResultT, RequestT]):
             resources_changed=True,
             tools_changed=True,
         )
+        # Reference to FastMCP server for middleware integration
+        self.fastmcp_server: FastMCP | None = None
 
     def create_initialization_options(
         self,
@@ -35,3 +100,46 @@ class LowLevelServer(_Server[LifespanResultT, RequestT]):
             experimental_capabilities=experimental_capabilities,
             **kwargs,
         )
+
+    async def run(
+        self,
+        read_stream,
+        write_stream,
+        initialization_options,
+        raise_exceptions=False,
+        stateless=False,
+    ):
+        """Override run to use MiddlewareExposedServerSession when fastmcp_server is available."""
+        async with AsyncExitStack() as stack:
+            lifespan_context = await stack.enter_async_context(self.lifespan(self))
+
+            # Use MiddlewareExposedServerSession if we have a FastMCP server, otherwise use default
+            if self.fastmcp_server:
+                session = await stack.enter_async_context(
+                    MiddlewareExposedServerSession(
+                        self.fastmcp_server,
+                        read_stream,
+                        write_stream,
+                        initialization_options,
+                        stateless=stateless,
+                    )
+                )
+            else:
+                session = await stack.enter_async_context(
+                    ServerSession(
+                        read_stream,
+                        write_stream,
+                        initialization_options,
+                        stateless=stateless,
+                    )
+                )
+
+            async with anyio.create_task_group() as tg:
+                async for message in session.incoming_messages:
+                    tg.start_soon(
+                        self._handle_message,
+                        message,
+                        session,
+                        lifespan_context,
+                        raise_exceptions,
+                    )

--- a/src/fastmcp/server/middleware/middleware.py
+++ b/src/fastmcp/server/middleware/middleware.py
@@ -53,6 +53,9 @@ class MiddlewareContext(Generic[T]):
 
     fastmcp_context: Context | None = None
 
+    # HACK: Session object for initialization middleware access
+    session: Any | None = None
+
     # Common metadata
     source: Literal["client", "server"] = "client"
     type: Literal["request", "notification"] = "request"
@@ -98,6 +101,8 @@ class Middleware:
         handler = call_next
 
         match context.method:
+            case "initialize":
+                handler = partial(self.on_initialize, call_next=handler)
             case "tools/call":
                 handler = partial(self.on_call_tool, call_next=handler)
             case "resources/read":
@@ -142,6 +147,13 @@ class Middleware:
         context: MiddlewareContext[mt.Notification],
         call_next: CallNext[mt.Notification, Any],
     ) -> Any:
+        return await call_next(context)
+
+    async def on_initialize(
+        self,
+        context: MiddlewareContext[mt.InitializeRequestParams],
+        call_next: CallNext[mt.InitializeRequestParams, mt.InitializeResult],
+    ) -> mt.InitializeResult:
         return await call_next(context)
 
     async def on_call_tool(

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -198,6 +198,8 @@ class FastMCP(Generic[LifespanResultT]):
             instructions=instructions,
             lifespan=_lifespan_wrapper(self, lifespan),
         )
+        # Set reference for middleware integration with initialization
+        self._mcp_server.fastmcp_server = self
 
         # if auth is `NotSet`, try to create a provider from the environment
         if auth is NotSet:


### PR DESCRIPTION
This is a proof-of-concept I hacked up with Claude.  I'm not proposing it for merge as-is.

I haven't thought carefully about the consequences of these modifications.  This might be touching on stateful/less aspects of MCP; not sure and perhaps not any more so than progress tokens or other remembered data on either side of the connection.   If there is interest, I'll take a closer look.

I was intrigued by a middleware based solution for #1193 and #1159, but this requires modifying FastMCP.

Middleware documentation mentions all requests are exposed to middleware, but this is not true.  The initialization part of the lifecycle is handled in the session establishment and not available to middleware.

This hack adds:

- A new session class which exposes itself to middleware for `on_initialize`
- Adds the session to the MiddlewareContext so there is cross-request storage for data only available in specific requests

It allows a middleware [like this](https://github.com/richardkmichael/fastmcp-experiments/blob/development/dereference_for_claude_middleware.py#L223-L242):

```python
class DereferenceForClaudeMiddleware(Middleware):
    async def on_initialize(self, context: MiddlewareContext, call_next):
        """Detect Claude clients and store on session object."""
        client_info = getattr(context.message, "clientInfo", None)
        client_name = (
            getattr(client_info, "name", "unknown") if client_info else "unknown"
        )

        is_claude_client = self._is_claude_client(client_name)

        # HACK: Store client type directly on session object
        if hasattr(context, "session") and context.session:
            context.session.is_claude_client = is_claude_client

        if is_claude_client:
            logger.info(f"Claude ({client_name}) detected - will dereference schemas")
        else:
            logger.info(
                f"Non-Claude ({client_name}) detected - schemas will remain unchanged"
            )

        return await call_next(context)

    async def on_list_tools(self, context: MiddlewareContext, call_next):
        """Dereference tool schemas for Claude clients."""
        tools = await call_next(context)

        # HACK: Read client type from session object (stored during initialization)
        is_claude_client = False
        if context.fastmcp_context and context.fastmcp_context.session:
            is_claude_client = getattr(
                context.fastmcp_context.session, "is_claude_client", False
            )

        if is_claude_client:
            for tool in tools:
                original_schema = deepcopy(tool.parameters)
                dereferenced_schema = self.dereference_json_schema(tool.parameters)

                if original_schema != dereferenced_schema:
                    tool.parameters = dereferenced_schema

        return tools
```


I think exposing initialization to middleware would also be useful for:
- logging
- analytics (i.e. server usage by specific MCP clients)
- future proofing for other [misbehaved] clients