### PR TITLE
fix: handle non-string $ref values in experimental OpenAPI parser

### DIFF
--- a/src/fastmcp/experimental/utilities/openapi/parser.py
+++ b/src/fastmcp/experimental/utilities/openapi/parser.py
@@ -146,6 +146,9 @@ class OpenAPIParser(
         """Resolves a reference to its target definition."""
         if isinstance(item, self.reference_cls):
             ref_str = item.ref
+            # Ensure ref_str is a string before calling startswith()
+            if not isinstance(ref_str, str):
+                return item
             try:
                 if not ref_str.startswith("#/"):
                     raise ValueError(

--- a/src/fastmcp/experimental/utilities/openapi/schemas.py
+++ b/src/fastmcp/experimental/utilities/openapi/schemas.py
@@ -93,15 +93,16 @@ def _replace_ref_with_defs(
     """
     schema = info.copy()
     if ref_path := schema.get("$ref"):
-        if ref_path.startswith("#/components/schemas/"):
-            schema_name = ref_path.split("/")[-1]
-            schema["$ref"] = f"#/$defs/{schema_name}"
-        elif not ref_path.startswith("#/"):
-            raise ValueError(
-                f"External or non-local reference not supported: {ref_path}. "
-                f"FastMCP only supports local schema references starting with '#/'. "
-                f"Please include all schema definitions within the OpenAPI document."
-            )
+        if isinstance(ref_path, str):
+            if ref_path.startswith("#/components/schemas/"):
+                schema_name = ref_path.split("/")[-1]
+                schema["$ref"] = f"#/$defs/{schema_name}"
+            elif not ref_path.startswith("#/"):
+                raise ValueError(
+                    f"External or non-local reference not supported: {ref_path}. "
+                    f"FastMCP only supports local schema references starting with '#/'. "
+                    f"Please include all schema definitions within the OpenAPI document."
+                )
     elif properties := schema.get("properties"):
         if "$ref" in properties:
             schema["properties"] = _replace_ref_with_defs(properties)


### PR DESCRIPTION
Apply the same fix from #1164 to the experimental OpenAPI parser. Some OpenAPI specs use non-string values for `$ref` properties, causing `AttributeError` when calling `startswith()` on them.

```python
# Before (causes error)
if ref_path.startswith("#/components/schemas/"):

# After (safe)
if isinstance(ref_path, str) and ref_path.startswith("#/components/schemas/"):
```

This fixes the "Failed to extract schema as dict: 'dict' object has no attribute 'startswith'" errors when parsing certain OpenAPI specifications like the GitHub API schema.

🤖 Generated with [Claude Code](https://claude.ai/code)

Also closes #1220 