### PR TITLE
Change server flag to --name

### DIFF
--- a/src/fastmcp/cli/install/claude_code.py
+++ b/src/fastmcp/cli/install/claude_code.py
@@ -173,7 +173,7 @@ def claude_code_command(
     server_name: Annotated[
         str | None,
         cyclopts.Parameter(
-            name=["--server-name", "-n"],
+            name=["--name", "-n"],
             help="Custom name for the server in Claude Code",
         ),
     ] = None,

--- a/src/fastmcp/cli/install/claude_desktop.py
+++ b/src/fastmcp/cli/install/claude_desktop.py
@@ -146,7 +146,7 @@ def claude_desktop_command(
     server_name: Annotated[
         str | None,
         cyclopts.Parameter(
-            name=["--server-name", "-n"],
+            name=["--name", "-n"],
             help="Custom name for the server in Claude Desktop's config",
         ),
     ] = None,

--- a/src/fastmcp/cli/install/cursor.py
+++ b/src/fastmcp/cli/install/cursor.py
@@ -156,7 +156,7 @@ def cursor_command(
     server_name: Annotated[
         str | None,
         cyclopts.Parameter(
-            name=["--server-name", "-n"],
+            name=["--name", "-n"],
             help="Custom name for the server in Cursor",
         ),
     ] = None,

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -37,7 +37,7 @@ class TestClaudeCodeInstall:
         """Test basic claude-code install command parsing."""
         # Parse command with correct parameter names
         command, bound, _ = install_app.parse_args(
-            ["claude-code", "server.py", "--server-name", "test-server"]
+            ["claude-code", "server.py", "--name", "test-server"]
         )
 
         # Verify parsing was successful
@@ -51,7 +51,7 @@ class TestClaudeCodeInstall:
             [
                 "claude-code",
                 "server.py",
-                "--server-name",
+                "--name",
                 "test-server",
                 "--with",
                 "package1",
@@ -93,7 +93,7 @@ class TestClaudeDesktopInstall:
     def test_claude_desktop_basic(self):
         """Test basic claude-desktop install command parsing."""
         command, bound, _ = install_app.parse_args(
-            ["claude-desktop", "server.py", "--server-name", "test-server"]
+            ["claude-desktop", "server.py", "--name", "test-server"]
         )
 
         assert command is not None
@@ -106,7 +106,7 @@ class TestClaudeDesktopInstall:
             [
                 "claude-desktop",
                 "server.py",
-                "--server-name",
+                "--name",
                 "test-server",
                 "--env",
                 "VAR1=value1",
@@ -145,7 +145,7 @@ class TestCursorInstall:
     def test_cursor_basic(self):
         """Test basic cursor install command parsing."""
         command, bound, _ = install_app.parse_args(
-            ["cursor", "server.py", "--server-name", "test-server"]
+            ["cursor", "server.py", "--name", "test-server"]
         )
 
         assert command is not None
@@ -155,7 +155,7 @@ class TestCursorInstall:
     def test_cursor_with_options(self):
         """Test cursor install with options."""
         command, bound, _ = install_app.parse_args(
-            ["cursor", "server.py", "--server-name", "test-server"]
+            ["cursor", "server.py", "--name", "test-server"]
         )
 
         assert bound.arguments["server_spec"] == "server.py"


### PR DESCRIPTION
Following #1239, updates all CLI commands to accept `--name` instead of `--server-name`. 

Note: this is a breaking change and documentation will be INCORRECT after merge until 2.11 is released.