### PR TITLE
Add _fastmcp meta namespace

### DIFF
--- a/docs/clients/prompts.mdx
+++ b/docs/clients/prompts.mdx
@@ -27,7 +27,8 @@ async with client:
             print(f"Arguments: {[arg.name for arg in prompt.arguments]}")
         # Access tags and other metadata
         if hasattr(prompt, '_meta') and prompt._meta:
-            print(f"Tags: {prompt._meta.get('tags', [])}")
+            fastmcp_meta = prompt._meta.get('_fastmcp', {})
+            print(f"Tags: {fastmcp_meta.get('tags', [])}")
 ```
 
 ### Filtering by Tags
@@ -41,15 +42,16 @@ async with client:
     # Filter prompts by tag
     analysis_prompts = [
         prompt for prompt in prompts 
-        if hasattr(prompt, '_meta') and prompt._meta and 
-           'analysis' in prompt._meta.get('tags', [])
+        if hasattr(prompt, '_meta') and prompt._meta and
+           prompt._meta.get('_fastmcp', {}) and
+           'analysis' in prompt._meta.get('_fastmcp', {}).get('tags', [])
     ]
     
     print(f"Found {len(analysis_prompts)} analysis prompts")
 ```
 
 <Note>
-The `_meta` field is part of the standard MCP specification, but the inclusion of tags within it is specific to FastMCP servers. Other MCP server implementations may not provide tags in their metadata.
+The `_meta` field is part of the standard MCP specification. FastMCP servers include tags and other metadata within a `_fastmcp` namespace (e.g., `_meta._fastmcp.tags`) to avoid conflicts with user-defined metadata. This behavior can be controlled with the server's `include_fastmcp_meta` setting - when disabled, the `_fastmcp` namespace won't be included. Other MCP server implementations may not provide this metadata structure.
 </Note>
 
 ## Using Prompts

--- a/docs/clients/prompts.mdx
+++ b/docs/clients/prompts.mdx
@@ -33,6 +33,8 @@ async with client:
 
 ### Filtering by Tags
 
+<VersionBadge version="2.11.0" />
+
 You can use the `meta` field to filter prompts based on their tags:
 
 ```python

--- a/docs/clients/resources.mdx
+++ b/docs/clients/resources.mdx
@@ -36,7 +36,8 @@ async with client:
         print(f"MIME Type: {resource.mimeType}")
         # Access tags and other metadata
         if hasattr(resource, '_meta') and resource._meta:
-            print(f"Tags: {resource._meta.get('tags', [])}")
+            fastmcp_meta = resource._meta.get('_fastmcp', {})
+            print(f"Tags: {fastmcp_meta.get('tags', [])}")
 ```
 
 ### Resource Templates
@@ -54,7 +55,8 @@ async with client:
         print(f"Description: {template.description}")
         # Access tags and other metadata
         if hasattr(template, '_meta') and template._meta:
-            print(f"Tags: {template._meta.get('tags', [])}")
+            fastmcp_meta = template._meta.get('_fastmcp', {})
+            print(f"Tags: {fastmcp_meta.get('tags', [])}")
 ```
 
 ### Filtering by Tags
@@ -68,15 +70,16 @@ async with client:
     # Filter resources by tag
     config_resources = [
         resource for resource in resources 
-        if hasattr(resource, '_meta') and resource._meta and 
-           'config' in resource._meta.get('tags', [])
+        if hasattr(resource, '_meta') and resource._meta and
+           resource._meta.get('_fastmcp', {}) and
+           'config' in resource._meta.get('_fastmcp', {}).get('tags', [])
     ]
     
     print(f"Found {len(config_resources)} config resources")
 ```
 
 <Note>
-The `_meta` field is part of the standard MCP specification, but the inclusion of tags within it is specific to FastMCP servers. Other MCP server implementations may not provide tags in their metadata.
+The `_meta` field is part of the standard MCP specification. FastMCP servers include tags and other metadata within a `_fastmcp` namespace (e.g., `_meta._fastmcp.tags`) to avoid conflicts with user-defined metadata. This behavior can be controlled with the server's `include_fastmcp_meta` setting - when disabled, the `_fastmcp` namespace won't be included. Other MCP server implementations may not provide this metadata structure.
 </Note>
 
 ## Reading Resources

