### PR TITLE
Add 2.11 version badge for state management

### DIFF
--- a/docs/servers/middleware.mdx
+++ b/docs/servers/middleware.mdx
@@ -280,6 +280,8 @@ You have complete control over the request flow:
 
 #### State Management
 
+<VersionBadge version="2.11.0" />
+
 In addition to modifying the request and response, you can also store state data that your tools can (optionally) access later. To do so, use the FastMCP Context to either `set_state` or `get_state` as appropriate. For more information, see the [Context State Management](/servers/context#state-management) docs.
 
 ## Creating Middleware


### PR DESCRIPTION
Close #1284 by ensuring a version badge is displayed on the middleware docs. The equivalent version badge is already present in the Context docs:
<img width="761" height="191" alt="image" src="https://github.com/user-attachments/assets/7d284bd9-29a4-40a7-a675-c9b8c6db1aac" />
