### PR TITLE
fix: experimental FastMCPOpenAPI server lost headers in request when __init__(client with headers)

### DIFF
--- a/src/fastmcp/experimental/server/openapi/components.py
+++ b/src/fastmcp/experimental/server/openapi/components.py
@@ -68,6 +68,13 @@ class OpenAPITool(Tool):
                 else "http://localhost"
             )
 
+            # Get Headers from client
+            cli_headers = (
+                self._client.headers
+                if hasattr(self._client, "headers") and self._client.headers
+                else {}
+            )
+
             # Build the request using RequestDirector
             request = self._director.build(self._route, arguments, base_url)
 
@@ -81,6 +88,17 @@ class OpenAPITool(Tool):
                     # Create new headers from mcp_headers
                     for key, value in mcp_headers.items():
                         request.headers[key] = value
+
+            if cli_headers:
+                # Merge with existing headers, _client headers take precedence
+                if request.headers:
+                    request.headers.update(cli_headers)
+                else:
+                    # Create new headers from cli_headers
+                    for key, value in cli_headers.items():
+                        request.headers[key] = value
+            # print logger
+            logger.debug(f"run - sending request; headers: {request.headers}")
 
             # Execute the request
             # Note: httpx.AsyncClient.send() doesn't accept timeout parameter

--- a/src/fastmcp/experimental/server/openapi/components.py
+++ b/src/fastmcp/experimental/server/openapi/components.py
@@ -228,6 +228,14 @@ class OpenAPIResource(Resource):
             headers = {}
             mcp_headers = get_http_headers()
             headers.update(mcp_headers)
+            # Get Headers from client
+            cli_headers = (
+                self._client.headers
+                if hasattr(self._client, "headers") and self._client.headers
+                else {}
+            )
+            # Merge with existing headers, _client headers take precedence
+            headers.update(cli_headers)
 
             response = await self._client.request(
                 method=self._route.method,

--- a/tests/experimental/server/openapi/test_comprehensive.py
+++ b/tests/experimental/server/openapi/test_comprehensive.py
@@ -468,6 +468,7 @@ class TestOpenAPIComprehensive:
         # Create a mock client that tracks requests
         mock_client = Mock(spec=httpx.AsyncClient)
         mock_client.base_url = "https://api.example.com"
+        mock_client.headers = None
 
         # Mock successful response
         mock_response = Mock(spec=Response)
@@ -509,6 +510,7 @@ class TestOpenAPIComprehensive:
         """Test complex request with both parameters and body."""
         mock_client = Mock(spec=httpx.AsyncClient)
         mock_client.base_url = "https://api.example.com"
+        mock_client.headers = None
 
         mock_response = Mock(spec=Response)
         mock_response.status_code = 201
@@ -557,6 +559,7 @@ class TestOpenAPIComprehensive:
         """Test query parameter handling."""
         mock_client = Mock(spec=httpx.AsyncClient)
         mock_client.base_url = "https://api.example.com"
+        mock_client.headers = None
 
         mock_response = Mock(spec=Response)
         mock_response.status_code = 200
@@ -595,6 +598,7 @@ class TestOpenAPIComprehensive:
         """Test error handling for HTTP errors."""
         mock_client = Mock(spec=httpx.AsyncClient)
         mock_client.base_url = "https://api.example.com"
+        mock_client.headers = None
 
         # Mock HTTP error response
         mock_response = Mock(spec=Response)


### PR DESCRIPTION
fix #1253 