--- a/docs/clients/resources.mdx
+++ b/docs/clients/resources.mdx
@@ -61,6 +61,8 @@ async with client:
 
 ### Filtering by Tags
 
+<VersionBadge version="2.11.0" />
+
 You can use the `meta` field to filter resources based on their tags:
 
 ```python

--- a/docs/clients/tools.mdx
+++ b/docs/clients/tools.mdx
@@ -27,7 +27,8 @@ async with client:
             print(f"Parameters: {tool.inputSchema}")
         # Access tags and other metadata
         if hasattr(tool, '_meta') and tool._meta:
-            print(f"Tags: {tool._meta.get('tags', [])}")
+            fastmcp_meta = tool._meta.get('_fastmcp', {})
+            print(f"Tags: {fastmcp_meta.get('tags', [])}")
 ```
 
 ### Filtering by Tags
@@ -41,15 +42,16 @@ async with client:
     # Filter tools by tag
     analysis_tools = [
         tool for tool in tools 
-        if hasattr(tool, '_meta') and tool._meta and 
-           'analysis' in tool._meta.get('tags', [])
+        if hasattr(tool, '_meta') and tool._meta and
+           tool._meta.get('_fastmcp', {}) and
+           'analysis' in tool._meta.get('_fastmcp', {}).get('tags', [])
     ]
     
     print(f"Found {len(analysis_tools)} analysis tools")
 ```
 
 <Note>
-The `_meta` field is part of the standard MCP specification, but the inclusion of tags within it is specific to FastMCP servers. Other MCP server implementations may not provide tags in their metadata.
+The `_meta` field is part of the standard MCP specification. FastMCP servers include tags and other metadata within a `_fastmcp` namespace (e.g., `_meta._fastmcp.tags`) to avoid conflicts with user-defined metadata. This behavior can be controlled with the server's `include_fastmcp_meta` setting - when disabled, the `_fastmcp` namespace won't be included. Other MCP server implementations may not provide this metadata structure.
 </Note>
 
 ## Executing Tools

--- a/docs/clients/tools.mdx
+++ b/docs/clients/tools.mdx
@@ -33,6 +33,8 @@ async with client:
 
 ### Filtering by Tags
 
+<VersionBadge version="2.11.0" />
+
 You can use the `meta` field to filter tools based on their tags:
 
 ```python

