### PR TITLE
Fix: prune hidden parameter defs

### DIFF
--- a/src/fastmcp/tools/tool_transform.py
+++ b/src/fastmcp/tools/tool_transform.py
@@ -13,6 +13,7 @@ from pydantic.functional_validators import BeforeValidator
 
 from fastmcp.tools.tool import ParsedFunction, Tool, ToolResult, _convert_to_content
 from fastmcp.utilities.components import FastMCPComponent, _convert_set_default_none
+from fastmcp.utilities.json_schema import compress_schema
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import (
     FastMCPBaseModel,
@@ -645,6 +646,7 @@ class TransformedTool(Tool):
 
         if parent_defs:
             schema["$defs"] = parent_defs
+            schema = compress_schema(schema, prune_defs=True)
 
         # Create forwarding function that closes over everything it needs
         async def _forward(**kwargs):

--- a/tests/tools/test_tool_transform.py
+++ b/tests/tools/test_tool_transform.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any
 
 import pytest
 from dirty_equals import IsList
@@ -200,7 +200,7 @@ async def test_hidden_param_prunes_defs():
         y: int
 
     @Tool.from_function
-    def tool_with_refs(a: VisibleType, b: Optional[HiddenType] = None) -> int:
+    def tool_with_refs(a: VisibleType, b: HiddenType | None = None) -> int:
         return a.x + (b.y if b else 0)
 
     # Hide parameter 'b'


### PR DESCRIPTION
I fixed issue #1189 by running the compress_schema method right after we create the "$defs" schema property from parent_defs. I also added a test case to ensure that the hidden parameter's $defs entry is removed in the output schema