### PR TITLE
Refactor `get_http_request` and `context.session_id`

### DIFF
--- a/src/fastmcp/server/dependencies.py
+++ b/src/fastmcp/server/dependencies.py
@@ -37,9 +37,14 @@ def get_context() -> Context:
 
 
 def get_http_request() -> Request:
-    from fastmcp.server.http import _current_http_request
+    from mcp.server.lowlevel.server import request_ctx
 
-    request = _current_http_request.get()
+    request = None
+    try:
+        request = request_ctx.get().request
+    except LookupError:
+        pass
+
     if request is None:
         raise RuntimeError("No active HTTP request found.")
     return request
@@ -72,6 +77,8 @@ def get_http_headers(include_all: bool = False) -> dict[str, str]:
             "proxy-authenticate",
             "proxy-authorization",
             "proxy-connection",
+            # MCP-related headers
+            "mcp-session-id",
         }
         # (just in case)
         if not all(h.lower() == h for h in exclude_headers):


### PR DESCRIPTION
According to the discussion by @gumgum27 in #956, in SHTTP transports, we can try to obtain the HTTP request from `request_ctx`. I think this aligns more with the original design intent of the `get_http_request` method, while also solving the issue of the session ID being `None`.

The second commit refactors the `session_id` of context; when the session ID cannot be found, it generates a UUID string as a substitute. This allows the concept of the session ID to extend from stateful SHTTP to SSE, stdio, in-memory, and other transports, which might be useful. This change caused the old tests to fail, so I rewrote the tests. 

Claude's review pointed out a thread safety issue with the generation process, but this implementation should be coroutine-safe, so I kept this commit.