### PR TITLE
Small clean-up from MCP Tool Transform PR

### DIFF
--- a/src/fastmcp/tools/tool_transform.py
+++ b/src/fastmcp/tools/tool_transform.py
@@ -832,7 +832,7 @@ class TransformedTool(Tool):
         )
 
 
-class ToolTransformConfig(FastMCPComponent):
+class ToolTransformConfig(FastMCPBaseModel):
     """Provides a way to transform a tool."""
 
     name: str | None = Field(default=None, description="The new name for the tool.")
@@ -863,7 +863,7 @@ class ToolTransformConfig(FastMCPComponent):
     def apply(self, tool: Tool) -> TransformedTool:
         """Create a TransformedTool from a provided tool and this transformation configuration."""
 
-        tool_changes = self.model_dump(exclude_unset=True, exclude={"arguments"})
+        tool_changes: dict[str, Any] = self.model_dump(exclude_unset=True, exclude={"arguments"})
 
         return TransformedTool.from_tool(
             tool=tool,
@@ -880,7 +880,7 @@ def apply_transformations_to_tools(
     are left unchanged.
     """
 
-    transformed_tools = {}
+    transformed_tools: dict[str, Tool] = {}
 
     for tool_name, tool in tools.items():
         if transformation := transformations.get(tool_name):

--- a/src/fastmcp/utilities/mcp_config.py
+++ b/src/fastmcp/utilities/mcp_config.py
@@ -1,12 +1,12 @@
+from typing import Any
+
 from fastmcp.mcp_config import MCPConfig
 from fastmcp.server.server import FastMCP
 
 
-def composite_server_from_mcp_config(
-    config: MCPConfig, name_as_prefix: bool = True
-) -> FastMCP:
+def composite_server_from_mcp_config(config: MCPConfig, name_as_prefix: bool = True) -> FastMCP[None]:
     """A utility function to create a composite server from an MCPConfig."""
-    composite_server = FastMCP()
+    composite_server = FastMCP[None]()
 
     mount_mcp_config_into_server(config, composite_server, name_as_prefix)
 
@@ -15,7 +15,7 @@ def composite_server_from_mcp_config(
 
 def mount_mcp_config_into_server(
     config: MCPConfig,
-    server: FastMCP,
+    server: FastMCP[Any],
     name_as_prefix: bool = True,
 ) -> None:
     """A utility function to mount the servers from an MCPConfig into a FastMCP server."""


### PR DESCRIPTION
Properly type FastMCP object returned by helper and incorporate missed feedback item about not using FastMCPComponent for the ToolTransformConfig