--- a/docs/integrations/openapi.mdx
+++ b/docs/integrations/openapi.mdx
@@ -334,7 +334,7 @@ mcp = FastMCP.from_openapi(
 
 #### OpenAPI Tags in Client Meta
 
-FastMCP automatically includes OpenAPI tags from your specification in the component's metadata. These tags are available to MCP clients through the `_meta` field, allowing clients to filter and organize components based on the original OpenAPI tagging:
+FastMCP automatically includes OpenAPI tags from your specification in the component's metadata. These tags are available to MCP clients through the `_meta._fastmcp.tags` field, allowing clients to filter and organize components based on the original OpenAPI tagging:
 
 <CodeGroup>
 ```json {5} OpenAPI spec with tags
@@ -350,13 +350,14 @@ FastMCP automatically includes OpenAPI tags from your specification in the compo
   }
 }
 ```
-```python {6-8} Access OpenAPI tags in MCP client
+```python {6-9} Access OpenAPI tags in MCP client
 async with client:
     tools = await client.list_tools()
     for tool in tools:
         if hasattr(tool, '_meta') and tool._meta:
-            # OpenAPI tags are now available!
-            openapi_tags = tool._meta.get('tags', [])
+            # OpenAPI tags are now available in _fastmcp namespace!
+            fastmcp_meta = tool._meta.get('_fastmcp', {})
+            openapi_tags = fastmcp_meta.get('tags', [])
             if 'users' in openapi_tags:
                 print(f"Found user-related tool: {tool.name}")
 ```

--- a/docs/servers/prompts.mdx
+++ b/docs/servers/prompts.mdx
@@ -85,7 +85,7 @@ def data_analysis_prompt(
 </ParamField>
 
 <ParamField body="tags" type="set[str] | None">
-  A set of strings used to categorize the prompt. Clients might use tags to filter or group available prompts. Tags are available to clients in the prompt's `meta` field when the prompt is listed (via `list_prompts`)
+  A set of strings used to categorize the prompt. Clients might use tags to filter or group available prompts. Tags are available to clients in the prompt's `meta._fastmcp.tags` field when the prompt is listed (via `list_prompts`). This can be controlled with the server's `include_fastmcp_meta` setting
 </ParamField>
 
 <ParamField body="enabled" type="bool" default="True">

--- a/docs/servers/prompts.mdx
+++ b/docs/servers/prompts.mdx
@@ -85,7 +85,7 @@ def data_analysis_prompt(
 </ParamField>
 
 <ParamField body="tags" type="set[str] | None">
-  A set of strings used to categorize the prompt. Clients might use tags to filter or group available prompts. Tags are available to clients in the prompt's `meta._fastmcp.tags` field when the prompt is listed (via `list_prompts`). This can be controlled with the server's `include_fastmcp_meta` setting
+  A set of strings used to categorize the prompt. These can be used by the server and, in some cases, by clients to filter or group available prompts.
 </ParamField>
 
 <ParamField body="enabled" type="bool" default="True">

--- a/docs/servers/resources.mdx
+++ b/docs/servers/resources.mdx
@@ -98,7 +98,7 @@ def get_application_status() -> dict:
 </ParamField>
 
 <ParamField body="tags" type="set[str] | None">
-  A set of strings for categorization, potentially used by clients for filtering. Tags are available to clients in the resource's `meta._fastmcp.tags` field when the resource is listed (via `list_resources` or `list_resource_templates`). This can be controlled with the server's `include_fastmcp_meta` setting
+  A set of strings used to categorize the resource. These can be used by the server and, in some cases, by clients to filter or group available resources.
 </ParamField>
 
 <ParamField body="enabled" type="bool" default="True">

--- a/docs/servers/resources.mdx
+++ b/docs/servers/resources.mdx
@@ -98,7 +98,7 @@ def get_application_status() -> dict:
 </ParamField>
 
 <ParamField body="tags" type="set[str] | None">
-  A set of strings for categorization, potentially used by clients for filtering. Tags are available to clients in the resource's `meta` field when the resource is listed (via `list_resources` or `list_resource_templates`)
+  A set of strings for categorization, potentially used by clients for filtering. Tags are available to clients in the resource's `meta._fastmcp.tags` field when the resource is listed (via `list_resources` or `list_resource_templates`). This can be controlled with the server's `include_fastmcp_meta` setting
 </ParamField>
 
 <ParamField body="enabled" type="bool" default="True">

--- a/docs/servers/server.mdx
+++ b/docs/servers/server.mdx
@@ -44,16 +44,38 @@ The `FastMCP` constructor accepts several arguments:
   An async context manager function for server startup and shutdown logic
 </ParamField>
 
-<ParamField body="tags" type="set[str] | None">
-  A set of strings to tag the server itself
-</ParamField>
-
 <ParamField body="tools" type="list[Tool | Callable] | None">
   A list of tools (or functions to convert to tools) to add to the server. In some cases, providing tools programmatically may be more convenient than using the `@mcp.tool` decorator
 </ParamField>
 
-<ParamField body="**settings" type="Any">
-  Keyword arguments corresponding to additional `ServerSettings` configuration
+<ParamField body="dependencies" type="list[str] | None">
+  Optional server dependencies list with package specifications
+</ParamField>
+
+<ParamField body="include_tags" type="set[str] | None">
+  Only expose components with at least one matching tag
+</ParamField>
+
+<ParamField body="exclude_tags" type="set[str] | None">
+  Hide components with any matching tag
+</ParamField>
+
+<ParamField body="on_duplicate_tools" type='Literal["error", "warn", "replace"]' default="error">
+  How to handle duplicate tool registrations
+</ParamField>
+
+<ParamField body="on_duplicate_resources" type='Literal["error", "warn", "replace"]' default="warn">
+  How to handle duplicate resource registrations
+</ParamField>
+
+<ParamField body="on_duplicate_prompts" type='Literal["error", "warn", "replace"]' default="replace">
+  How to handle duplicate prompt registrations
+</ParamField>
+
+<ParamField body="include_fastmcp_meta" type="bool" default="True">
+  <VersionBadge version="2.11.0" />
+  
+  Whether to include FastMCP metadata in component responses. When `True`, component tags and other FastMCP-specific metadata are included in the `_fastmcp` namespace within each component's `meta` field. When `False`, this metadata is omitted, resulting in cleaner integration with external systems. Can be overridden globally via `FASTMCP_INCLUDE_FASTMCP_META` environment variable
 </ParamField>
 </Card>
 ## Components
@@ -277,38 +299,6 @@ mcp = FastMCP(
     include_fastmcp_meta=False,                  # Disable FastMCP metadata for cleaner integration
 )
 ```
-
-### Constructor Parameters
-
-<Card icon="code" title="AdditionalFastMCP Constructor Parameters">
-<ParamField body="dependencies" type="list[str] | None">
-  Optional server dependencies list with package specifications
-</ParamField>
-
-<ParamField body="include_tags" type="set[str] | None">
-  Only expose components with at least one matching tag
-</ParamField>
-
-<ParamField body="exclude_tags" type="set[str] | None">
-  Hide components with any matching tag
-</ParamField>
-
-<ParamField body="on_duplicate_tools" type='Literal["error", "warn", "replace"]' default="error">
-  How to handle duplicate tool registrations
-</ParamField>
-
-<ParamField body="on_duplicate_resources" type='Literal["error", "warn", "replace"]' default="warn">
-  How to handle duplicate resource registrations
-</ParamField>
-
-<ParamField body="on_duplicate_prompts" type='Literal["error", "warn", "replace"]' default="replace">
-  How to handle duplicate prompt registrations
-</ParamField>
-
-<ParamField body="include_fastmcp_meta" type="bool" default="True">
-  Whether to include FastMCP metadata in component responses. When `True`, component tags and other FastMCP-specific metadata are included in the `_fastmcp` namespace within each component's `meta` field. When `False`, this metadata is omitted, resulting in cleaner integration with external systems. Can be overridden globally via `FASTMCP_INCLUDE_FASTMCP_META` environment variable
-</ParamField>
-</Card>
 
 ### Global Settings
 

--- a/docs/servers/server.mdx
+++ b/docs/servers/server.mdx
@@ -274,6 +274,7 @@ mcp = FastMCP(
     on_duplicate_tools="error",                  # Handle duplicate registrations
     on_duplicate_resources="warn",
     on_duplicate_prompts="replace",
+    include_fastmcp_meta=False,                  # Disable FastMCP metadata for cleaner integration
 )
 ```
 
@@ -303,6 +304,10 @@ mcp = FastMCP(
 <ParamField body="on_duplicate_prompts" type='Literal["error", "warn", "replace"]' default="replace">
   How to handle duplicate prompt registrations
 </ParamField>
+
+<ParamField body="include_fastmcp_meta" type="bool" default="True">
+  Whether to include FastMCP metadata in component responses. When `True`, component tags and other FastMCP-specific metadata are included in the `_fastmcp` namespace within each component's `meta` field. When `False`, this metadata is omitted, resulting in cleaner integration with external systems. Can be overridden globally via `FASTMCP_INCLUDE_FASTMCP_META` environment variable
+</ParamField>
 </Card>
 
 ### Global Settings
@@ -316,12 +321,14 @@ import fastmcp
 print(fastmcp.settings.log_level)        # Default: "INFO"
 print(fastmcp.settings.mask_error_details)  # Default: False
 print(fastmcp.settings.resource_prefix_format)  # Default: "path"
+print(fastmcp.settings.include_fastmcp_meta)   # Default: True
 ```
 
 Common global settings include:
 - **`log_level`**: Logging level ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"), set with `FASTMCP_LOG_LEVEL`
 - **`mask_error_details`**: Whether to hide detailed error information from clients, set with `FASTMCP_MASK_ERROR_DETAILS`
 - **`resource_prefix_format`**: How to format resource prefixes ("path" or "protocol"), set with `FASTMCP_RESOURCE_PREFIX_FORMAT`
+- **`include_fastmcp_meta`**: Whether to include FastMCP metadata in component responses (default: True), set with `FASTMCP_INCLUDE_FASTMCP_META`
 
 ### Transport-Specific Configuration
 
@@ -353,6 +360,7 @@ Global FastMCP settings can be configured via environment variables (prefixed wi
 export FASTMCP_LOG_LEVEL=DEBUG
 export FASTMCP_MASK_ERROR_DETAILS=True
 export FASTMCP_RESOURCE_PREFIX_FORMAT=protocol
+export FASTMCP_INCLUDE_FASTMCP_META=False
 ```
 
 ### Custom Tool Serialization

--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -76,7 +76,7 @@ def search_products_implementation(query: str, category: str | None = None) -> l
 </ParamField>
 
 <ParamField body="tags" type="set[str] | None">
-  A set of strings to categorize the tool. Clients might use tags to filter or group available tools. Tags are available to clients in the tool's `meta._fastmcp.tags` field when the tool is listed (via `list_tools`). This can be controlled with the server's `include_fastmcp_meta` setting
+  A set of strings used to categorize the tool. These can be used by the server and, in some cases, by clients to filter or group available tools.
 </ParamField>
 
 <ParamField body="enabled" type="bool" default="True">

--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -76,7 +76,7 @@ def search_products_implementation(query: str, category: str | None = None) -> l
 </ParamField>
 
 <ParamField body="tags" type="set[str] | None">
-  A set of strings to categorize the tool. Clients might use tags to filter or group available tools. Tags are available to clients in the tool's `meta` field when the tool is listed (via `list_tools`)
+  A set of strings to categorize the tool. Clients might use tags to filter or group available tools. Tags are available to clients in the tool's `meta._fastmcp.tags` field when the tool is listed (via `list_tools`). This can be controlled with the server's `include_fastmcp_meta` setting
 </ParamField>
 
 <ParamField body="enabled" type="bool" default="True">

--- a/src/fastmcp/prompts/prompt.py
+++ b/src/fastmcp/prompts/prompt.py
@@ -85,7 +85,12 @@ class Prompt(FastMCPComponent, ABC):
         except RuntimeError:
             pass  # No context available
 
-    def to_mcp_prompt(self, **overrides: Any) -> MCPPrompt:
+    def to_mcp_prompt(
+        self,
+        *,
+        include_fastmcp_meta: bool | None = None,
+        **overrides: Any,
+    ) -> MCPPrompt:
         """Convert the prompt to an MCP prompt."""
         arguments = [
             MCPPromptArgument(
@@ -100,7 +105,7 @@ class Prompt(FastMCPComponent, ABC):
             "description": self.description,
             "arguments": arguments,
             "title": self.title,
-            "_meta": self.get_meta(),
+            "_meta": self.get_meta(include_fastmcp_meta=include_fastmcp_meta),
         }
         return MCPPrompt(**kwargs | overrides)
 

--- a/src/fastmcp/resources/resource.py
+++ b/src/fastmcp/resources/resource.py
@@ -113,7 +113,12 @@ class Resource(FastMCPComponent, abc.ABC):
         """Read the resource content."""
         pass
 
-    def to_mcp_resource(self, **overrides: Any) -> MCPResource:
+    def to_mcp_resource(
+        self,
+        *,
+        include_fastmcp_meta: bool | None = None,
+        **overrides: Any,
+    ) -> MCPResource:
         """Convert the resource to an MCPResource."""
         kwargs = {
             "uri": self.uri,
@@ -122,7 +127,7 @@ class Resource(FastMCPComponent, abc.ABC):
             "mimeType": self.mime_type,
             "title": self.title,
             "annotations": self.annotations,
-            "_meta": self.get_meta(),
+            "_meta": self.get_meta(include_fastmcp_meta=include_fastmcp_meta),
         }
         return MCPResource(**kwargs | overrides)
 

--- a/src/fastmcp/resources/template.py
+++ b/src/fastmcp/resources/template.py
@@ -145,7 +145,12 @@ class ResourceTemplate(FastMCPComponent):
             enabled=self.enabled,
         )
 
-    def to_mcp_template(self, **overrides: Any) -> MCPResourceTemplate:
+    def to_mcp_template(
+        self,
+        *,
+        include_fastmcp_meta: bool | None = None,
+        **overrides: Any,
+    ) -> MCPResourceTemplate:
         """Convert the resource template to an MCPResourceTemplate."""
         kwargs = {
             "uriTemplate": self.uri_template,
@@ -154,7 +159,7 @@ class ResourceTemplate(FastMCPComponent):
             "mimeType": self.mime_type,
             "title": self.title,
             "annotations": self.annotations,
-            "_meta": self.get_meta(),
+            "_meta": self.get_meta(include_fastmcp_meta=include_fastmcp_meta),
         }
         return MCPResourceTemplate(**kwargs | overrides)
 

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -154,6 +154,7 @@ class FastMCP(Generic[LifespanResultT]):
         dependencies: list[str] | None = None,
         include_tags: set[str] | None = None,
         exclude_tags: set[str] | None = None,
+        include_fastmcp_meta: bool | None = None,
         # ---
         # ---
         # --- The following arguments are DEPRECATED ---
@@ -222,6 +223,12 @@ class FastMCP(Generic[LifespanResultT]):
         # Set up MCP protocol handlers
         self._setup_handlers()
         self.dependencies = dependencies or fastmcp.settings.server_dependencies
+
+        self.include_fastmcp_meta = (
+            include_fastmcp_meta
+            if include_fastmcp_meta is not None
+            else fastmcp.settings.include_fastmcp_meta
+        )
 
         # handle deprecated settings
         self._handle_deprecated_settings(
@@ -470,7 +477,13 @@ class FastMCP(Generic[LifespanResultT]):
 
         async with fastmcp.server.context.Context(fastmcp=self):
             tools = await self._list_tools()
-            return [tool.to_mcp_tool(name=tool.key) for tool in tools]
+            return [
+                tool.to_mcp_tool(
+                    name=tool.key,
+                    include_fastmcp_meta=self.include_fastmcp_meta,
+                )
+                for tool in tools
+            ]
 
     async def _list_tools(self) -> list[Tool]:
         """
@@ -509,7 +522,11 @@ class FastMCP(Generic[LifespanResultT]):
         async with fastmcp.server.context.Context(fastmcp=self):
             resources = await self._list_resources()
             return [
-                resource.to_mcp_resource(uri=resource.key) for resource in resources
+                resource.to_mcp_resource(
+                    uri=resource.key,
+                    include_fastmcp_meta=self.include_fastmcp_meta,
+                )
+                for resource in resources
             ]
 
     async def _list_resources(self) -> list[Resource]:
@@ -550,7 +567,10 @@ class FastMCP(Generic[LifespanResultT]):
         async with fastmcp.server.context.Context(fastmcp=self):
             templates = await self._list_resource_templates()
             return [
-                template.to_mcp_template(uriTemplate=template.key)
+                template.to_mcp_template(
+                    uriTemplate=template.key,
+                    include_fastmcp_meta=self.include_fastmcp_meta,
+                )
                 for template in templates
             ]
 
@@ -591,7 +611,13 @@ class FastMCP(Generic[LifespanResultT]):
 
         async with fastmcp.server.context.Context(fastmcp=self):
             prompts = await self._list_prompts()
-            return [prompt.to_mcp_prompt(name=prompt.key) for prompt in prompts]
+            return [
+                prompt.to_mcp_prompt(
+                    name=prompt.key,
+                    include_fastmcp_meta=self.include_fastmcp_meta,
+                )
+                for prompt in prompts
+            ]
 
     async def _list_prompts(self) -> list[Prompt]:
         """

--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -304,6 +304,21 @@ class Settings(BaseSettings):
         ),
     ] = None
 
+    include_fastmcp_meta: Annotated[
+        bool,
+        Field(
+            default=True,
+            description=inspect.cleandoc(
+                """
+                Whether to include FastMCP meta in the server's MCP responses.
+                If True, a `_fastmcp` key will be added to the `meta` field of
+                all MCP component responses. This key will contain a dict of
+                various FastMCP-specific metadata, such as tags. 
+                """
+            ),
+        ),
+    ] = True
+
 
 def __getattr__(name: str):
     """

--- a/src/fastmcp/tools/tool.py
+++ b/src/fastmcp/tools/tool.py
@@ -130,7 +130,12 @@ class Tool(FastMCPComponent):
         except RuntimeError:
             pass  # No context available
 
-    def to_mcp_tool(self, **overrides: Any) -> MCPTool:
+    def to_mcp_tool(
+        self,
+        *,
+        include_fastmcp_meta: bool | None = None,
+        **overrides: Any,
+    ) -> MCPTool:
         if self.title:
             title = self.title
         elif self.annotations and self.annotations.title:
@@ -145,7 +150,7 @@ class Tool(FastMCPComponent):
             "outputSchema": self.output_schema,
             "annotations": self.annotations,
             "title": title,
-            "_meta": self.get_meta(),
+            "_meta": self.get_meta(include_fastmcp_meta=include_fastmcp_meta),
         }
         return MCPTool(**kwargs | overrides)
 

--- a/tests/server/openapi/test_basic_functionality.py
+++ b/tests/server/openapi/test_basic_functionality.py
@@ -97,7 +97,7 @@ class TestTools:
 
         assert tools[0].model_dump() == dict(
             name="create_user_users_post",
-            meta=dict(tags=["create", "users"]),
+            meta=dict(_fastmcp=dict(tags=["create", "users"])),
             title=None,
             annotations=None,
             description=IsStr(regex=r"^Create a new user\..*$", regex_flags=re.DOTALL),
@@ -122,7 +122,7 @@ class TestTools:
         )
         assert tools[1].model_dump() == dict(
             name="update_user_name_users",
-            meta=dict(tags=["update", "users"]),
+            meta=dict(_fastmcp=dict(tags=["update", "users"])),
             title=None,
             annotations=None,
             description=IsStr(

--- a/tests/server/proxy/test_proxy_client.py
+++ b/tests/server/proxy/test_proxy_client.py
@@ -91,7 +91,7 @@ class TestProxyClient:
         async with Client(proxy_server) as client:
             tools = await client.list_tools()
             echo_tool = next(t for t in tools if t.name == "echo")
-            assert echo_tool.meta == {"tags": ["echo"]}
+            assert echo_tool.meta == {"_fastmcp": {"tags": ["echo"]}}
 
     async def test_forward_error_response(self, proxy_server: FastMCP):
         """

--- a/tests/server/proxy/test_proxy_server.py
+++ b/tests/server/proxy/test_proxy_server.py
@@ -124,7 +124,7 @@ class TestTools:
     async def test_get_tools_meta(self, proxy_server):
         tools = await proxy_server.get_tools()
         greet_tool = tools["greet"]
-        assert greet_tool.meta == {"tags": ["greet"]}
+        assert greet_tool.meta == {"_fastmcp": {"tags": ["greet"]}}
 
     async def test_get_transformed_tools(
         self, fastmcp_server: FastMCP, proxy_server: FastMCPProxy
@@ -246,7 +246,7 @@ class TestResources:
     async def test_get_resources_meta(self, proxy_server):
         resources = await proxy_server.get_resources()
         wave_resource = resources["resource://wave"]
-        assert wave_resource.meta == {"tags": ["wave"]}
+        assert wave_resource.meta == {"_fastmcp": {"tags": ["wave"]}}
 
     async def test_list_resources_same_as_original(self, fastmcp_server, proxy_server):
         assert (
@@ -345,7 +345,7 @@ class TestResourceTemplates:
     async def test_get_resource_templates_meta(self, proxy_server):
         templates = await proxy_server.get_resource_templates()
         get_user_template = templates["data://user/{user_id}"]
-        assert get_user_template.meta == {"tags": ["users"]}
+        assert get_user_template.meta == {"_fastmcp": {"tags": ["users"]}}
 
     async def test_list_resource_templates_same_as_original(
         self, fastmcp_server, proxy_server
@@ -449,7 +449,7 @@ class TestPrompts:
     async def test_get_prompts_meta(self, proxy_server):
         prompts = await proxy_server.get_prompts()
         welcome_prompt = prompts["welcome"]
-        assert welcome_prompt.meta == {"tags": ["welcome"]}
+        assert welcome_prompt.meta == {"_fastmcp": {"tags": ["welcome"]}}
 
     async def test_list_prompts_same_as_original(self, fastmcp_server, proxy_server):
         async with Client(fastmcp_server) as client:


### PR DESCRIPTION
## Summary

Follow-up to #1281

This PR introduces an optional `_fastmcp` namespace within the meta field of MCP components, providing a reserved space for FastMCP-specific metadata while maintaining backward compatibility.

## Key Changes

### New Setting: `include_fastmcp_meta`

Controls whether FastMCP adds its own metadata to component responses:

```python
# Default behavior - includes FastMCP meta
mcp = FastMCP()  # or FastMCP(include_fastmcp_meta=True)

@mcp.tool(tags={"example", "utility"})
def my_tool():
    pass

# Result: tool.meta = {"_fastmcp": {"tags": ["example", "utility"]}}
```

```python
# Disabled FastMCP meta - cleaner for integrations
mcp = FastMCP(include_fastmcp_meta=False)

@mcp.tool(tags={"example", "utility"})
def my_tool():
    pass

# Result: tool.meta = None (when no explicit meta set)
```

### Global Configuration

The setting can be configured globally and inherited by servers:

```python
# Set globally via environment or settings
fastmcp.settings.include_fastmcp_meta = False

# All new servers inherit this setting
mcp = FastMCP()  # Will have include_fastmcp_meta=False

# Can still override per server
mcp_with_meta = FastMCP(include_fastmcp_meta=True)
```

### Meta Structure Change

Component metadata now uses a structured approach:

**Before:**
```json
{
  "meta": {
    "tags": ["example", "utility"]
  }
}
```

**After (with include_fastmcp_meta=True):**
```json
{
  "meta": {
    "_fastmcp": {
      "tags": ["example", "utility"]
    }
  }
}
```

**After (with include_fastmcp_meta=False):**
```json
{
  "meta": null
}
```

## Benefits

1. **Reserved Namespace**: The `_fastmcp` key provides a dedicated space for FastMCP metadata, preventing conflicts with user-defined meta
2. **Cleaner Integrations**: Servers can opt out of FastMCP-specific metadata when integrating with external systems
3. **Backward Compatibility**: Existing code continues to work, tests have been updated to expect the new structure
4. **Future Extensibility**: The namespace can accommodate additional FastMCP metadata beyond just tags

## Implementation Notes

- All component types (tools, resources, resource templates, prompts) support the new meta structure
- Setting defaults to `True` to maintain existing behavior
- Comprehensive test coverage includes both enabled and disabled scenarios
- Tests improved to be more robust by selecting components by name/URI rather than array position