### PR TITLE
cache _load_tools() and has_tool() , both used by list_tools() and call_tool()

### DIFF
--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import datetime
+import time
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -69,6 +70,9 @@ logger = get_logger(__name__)
 
 T = TypeVar("T", bound="ClientTransport")
 
+# Global cache for list_tools() results to minimize repeated schema fetching
+_GLOBAL_LIST_TOOLS_CACHE: dict[str, tuple[float, Any]] = {}
+
 
 @dataclass
 class ClientSessionState:
@@ -132,6 +136,8 @@ class Client(Generic[ClientTransportT]):
         timeout: Optional timeout for requests (seconds or timedelta)
         init_timeout: Optional timeout for initial connection (seconds or timedelta).
             Set to 0 to disable. If None, uses the value in the FastMCP global settings.
+        list_tools_cache_ttl: Optional cache TTL for list_tools() results (seconds or timedelta).
+            If None (default), caching is disabled. Specify a positive value to enable caching.
 
     Examples:
         ```python
@@ -217,6 +223,7 @@ class Client(Generic[ClientTransportT]):
         init_timeout: datetime.timedelta | float | int | None = None,
         client_info: mcp.types.Implementation | None = None,
         auth: httpx.Auth | Literal["oauth"] | str | None = None,
+        list_tools_cache_ttl: datetime.timedelta | float | int | None = None,
     ) -> None:
         self.transport = cast(ClientTransportT, infer_transport(transport))
         if auth is not None:
@@ -266,8 +273,31 @@ class Client(Generic[ClientTransportT]):
                 elicitation_handler
             )
 
+        # Handle list_tools cache TTL
+        if list_tools_cache_ttl is None:
+            self._list_tools_cache_ttl = None  # No caching by default
+        elif isinstance(list_tools_cache_ttl, datetime.timedelta):
+            self._list_tools_cache_ttl = list_tools_cache_ttl.total_seconds()
+        else:
+            self._list_tools_cache_ttl = float(list_tools_cache_ttl)
+
         # Session context management - see class docstring for detailed explanation
         self._session_state = ClientSessionState()
+
+    def _cleanup_expired_list_tools_cache(self) -> None:
+        """Remove expired list_tools cache entries."""
+        if self._list_tools_cache_ttl is None:
+            return  # No caching enabled
+
+        global _GLOBAL_LIST_TOOLS_CACHE
+        current_time = time.time()
+        expired_keys = [
+            key
+            for key, (timestamp, _) in _GLOBAL_LIST_TOOLS_CACHE.items()
+            if current_time - timestamp > self._list_tools_cache_ttl
+        ]
+        for key in expired_keys:
+            del _GLOBAL_LIST_TOOLS_CACHE[key]
 
     @property
     def session(self) -> ClientSession:
@@ -767,10 +797,34 @@ class Client(Generic[ClientTransportT]):
             mcp.types.ListToolsResult: The complete response object from the protocol,
                 containing the list of tools and any additional metadata.
 
+        Results can be cached to minimize repeated MCP server calls when enabled.
+        Use the list_tools_cache_ttl constructor parameter to enable caching.
+
         Raises:
             RuntimeError: If called while the client is not connected.
         """
+        # Skip caching if disabled
+        if self._list_tools_cache_ttl is None:
+            return await self.session.list_tools()
+
+        global _GLOBAL_LIST_TOOLS_CACHE
+
+        # Check cache first
+        cache_key = f"list_tools_{id(self.session)}"
+        current_time = time.time()
+
+        if cache_key in _GLOBAL_LIST_TOOLS_CACHE:
+            cache_timestamp, cached_result = _GLOBAL_LIST_TOOLS_CACHE[cache_key]
+            if current_time - cache_timestamp <= self._list_tools_cache_ttl:
+                return cached_result
+
+        # Cache miss - fetch from server
         result = await self.session.list_tools()
+
+        # Cache the result and cleanup expired entries
+        _GLOBAL_LIST_TOOLS_CACHE[cache_key] = (current_time, result)
+        self._cleanup_expired_list_tools_cache()
+
         return result
 
     async def list_tools(self) -> list[mcp.types.Tool]:

--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -136,8 +136,8 @@ class Client(Generic[ClientTransportT]):
         timeout: Optional timeout for requests (seconds or timedelta)
         init_timeout: Optional timeout for initial connection (seconds or timedelta).
             Set to 0 to disable. If None, uses the value in the FastMCP global settings.
-        list_tools_cache_ttl: Optional cache TTL for list_tools() results (seconds or timedelta).
-            If None (default), caching is disabled. Specify a positive value to enable caching.
+        tools_cache_ttl: Optional cache TTL for tools operations in seconds.
+            If None (default), caching is disabled. Specify a positive integer to enable caching.
 
     Examples:
         ```python
