### PR TITLE
Implemented a client-side feature use call_tool to **stream server output in chunks**, i.e., yielding chunks.

### DIFF
--- a/src/fastmcp/client/client.py
+++ b/src/fastmcp/client/client.py
@@ -968,9 +968,9 @@ class Client(Generic[ClientTransportT]):
                     mcp_done = True
                     break
                 else:
-                    if type(mcp_data) == str:
+                    if isinstance(mcp_data, str):
                         yield mcp_data
-                    elif type(mcp_data) == CallToolResult:
+                    elif isinstance(mcp_data, CallToolResult):
 
                         data = {
                             "content": vars(mcp_data.content[0]),


### PR DESCRIPTION
 I recently implemented this feature using a somewhat hacky approach while making as few changes as possible to the original SDK. Later, I tried integrating the feature as an extension of client.call_tool directly into the client class. I’ll now present both approaches.
Let's take a look at the results now. I test the function with postman.

This is the result response in chunks.
<img width="2132" height="1866" alt="7c45b28f02ef70f61e598c7b3f32869d" src="https://github.com/user-attachments/assets/6ef87ef3-d4ea-4d54-b5d9-ef7719e4adc3" />

And here is the mcp server tool code.

<img width="1508" height="996" alt="22ebdc36dc4a0fd72e873f1438075092" src="https://github.com/user-attachments/assets/94389b17-7fa3-4f8b-bdd9-8520d854f475" />
Of cource you can only yield one chunk , which is the tool finally return.

<img width="2122" height="1440" alt="64ef50f1b3e6db6b462edee34d9f3700" src="https://github.com/user-attachments/assets/5f8b091f-1d41-4ef6-957d-ffcf1462fc86" />
<img width="1186" height="366" alt="0621b876d90e84debd6a40b9d03a31a5" src="https://github.com/user-attachments/assets/b9a4ff2c-48d8-4136-9389-88066a02ec6d" />


What I did was provide a custom implementation of the ProgressHandler used inside client.call_tool. I had first tried to yield chunks directly from the handler, but that’s impossible when call_tool itself is awaited. So I extended call_tool so that the custom progress states can also be yielded out.

I didn’t change the original @server.tool at all, so you can still use it exactly as before. Whenever you want to return additional states, just send your custom protocol—say, a JSON chunk—via ctx.report_progress().

Now let’s look at the code, starting with the interface layer.
```python
@app.post("/v1/mcp/tinker")
async def call_mcp_tools(request: Request):
    body = await request.json()
    return StreamingResponse(
        custom_mcp(url=body["url"], funname=body["name"], args=body["args"]),
        media_type="text/event-stream",
        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
    )


async def custom_mcp(url: str, funname: str, args: dict):

    try:
        try:
            async with Client(url) as client:

                async for chunk in client.call_tool_stream_chunks(
                    name=funname, arguments=args
                ):
                    yield f"data: {json.dumps({"chunk":chunk},ensure_ascii=False)}\n\n"

        except Exception as e:
            print("task failed", e)

    except Exception as e:
        logger.error(f"Error: {e}")
        async for sendchunk in stream_completions_create(
            content=str(e), type="mcp_tool_error"
        ):
            yield f"data: {json.dumps(sendchunk,ensure_ascii=False)}\n\n"
```
Next, we created an enhanced version of call_tool as a custom method inside the Client class.
```python

    async def call_tool_stream_chunks(
        self,
        name: str,
        arguments: dict[str, Any] | None = None,
        timeout: datetime.timedelta | float | int | None = None,
        progress_handler: ProgressHandler | None = None,
        raise_on_error: bool = True,
    ):

        mcp_progress_queue = asyncio.Queue()

        async def state_update(progress: float, total: float = None, message: str = None):

            try:
                if message: 
                    logger.info(f"catch {message}")
                    await mcp_progress_queue.put(message)

            except ValueError as e:
                logger.error(f"no message {str(e)}")


        async def fetch_mcp_progress():
            try:
                 
                result = await self.call_tool_mcp(
                    name=name,
                    arguments=arguments or {},
                    timeout=timeout,
                    progress_handler=state_update,
                )
                data = None
                if result.isError and raise_on_error:
                    msg = cast(mcp.types.TextContent, result.content[0]).text
                    raise ToolError(msg)
                elif result.structuredContent:
                    try:
                        if name not in self.session._tool_output_schemas:
                            await self.session.list_tools()
                        if name in self.session._tool_output_schemas:
                            output_schema = self.session._tool_output_schemas.get(name)
                            if output_schema:
                                if output_schema.get("x-fastmcp-wrap-result"):
                                    output_schema = output_schema.get("properties", {}).get(
                                        "result"
                                    )
                                    structured_content = result.structuredContent.get("result")
                                else:
                                    structured_content = result.structuredContent
                                output_type = json_schema_to_type(output_schema)
                                type_adapter = get_cached_typeadapter(output_type)
                                data = type_adapter.validate_python(structured_content)
                            else:
                                data = result.structuredContent
                    except Exception as e:
                        logger.error(f"Error parsing structured content: {e}")

                tempresult= CallToolResult(
                    content=result.content,
                    structured_content=result.structuredContent,
                    data=data,
                    is_error=result.isError,
                )
                logger.info(f"result:{tempresult} {type(tempresult)}")
                await mcp_progress_queue.put(tempresult)
                logger.info(f"run success, result:{tempresult}")
                await mcp_progress_queue.put(None)
            except Exception as e:
                logger.error(f"task failed: {str(e)}")
        mcp_task = asyncio.create_task(fetch_mcp_progress())
        mcp_done = False
        while not mcp_done:
            try:
                mcp_data = await mcp_progress_queue.get()
                if mcp_data is None:
                    mcp_done = True
                    break
                else:
                    if type(mcp_data) == str:
                        yield mcp_data
                    elif type(mcp_data) == CallToolResult:

                        data = {
                            "content": vars(mcp_data.content[0]),
                            "structured_content": mcp_data.structured_content,
                            "data": mcp_data.data,
                            "is_error": mcp_data.is_error
                        }
                        yield data
                    await asyncio.sleep(0.0001)

            except asyncio.QueueEmpty:
                await asyncio.sleep(0.01)  
        await asyncio.gather(mcp_task)
```