### PR TITLE
feat (#1162): Introduce Bearer Auth for In-Memory Transport

### DIFF
--- a/docs/patterns/testing.mdx
+++ b/docs/patterns/testing.mdx
@@ -37,6 +37,51 @@ async def test_tool_functionality(mcp_server):
 
 This pattern creates a direct connection between the client and server, allowing you to test your server's functionality efficiently.
 
+You can also test your MCP servers with Bearer Token Authentication with this approach, by using the [Generating Tokens](https://gofastmcp.com/servers/auth/bearer#generating-tokens) functionality.
+
+```python
+import pytest
+
+from tools import mytool
+
+from fastmcp import FastMCP, Client
+from fastmcp.server.auth import BearerAuthProvider
+from fastmcp.server.auth.providers.bearer import RSAKeyPair
+
+@pytest.fixture(scope="module")
+def rsa_key_pair() -> RSAKeyPair:
+    return RSAKeyPair.generate()
+
+
+@pytest.fixture
+def bearer_provider(rsa_key_pair: RSAKeyPair) -> BearerAuthProvider:
+    return BearerAuthProvider(
+        public_key=rsa_key_pair.public_key,
+        issuer="https://test.example.com",
+        audience="https://api.example.com",
+    )
+
+@pytest.fixture
+def mcp_server(bearer_provider):
+    server = FastMCP("TestServer", auth=bearer_provider)
+    server.tool()(mytool.to_test)
+    return server
+
+async def test_my_tool_jwt_claims(mcp_server, rsa_key_pair):
+    async with Client(
+        mcp_server,
+        auth=rsa_key_pair.create_token(
+            subject="john.doe@example.com",
+            issuer="https://test.example.com",
+            audience="https://api.example.com",
+            additional_claims={
+                /* Add as many claims to be tested for your business logic as you want
+            }
+        )
+    ) as client:
+        ...
+```
+
 <Tip>
 If you're using pytest for async tests, as shown above, you may need to configure appropriate markers or set `asyncio_mode = "auto"` in your pytest configuration in order to handle async test functions automatically.
 </Tip> 

--- a/src/fastmcp/client/transports.py
+++ b/src/fastmcp/client/transports.py
@@ -691,8 +691,9 @@ class FastMCPTransport(ClientTransport):
         # ``_mcp_server`` attribute pointing to the underlying MCP server
         # implementation, so we can treat them identically.
         self.server = mcp
-        self.auth = self._set_auth(auth)
         self.raise_exceptions = raise_exceptions
+
+        self._set_auth(auth)
 
     @contextlib.asynccontextmanager
     async def connect_session(

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -310,9 +310,7 @@ async def test_server_deserialization_error():
         with pytest.raises(McpError, match="Error rendering prompt"):
             await client.get_prompt(
                 "strict_typed_prompt",
-                {
-                    "numbers": "not valid json"  # This will fail server-side conversion
-                },
+                {"numbers": "not valid json"},  # This will fail server-side conversion
             )
 
 
@@ -984,6 +982,25 @@ class TestAuth:
         client = Client(transport=SSETransport("http://localhost:8000", auth="oauth"))
         assert isinstance(client.transport, SSETransport)
         assert isinstance(client.transport.auth, OAuthClientProvider)
+
+    def test_auth_string_sets_up_bearer_in_memory(self, fastmcp_server: FastMCP):
+        client = Client(
+            transport=FastMCPTransport(fastmcp_server),
+            auth="test_token",
+        )
+        assert isinstance(client.transport, FastMCPTransport)
+        assert isinstance(client.transport.auth, BearerAuth)
+        assert client.transport.auth.token.get_secret_value() == "test_token"
+
+    def test_auth_string_pass_direct_to_transport_in_memory(
+        self, fastmcp_server: FastMCP
+    ):
+        client = Client(
+            transport=FastMCPTransport(fastmcp_server, auth="test_token"),
+        )
+        assert isinstance(client.transport, FastMCPTransport)
+        assert isinstance(client.transport.auth, BearerAuth)
+        assert client.transport.auth.token.get_secret_value() == "test_token"
 
     def test_auth_string_sets_up_bearer_auth_shttp(self):
         client = Client(


### PR DESCRIPTION
## Context

Developers may implement some business logic regarding the received JWT Token which is being provided as part of the Bearer Authentication, like claims verification or similar.

Since this logic may be introduced, I consider the easiest way to test it would by allowing bearer auth directly in the in-memory transport, as stated in #1162, plus it doesn't really affect the business logic on those not implementing it.