@@ -223,9 +223,17 @@ class Client(Generic[ClientTransportT]):
         init_timeout: datetime.timedelta | float | int | None = None,
         client_info: mcp.types.Implementation | None = None,
         auth: httpx.Auth | Literal["oauth"] | str | None = None,
-        list_tools_cache_ttl: datetime.timedelta | float | int | None = None,
+        tools_cache_ttl: int | None = None,
     ) -> None:
-        self.transport = cast(ClientTransportT, infer_transport(transport))
+        # Handle MCPConfig case specially to pass through cache TTL
+        if isinstance(transport, (MCPConfig, dict)):
+            self.transport = cast(ClientTransportT, MCPConfigTransport(
+                transport, 
+                tools_cache_ttl=tools_cache_ttl
+            ))
+        else:
+            self.transport = cast(ClientTransportT, infer_transport(transport))
+            
         if auth is not None:
             self.transport._set_auth(auth)
 
@@ -273,20 +281,15 @@ class Client(Generic[ClientTransportT]):
                 elicitation_handler
             )
 
-        # Handle list_tools cache TTL
-        if list_tools_cache_ttl is None:
-            self._list_tools_cache_ttl = None  # No caching by default
-        elif isinstance(list_tools_cache_ttl, datetime.timedelta):
-            self._list_tools_cache_ttl = list_tools_cache_ttl.total_seconds()
-        else:
-            self._list_tools_cache_ttl = float(list_tools_cache_ttl)
+        # Handle tools cache TTL
+        self._tools_cache_ttl = tools_cache_ttl
 
         # Session context management - see class docstring for detailed explanation
         self._session_state = ClientSessionState()
 
     def _cleanup_expired_list_tools_cache(self) -> None:
         """Remove expired list_tools cache entries."""
-        if self._list_tools_cache_ttl is None:
+        if self._tools_cache_ttl is None:
             return  # No caching enabled
 
         global _GLOBAL_LIST_TOOLS_CACHE
@@ -294,7 +297,7 @@ class Client(Generic[ClientTransportT]):
         expired_keys = [
             key
             for key, (timestamp, _) in _GLOBAL_LIST_TOOLS_CACHE.items()
-            if current_time - timestamp > self._list_tools_cache_ttl
+            if current_time - timestamp > self._tools_cache_ttl
         ]
         for key in expired_keys:
             del _GLOBAL_LIST_TOOLS_CACHE[key]
@@ -798,13 +801,13 @@ class Client(Generic[ClientTransportT]):
                 containing the list of tools and any additional metadata.
 
         Results can be cached to minimize repeated MCP server calls when enabled.
-        Use the list_tools_cache_ttl constructor parameter to enable caching.
+        Use the tools_cache_ttl constructor parameter to enable caching.
 
         Raises:
             RuntimeError: If called while the client is not connected.
         """
         # Skip caching if disabled
-        if self._list_tools_cache_ttl is None:
+        if self._tools_cache_ttl is None:
             return await self.session.list_tools()
 
         global _GLOBAL_LIST_TOOLS_CACHE
@@ -815,7 +818,7 @@ class Client(Generic[ClientTransportT]):
 
         if cache_key in _GLOBAL_LIST_TOOLS_CACHE:
             cache_timestamp, cached_result = _GLOBAL_LIST_TOOLS_CACHE[cache_key]
-            if current_time - cache_timestamp <= self._list_tools_cache_ttl:
+            if current_time - cache_timestamp <= self._tools_cache_ttl:
                 return cached_result
 
         # Cache miss - fetch from server

--- a/src/fastmcp/client/transports.py
+++ b/src/fastmcp/client/transports.py
@@ -772,7 +772,7 @@ class MCPConfigTransport(ClientTransport):
         ```
     """
 
-    def __init__(self, config: MCPConfig | dict, name_as_prefix: bool = True):
+    def __init__(self, config: MCPConfig | dict, name_as_prefix: bool = True, tools_cache_ttl: int | None = None):
         from fastmcp.utilities.mcp_config import composite_server_from_mcp_config
 
         if isinstance(config, dict):
@@ -791,7 +791,7 @@ class MCPConfigTransport(ClientTransport):
         else:
             self.transport = FastMCPTransport(
                 mcp=composite_server_from_mcp_config(
-                    self.config, name_as_prefix=name_as_prefix
+                    self.config, name_as_prefix=name_as_prefix, tools_cache_ttl=tools_cache_ttl
                 )
             )
 

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -150,6 +150,7 @@ class FastMCP(Generic[LifespanResultT]):
         mask_error_details: bool | None = None,
         tools: list[Tool | Callable[..., Any]] | None = None,
         tool_transformations: dict[str, ToolTransformConfig] | None = None,
+        tools_cache_ttl: int | None = None,
         dependencies: list[str] | None = None,
         include_tags: set[str] | None = None,
         exclude_tags: set[str] | None = None,
@@ -180,6 +181,7 @@ class FastMCP(Generic[LifespanResultT]):
             duplicate_behavior=on_duplicate_tools,
             mask_error_details=mask_error_details,
             transformations=tool_transformations,
+            tools_cache_ttl=tools_cache_ttl,
         )
         self._resource_manager = ResourceManager(
             duplicate_behavior=on_duplicate_resources,

--- a/src/fastmcp/tools/tool_manager.py
+++ b/src/fastmcp/tools/tool_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -36,6 +37,13 @@ class ToolManager:
         self.mask_error_details = mask_error_details or settings.mask_error_details
         self.transformations = transformations or {}
 
+        # Tool existence cache to minimize server calls during validation
+        self._tool_existence_cache: dict[str, bool] = {}
+
+        # Optimal caching at _load_tools level (catches both get_tools and list_tools)
+        self._load_tools_cache: dict[bool, tuple[float, dict[str, Tool]]] = {}
+        self._tools_cache_ttl: float = 300  # 5 minutes
+
         # Default to "warn" if None is provided
         if duplicate_behavior is None:
             duplicate_behavior = "warn"
@@ -60,6 +68,22 @@ class ToolManager:
         - via_server=False: Manager-to-manager path for complete, unfiltered inventory
         - via_server=True: Server-to-server path for filtered MCP requests
         """
+        import time
+        import datetime
+        timestamp = datetime.datetime.now().strftime("%H:%M:%S.%f")[:-3]
+        print(f"🔍 [{timestamp}] _load_tools(via_server={via_server}) CALLED")
+
+        current_time = time.time()
+
+        # Check cache for this specific via_server parameter
+        if via_server in self._load_tools_cache:
+            cache_timestamp, cached_result = self._load_tools_cache[via_server]
+            if current_time - cache_timestamp <= self._tools_cache_ttl:
+                cache_age = current_time - cache_timestamp
+                print(f"🔍 [{timestamp}] _load_tools(via_server={via_server}) CACHE HIT - {len(cached_result)} tools (age: {cache_age:.1f}s)")
+                return cached_result
+
+        print(f"🔍 [{timestamp}] _load_tools(via_server={via_server}) CACHE MISS - loading from servers")
         all_tools: dict[str, Tool] = {}
 
         for mounted in self._mounted_servers:
@@ -94,32 +118,101 @@ class ToolManager:
             transformations=self.transformations,
         )
 
+        # Update cache
+        self._load_tools_cache[via_server] = (current_time, transformed_tools)
+        self._tool_existence_cache.clear()  # Clear existence cache when tools change
+
+        print(f"🔍 [{timestamp}] _load_tools(via_server={via_server}) COMPLETED - {len(transformed_tools)} tools (cached)")
         return transformed_tools
 
     async def has_tool(self, key: str) -> bool:
-        """Check if a tool exists."""
+        """Check if a tool exists - optimized with existence cache."""
+        import traceback
+        import datetime
+        timestamp = datetime.datetime.now().strftime("%H:%M:%S.%f")[:-3]
+        stack = traceback.extract_stack()
+        caller_info = f"{stack[-2].filename}:{stack[-2].lineno} in {stack[-2].name}"
+        print(f"🔍 [{timestamp}] has_tool('{key}') CALLED from: {caller_info}")
+
+        # Check existence cache first
+        if key in self._tool_existence_cache:
+            result = self._tool_existence_cache[key]
+            print(f"🔍 [{timestamp}] has_tool('{key}') EXISTENCE CACHE HIT - {result}")
+            return result
+
+        # Check local tools first (immediate)
+        if key in self._tools:
+            self._tool_existence_cache[key] = True
+            print(f"🔍 [{timestamp}] has_tool('{key}') COMPLETED - found in local tools")
+            return True
+
+        # Check mounted servers with prefix matching (targeted)
+        for mounted in self._mounted_servers:
+            if mounted.prefix:
+                if key.startswith(f"{mounted.prefix}_"):
+                    self._tool_existence_cache[key] = True
+                    print(f"🔍 [{timestamp}] has_tool('{key}') COMPLETED - prefix match for {mounted.prefix}")
+                    return True
+
+        # Fallback to full tool loading only if needed
         tools = await self.get_tools()
-        return key in tools
+        result = key in tools
+        self._tool_existence_cache[key] = result
+        print(f"🔍 [{timestamp}] has_tool('{key}') COMPLETED - {result} (full lookup, cached)")
+        return result
 
     async def get_tool(self, key: str) -> Tool:
-        """Get tool by key."""
+        """Get tool by key - optimized for validation."""
+        import traceback
+        import datetime
+        timestamp = datetime.datetime.now().strftime("%H:%M:%S.%f")[:-3]
+        stack = traceback.extract_stack()
+        caller_info = f"{stack[-2].filename}:{stack[-2].lineno} in {stack[-2].name}"
+        print(f"🔍 [{timestamp}] get_tool('{key}') CALLED from: {caller_info}")
+
+        # Check local tools first (immediate)
+        if key in self._tools:
+            tool = self._tools[key]
+            print(f"🔍 [{timestamp}] get_tool('{key}') COMPLETED - found in local tools")
+            return tool
+
+        # For mounted servers, we still need full tool loading for the Tool object
+        # But this gives us visibility into the pattern
         tools = await self.get_tools()
         if key in tools:
+            print(f"🔍 [{timestamp}] get_tool('{key}') COMPLETED - found via full lookup")
             return tools[key]
+        print(f"🔍 [{timestamp}] get_tool('{key}') COMPLETED - NOT FOUND")
         raise NotFoundError(f"Tool {key!r} not found")
 
     async def get_tools(self) -> dict[str, Tool]:
         """
         Gets the complete, unfiltered inventory of all tools.
         """
-        return await self._load_tools(via_server=False)
+        import traceback
+        import datetime
+        timestamp = datetime.datetime.now().strftime("%H:%M:%S.%f")[:-3]
+        stack = traceback.extract_stack()
+        caller_info = f"{stack[-2].filename}:{stack[-2].lineno} in {stack[-2].name}"
+        print(f"🔍 [{timestamp}] get_tools() CALLED from: {caller_info}")
+        result = await self._load_tools(via_server=False)
+        print(f"🔍 [{timestamp}] get_tools() COMPLETED - {len(result)} tools")
+        return result
 
     async def list_tools(self) -> list[Tool]:
         """
         Lists all tools, applying protocol filtering.
         """
+        import traceback
+        import datetime
+        timestamp = datetime.datetime.now().strftime("%H:%M:%S.%f")[:-3]
+        stack = traceback.extract_stack()
+        caller_info = f"{stack[-2].filename}:{stack[-2].lineno} in {stack[-2].name}"
+        print(f"🔍 [{timestamp}] list_tools() CALLED from: {caller_info}")
         tools_dict = await self._load_tools(via_server=True)
-        return list(tools_dict.values())
+        result = list(tools_dict.values())
+        print(f"🔍 [{timestamp}] list_tools() COMPLETED - {len(result)} tools")
+        return result
 
     @property
     def _tools_transformed(self) -> list[str]:
@@ -211,7 +304,29 @@ class ToolManager:
         filtered protocol path.
         """
         # 1. Check local tools first. The server will have already applied its filter.
-        if key in self._tools or key in self._tools_transformed:
+        if key in self._tools:
+            # Direct access - avoid loading all tools from all servers
+            tool = self._tools[key]
+            try:
+                return await tool.run(arguments)
+
+            # raise ToolErrors as-is
+            except ToolError as e:
+                logger.exception(f"Error calling tool {key!r}")
+                raise e
+
+            # Handle other exceptions
+            except Exception as e:
+                logger.exception(f"Error calling tool {key!r}")
+                if self.mask_error_details:
+                    # Mask internal details
+                    raise ToolError(f"Error calling tool {key!r}") from e
+                else:
+                    # Include original error details
+                    raise ToolError(f"Error calling tool {key!r}: {e}") from e
+
+        # 1.1 Check transformed tools (these need the full tool resolution)
+        elif key in self._tools_transformed:
             tool = await self.get_tool(key)
             if not tool:
                 raise NotFoundError(f"Tool {key!r} not found")

--- a/src/fastmcp/utilities/mcp_config.py
+++ b/src/fastmcp/utilities/mcp_config.py
@@ -3,10 +3,10 @@ from fastmcp.server.server import FastMCP
 
 
 def composite_server_from_mcp_config(
-    config: MCPConfig, name_as_prefix: bool = True
+    config: MCPConfig, name_as_prefix: bool = True, tools_cache_ttl: int | None = None
 ) -> FastMCP:
     """A utility function to create a composite server from an MCPConfig."""
-    composite_server = FastMCP()
+    composite_server = FastMCP(tools_cache_ttl=tools_cache_ttl)
 
     mount_mcp_config_into_server(config, composite_server, name_as_prefix)
 


### PR DESCRIPTION
Because each call to call_tool results in 5 calls to list_tools which can be slow when many MCP servers. In my case, I have 30+ MCP servers running. and each call to list_tools takes ~100ms x5 makes each request take a minimum of 500ms for call_tool().

To not change the functioanlity of fastmcp, by default, caching is disabled. User should do `Client(list_tools_cache_ttl=300)` to enable list_tools caching for 5 minutes. 