### PR TITLE
(RFC) contrib: better validation of external resources thorough MCP

### DIFF
--- a/src/fastmcp/contrib/external_resources/README.md
+++ b/src/fastmcp/contrib/external_resources/README.md
@@ -1,0 +1,91 @@
+# External Resources for FastMCP
+
+A safe, controlled, and scalable approach to exposing external data to LLMs using MCP as a gateway protocol.
+
+External Resources provides a way for MCP servers to declare and control access to external resources. Servers declare which external resources they provide access to as metadata containers. The validation middleware ensures tools only access declared resources, creating a secure gateway where LLMs interact with external data through MCP's controlled interface.
+
+## Components
+
+### ExternalResource
+
+Represents a specific external resource with a fixed URI:
+
+```python
+from fastmcp.contrib.external_resources import ExternalResource
+
+resource = ExternalResource(
+    uri="s3://my-bucket/datasets/training-data.csv",
+    name="Training Dataset",
+    description="Customer behavior training data",
+    mime_type="text/csv",
+    meta={"size": "1.2GB", "updated": "2024-01-15"}
+)
+```
+
+### ExternalResourceTemplate
+
+Represents a pattern for accessing multiple related resources:
+
+```python
+from fastmcp.contrib.external_resources import ExternalResourceTemplate
+
+template = ExternalResourceTemplate(
+    uri_template="https://api.weather.com/v1/cities/{city}/forecast",
+    name="Weather Forecast API",
+    parameters=["city"],
+    description="Get weather forecast for any city",
+    mime_type="application/json"
+)
+```
+
+### ValidationMiddleware
+
+Ensures tools can only access declared external resources:
+
+```python
+from fastmcp.contrib.external_resources import ValidationMiddleware
+
+app.add_middleware(ValidationMiddleware(app))
+```
+
+## Usage Example
+
+```python
+from fastmcp import FastMCP
+from fastmcp.contrib.external_resources import (
+    ExternalResource,
+    ExternalResourceTemplate,
+    register_external_resources,
+    ValidationMiddleware
+)
+
+app = FastMCP("DataGateway")
+
+# Declare external resources
+resources = [
+    ExternalResource(
+        uri="s3://company-data/reports/2024/sales.pdf",
+        name="2024 Sales Report",
+        mime_type="application/pdf",
+        meta={"confidential": True}
+    ),
+    ExternalResourceTemplate(
+        uri_template="https://internal.api/v2/users/{user_id}",
+        name="User API",
+        parameters=["user_id"],
+        mime_type="application/json"
+    )
+]
+
+register_external_resources(app, resources)
+
+# Optional: Enable validation
+app.add_middleware(ValidationMiddleware(app))
+
+# Tools can now safely work with these resources
+@app.tool()
+async def analyze_sales_report(report_uri: AnyUrl) -> str:
+    # Tool implementation can fetch and process the external resource
+    return f"Analyzing report at: {report_uri}"
+```
+

--- a/src/fastmcp/contrib/external_resources/__init__.py
+++ b/src/fastmcp/contrib/external_resources/__init__.py
@@ -1,0 +1,25 @@
+"""External Resources for FastMCP.
+
+This module provides a safe, controlled, and scalable approach to exposing
+external data to LLMs using MCP as a gateway protocol.
+
+Key components:
+- ExternalResource: Declares specific external resources
+- ExternalResourceTemplate: Declares patterns for external resources
+- ValidationMiddleware: Optional middleware to enforce access control
+- register_external_resources: Helper to register multiple resources
+"""
+
+from .resources import (
+    ExternalResource,
+    ExternalResourceTemplate,
+    register_external_resources,
+)
+from .validation_middleware import ValidationMiddleware
+
+__all__ = [
+    "ExternalResource",
+    "ExternalResourceTemplate",
+    "register_external_resources",
+    "ValidationMiddleware",
+]

--- a/src/fastmcp/contrib/external_resources/example.py
+++ b/src/fastmcp/contrib/external_resources/example.py
@@ -1,0 +1,72 @@
+"""Example demonstrating external resources with MCP as a gateway protocol."""
+
+from pydantic import AnyUrl
+
+from fastmcp import FastMCP
+from fastmcp.contrib.external_resources import (
+    ExternalResource,
+    ExternalResourceTemplate,
+    ValidationMiddleware,
+    register_external_resources,
+)
+
+# Create server with external resource gateway
+app = FastMCP("External Resources Gateway")
+
+# Optional: Add validation middleware for access control
+app.add_middleware(ValidationMiddleware(app))
+
+# Define external resources as metadata containers
+external_resources = [
+    ExternalResource(
+        uri=AnyUrl("s3://my-bucket/data/training.csv"),
+        name="Training Data",
+        description="ML training dataset stored in S3",
+        mime_type="text/csv",
+        meta={"size": "1.2GB", "updated": "2024-01-15"},
+    ),
+    ExternalResource(
+        uri=AnyUrl("https://api.company.com/v1/users"),
+        name="Users API",
+        description="Company users API endpoint",
+        mime_type="application/json",
+    ),
+    ExternalResourceTemplate(
+        uri_template="file:///config/{env}",
+        name="Config Files",
+        parameters=["env"],
+        description="Environment-specific configuration files",
+        mime_type="application/json",
+    ),
+    ExternalResourceTemplate(
+        uri_template="s3://my-bucket/models/{model_name}",
+        name="ML Models",
+        parameters=["model_name"],
+        description="Trained ML models in S3",
+        meta={"format": "pytorch"},
+    ),
+    ExternalResourceTemplate(
+        uri_template="https://api.example.com/data/{dataset}/{version}",
+        name="Versioned Datasets",
+        parameters=["dataset", "version"],
+        required=["dataset"],  # version is optional
+        description="Versioned datasets with optional version parameter",
+    ),
+]
+
+# Register all external resources
+register_external_resources(app, external_resources)
+
+
+# Tool without annotation - validated by default
+@app.tool()
+async def process_data(data_uri: AnyUrl) -> str:
+    """Process data from a URI."""
+    return f"Processing data from: {data_uri}"
+
+
+# Tool with explicit opt-out - not validated
+@app.tool(annotations={"openWorldHint": True})
+async def download_anything(url: AnyUrl) -> str:
+    """Download from any URL."""
+    return f"Downloading from: {url}"

--- a/src/fastmcp/contrib/external_resources/resources.py
+++ b/src/fastmcp/contrib/external_resources/resources.py
@@ -1,0 +1,102 @@
+"""External resource classes for URI validation middleware."""
+
+from typing import Any
+
+from fastmcp.resources import Resource
+from fastmcp.resources.template import ResourceTemplate
+
+
+class ExternalResource(Resource):
+    """Represents an external resource that exists outside the MCP server.
+
+    This is a metadata-only resource that describes an external resource
+    without providing actual access to it. Used for URI validation to
+    declare which external resources a server's tools are allowed to reference.
+    """
+
+    async def read(self) -> str:
+        """Return a JSON representation of the resource metadata."""
+        import json
+
+        return json.dumps(
+            {
+                "uri": str(self.uri),
+                "name": self.name,
+                "description": self.description,
+                "mime_type": self.mime_type,
+                "meta": self.meta,
+            },
+            indent=2,
+        )
+
+
+class ExternalResourceTemplate(ResourceTemplate):
+    """Represents a template for external resources with URI patterns.
+
+    Similar to ExternalResource but supports URI templates with placeholders
+    like 's3://bucket/{key}' or 'https://api.example.com/v1/{endpoint}'.
+    """
+
+    def __init__(
+        self,
+        uri_template: str,
+        name: str,
+        parameters: list[str],
+        required: list[str] | None = None,
+        **kwargs,
+    ):
+        """Initialize with automatic parameter schema generation from string list.
+
+        Args:
+            uri_template: URI template with placeholders
+            name: Name of the resource template
+            parameters: List of parameter names as strings
+            required: List of required parameter names (defaults to all parameters)
+            **kwargs: Additional fields like description, mime_type, _meta
+        """
+        # Default to all parameters being required if not specified
+        if required is None:
+            required = parameters
+
+        # Generate JSON schema from parameter list
+        parameters_schema = {
+            "type": "object",
+            "properties": {param: {"type": "string"} for param in parameters},
+            "required": required,
+        }
+
+        super().__init__(
+            uri_template=uri_template, name=name, parameters=parameters_schema, **kwargs
+        )
+
+    async def read(self, arguments: dict[str, Any]) -> str:
+        """Return a JSON representation of the template with resolved arguments."""
+        import json
+
+        return json.dumps(
+            {
+                "uri_template": self.uri_template,
+                "name": self.name,
+                "description": self.description,
+                "mime_type": self.mime_type,
+                "meta": self.meta,
+                "resolved_args": arguments,
+            },
+            indent=2,
+        )
+
+
+def register_external_resources(
+    app, resources: list[ExternalResource | ExternalResourceTemplate]
+):
+    """Helper to register multiple external resources with a FastMCP app.
+
+    Args:
+        app: FastMCP application instance
+        resources: List of ExternalResource or ExternalResourceTemplate instances
+    """
+    for resource in resources:
+        if isinstance(resource, ExternalResource):
+            app.add_resource(resource)
+        elif isinstance(resource, ExternalResourceTemplate):
+            app.add_template(resource)

--- a/src/fastmcp/contrib/external_resources/validation_middleware.py
+++ b/src/fastmcp/contrib/external_resources/validation_middleware.py
@@ -1,0 +1,106 @@
+"""Validation middleware for external resource access control."""
+
+from typing import Any
+
+import mcp.types as mt
+
+from fastmcp.exceptions import ToolError
+from fastmcp.resources.template import match_uri_template
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
+from fastmcp.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class ValidationMiddleware(Middleware):
+    """Middleware that validates URI parameters against declared external resources.
+
+    By default, validates all tools unless they explicitly set openWorldHint=True.
+    This ensures tools can only access external resources that have been explicitly
+    declared by the server, providing a controlled gateway to external data.
+    """
+
+    def __init__(self, server: Any):
+        """Initialize the middleware with a FastMCP server instance.
+
+        Args:
+            server: The FastMCP server instance to get resources from
+        """
+        self.server = server
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        """Intercept tool calls to validate URI parameters.
+
+        Only tools with explicit openWorldHint=True bypass validation.
+        All other tools (including those without annotations) are validated.
+        """
+        tool_name = context.message.name
+        arguments = context.message.arguments
+
+        # Get the tool from the server
+        try:
+            tool = await self.server._tool_manager.get_tool(tool_name)
+        except Exception:
+            # Tool not found - let the normal error handling deal with it
+            return await call_next(context)
+
+        # Check if we should skip validation
+        # ONLY skip if explicitly openWorldHint=True
+        if tool.annotations and tool.annotations.openWorldHint is True:
+            logger.debug(
+                f"Skipping URI validation for tool '{tool_name}' (openWorldHint=True)"
+            )
+            return await call_next(context)
+
+        # Validate URI parameters
+        logger.debug(f"Validating URIs for tool '{tool_name}'")
+        if tool.parameters and isinstance(tool.parameters, dict) and arguments:
+            await self._validate_uri_arguments(tool.parameters, arguments, tool_name)
+
+        return await call_next(context)
+
+    async def _validate_uri_arguments(
+        self, input_schema: dict[str, Any], arguments: dict[str, Any], tool_name: str
+    ) -> None:
+        """Validate URI arguments against known resources."""
+        properties = input_schema.get("properties", {})
+        if not properties:
+            return
+
+        # Find URL parameters (those with format: "uri")
+        url_params = [
+            (name, arguments[name])
+            for name, schema in properties.items()
+            if name in arguments
+            and isinstance(schema, dict)
+            and schema.get("format") == "uri"
+        ]
+
+        if not url_params:
+            return
+
+        # Get resources and templates from server
+        resources = await self.server.get_resources()
+        templates = await self.server.get_resource_templates()
+        resource_uris = {str(r.uri) for r in resources.values()}
+
+        # Validate each URL parameter
+        for param_name, uri_value in url_params:
+            uri_str = str(uri_value)
+
+            # Skip if matches exact resource or template
+            if uri_str in resource_uris or any(
+                match_uri_template(uri_str, t.uri_template) is not None
+                for t in templates.values()
+            ):
+                continue
+
+            raise ToolError(
+                f"Unknown resource URI '{uri_str}' for parameter '{param_name}' in tool '{tool_name}'. "
+                f"This tool requires valid resource URIs. To allow any URI, set openWorldHint=True."
+            )

--- a/tests/contrib/test_external_resources.py
+++ b/tests/contrib/test_external_resources.py
@@ -1,0 +1,472 @@
+"""Tests for external resources and validation middleware."""
+
+import json
+
+import pytest
+from mcp.types import TextContent, TextResourceContents
+from pydantic import AnyUrl
+
+from fastmcp import FastMCP
+from fastmcp.client import Client
+from fastmcp.contrib.external_resources import (
+    ExternalResource,
+    ExternalResourceTemplate,
+    ValidationMiddleware,
+    register_external_resources,
+)
+from fastmcp.exceptions import ToolError
+
+# Tests for ExternalResource and ExternalResourceTemplate classes
+
+
+async def test_external_resource_basic():
+    """Test basic ExternalResource functionality."""
+    resource = ExternalResource(
+        uri=AnyUrl("s3://bucket/file.csv"),
+        name="Test File",
+        description="A test CSV file",
+        mime_type="text/csv",
+        meta={"size": "100MB", "created": "2024-01-01"},
+    )
+
+    # Check attributes
+    assert str(resource.uri) == "s3://bucket/file.csv"
+    assert resource.name == "Test File"
+    assert resource.description == "A test CSV file"
+    assert resource.mime_type == "text/csv"
+    assert resource.meta == {"size": "100MB", "created": "2024-01-01"}
+
+    # Test read method
+    content = await resource.read()
+    data = json.loads(content)
+    assert data["uri"] == "s3://bucket/file.csv"
+    assert data["name"] == "Test File"
+    assert data["description"] == "A test CSV file"
+    assert data["mime_type"] == "text/csv"
+    assert data["meta"] == {"size": "100MB", "created": "2024-01-01"}
+
+
+async def test_external_resource_minimal():
+    """Test ExternalResource with minimal fields."""
+    resource = ExternalResource(
+        uri=AnyUrl("https://api.example.com/data"),
+        name="API Data",
+    )
+
+    # Default values
+    assert resource.description is None
+    assert resource.mime_type == "text/plain"  # Default from parent
+    assert resource.meta is None
+
+    # Test read
+    content = await resource.read()
+    data = json.loads(content)
+    assert data["uri"] == "https://api.example.com/data"
+    assert data["name"] == "API Data"
+    assert data["description"] is None
+    assert data["mime_type"] == "text/plain"
+    assert data["meta"] is None
+
+
+async def test_external_resource_template_basic():
+    """Test basic ExternalResourceTemplate functionality."""
+    template = ExternalResourceTemplate(
+        uri_template="s3://bucket/data/{year}/{month}",
+        name="Monthly Data",
+        parameters=["year", "month"],
+        description="Monthly data files",
+        mime_type="application/json",
+        meta={"format": "parquet"},
+    )
+
+    # Check attributes
+    assert template.uri_template == "s3://bucket/data/{year}/{month}"
+    assert template.name == "Monthly Data"
+    assert template.description == "Monthly data files"
+    assert template.mime_type == "application/json"
+    assert template.meta == {"format": "parquet"}
+
+    # Check generated parameters schema
+    assert template.parameters["type"] == "object"
+    assert "year" in template.parameters["properties"]
+    assert "month" in template.parameters["properties"]
+    assert template.parameters["required"] == ["year", "month"]
+
+    # Test read method with arguments
+    content = await template.read({"year": "2024", "month": "01"})
+    data = json.loads(content)
+    assert data["uri_template"] == "s3://bucket/data/{year}/{month}"
+    assert data["name"] == "Monthly Data"
+    assert data["resolved_args"] == {"year": "2024", "month": "01"}
+
+
+async def test_external_resource_template_optional_params():
+    """Test ExternalResourceTemplate with optional parameters."""
+    template = ExternalResourceTemplate(
+        uri_template="https://api.example.com/v1/{endpoint}?limit={limit}",
+        name="API Endpoint",
+        parameters=["endpoint", "limit"],
+        required=["endpoint"],  # Only endpoint is required
+    )
+
+    # Check that only endpoint is required
+    assert template.parameters["required"] == ["endpoint"]
+    assert "limit" in template.parameters["properties"]
+
+    # Test read
+    content = await template.read({"endpoint": "users", "limit": "10"})
+    data = json.loads(content)
+    assert data["resolved_args"] == {"endpoint": "users", "limit": "10"}
+
+
+async def test_register_external_resources():
+    """Test registering external resources with a FastMCP app."""
+    app = FastMCP("Test External Resources")
+
+    resources = [
+        ExternalResource(
+            uri=AnyUrl("s3://bucket/file1.csv"),
+            name="File 1",
+        ),
+        ExternalResource(
+            uri=AnyUrl("s3://bucket/file2.csv"),
+            name="File 2",
+        ),
+        ExternalResourceTemplate(
+            uri_template="https://api.example.com/{endpoint}",
+            name="API Template",
+            parameters=["endpoint"],
+        ),
+    ]
+
+    register_external_resources(app, resources)
+
+    # Check resources were registered
+    async with Client(app) as client:
+        # List resources
+        resources_list = await client.list_resources()
+        assert len(resources_list) == 2
+        uris = [str(r.uri) for r in resources_list]
+        assert "s3://bucket/file1.csv" in uris
+        assert "s3://bucket/file2.csv" in uris
+
+        # List templates
+        templates_list = await client.list_resource_templates()
+        assert len(templates_list) == 1
+        assert templates_list[0].uriTemplate == "https://api.example.com/{endpoint}"
+
+
+async def test_external_resource_read_through_client():
+    """Test reading external resources through the MCP client."""
+    app = FastMCP("Test Read External Resources")
+
+    resource = ExternalResource(
+        uri=AnyUrl("s3://bucket/important.csv"),
+        name="Important Data",
+        description="Critical business data",
+        mime_type="text/csv",
+        meta={"confidential": True, "size": "500MB"},
+    )
+
+    app.add_resource(resource)
+
+    async with Client(app) as client:
+        # Read the resource
+        contents = await client.read_resource("s3://bucket/important.csv")
+        assert len(contents) == 1
+
+        # Parse the returned content
+        assert isinstance(contents[0], TextResourceContents)
+        data = json.loads(contents[0].text)
+        assert data["uri"] == "s3://bucket/important.csv"
+        assert data["name"] == "Important Data"
+        assert data["description"] == "Critical business data"
+        assert data["mime_type"] == "text/csv"
+        assert data["meta"]["confidential"] is True
+        assert data["meta"]["size"] == "500MB"
+
+
+async def test_external_resource_template_read_through_client():
+    """Test reading template resources through the MCP client."""
+    app = FastMCP("Test Read Template Resources")
+
+    template = ExternalResourceTemplate(
+        uri_template="https://api.weather.com/v1/cities/{city}/forecast",
+        name="Weather API",
+        parameters=["city"],
+        description="Get weather forecast for any city",
+        mime_type="application/json",
+        meta={"api_version": "v1"},
+    )
+
+    app.add_template(template)
+
+    async with Client(app) as client:
+        # Read a specific instance
+        contents = await client.read_resource(
+            "https://api.weather.com/v1/cities/london/forecast"
+        )
+        assert len(contents) == 1
+
+        # Parse the returned content
+        assert isinstance(contents[0], TextResourceContents)
+        data = json.loads(contents[0].text)
+        assert (
+            data["uri_template"] == "https://api.weather.com/v1/cities/{city}/forecast"
+        )
+        assert data["name"] == "Weather API"
+        assert data["resolved_args"]["city"] == "london"
+        assert data["meta"]["api_version"] == "v1"
+
+
+async def test_external_resource_different_uri_schemes():
+    """Test ExternalResource with various URI schemes."""
+    schemes = [
+        ("s3://bucket/file.csv", "S3 File"),
+        ("gs://bucket/data.json", "Google Cloud Storage"),
+        ("https://api.example.com/data", "HTTPS API"),
+        ("http://localhost:8080/test", "HTTP Local"),
+        ("ftp://server.com/file.txt", "FTP File"),
+        ("file:///home/user/data.csv", "Local File"),
+        ("mongodb://localhost:27017/db", "MongoDB"),
+        ("redis://localhost:6379/0", "Redis"),
+    ]
+
+    for uri_str, name in schemes:
+        resource = ExternalResource(
+            uri=AnyUrl(uri_str),
+            name=name,
+        )
+        assert str(resource.uri) == uri_str
+        assert resource.name == name
+
+        # Should be readable
+        content = await resource.read()
+        data = json.loads(content)
+        assert data["uri"] == uri_str
+
+
+async def test_external_resource_inheritance():
+    """Test that ExternalResource properly inherits from Resource."""
+    resource = ExternalResource(
+        uri=AnyUrl("s3://bucket/file.csv"),
+        name="Test Resource",
+    )
+
+    # Should have all Resource base class features
+    assert hasattr(resource, "uri")
+    assert hasattr(resource, "name")
+    assert hasattr(resource, "description")
+    assert hasattr(resource, "mime_type")
+    assert hasattr(resource, "meta")
+    assert hasattr(resource, "enabled")
+    assert hasattr(resource, "tags")
+
+    # Should be enabled by default
+    assert resource.enabled is True
+
+    # Can use tags
+    resource.tags.add("external")
+    resource.tags.add("s3")
+    assert "external" in resource.tags
+    assert "s3" in resource.tags
+
+
+# Tests for ValidationMiddleware
+
+
+@pytest.fixture
+def app_with_middleware():
+    """Create a FastMCP app with external resource validation."""
+    app = FastMCP("Test External Resources")
+
+    # Add validation middleware
+    app.add_middleware(ValidationMiddleware(app))
+
+    # Add some resources
+    @app.resource("resource://test-data")
+    async def test_data():
+        return "Test data content"
+
+    @app.resource("resource://config/{name}")
+    async def config_resource(name: str):
+        return f"Config for {name}"
+
+    # Tool without annotation - will be validated (secure by default)
+    @app.tool()
+    async def process_resource(resource_uri: AnyUrl) -> str:
+        """Process a resource by URI."""
+        return f"Processing: {resource_uri}"
+
+    # Tool with AnyUrl parameter - will be validated
+    @app.tool()
+    async def fetch_data(url: AnyUrl) -> str:
+        """Fetch data from a URL."""
+        return f"Fetching from: {url}"
+
+    # Tool with openWorldHint=False - will be validated
+    @app.tool(annotations={"openWorldHint": False})
+    async def secure_process(uri: AnyUrl) -> str:
+        """Securely process a resource."""
+        return f"Secure processing: {uri}"
+
+    # Tool with openWorldHint=True - will NOT be validated
+    @app.tool(annotations={"openWorldHint": True})
+    async def process_external(external_uri: AnyUrl) -> str:
+        """Process an external resource."""
+        return f"Processing external: {external_uri}"
+
+    return app
+
+
+async def test_default_validation_for_tool_without_annotation(app_with_middleware):
+    """Test that tools without annotation are validated by default."""
+    async with Client(app_with_middleware) as client:
+        # Valid resource should work
+        result = await client.call_tool(
+            "process_resource", {"resource_uri": "resource://test-data"}
+        )
+        assert len(result.content) > 0
+        content = result.content[0]
+        assert isinstance(content, TextContent)
+        assert "Processing: resource://test-data" in content.text
+
+        # Invalid resource should fail
+        with pytest.raises(ToolError) as exc_info:
+            await client.call_tool(
+                "process_resource", {"resource_uri": "resource://invalid"}
+            )
+
+        assert "Unknown resource URI 'resource://invalid'" in str(exc_info.value)
+        assert "To allow any URI, set openWorldHint=True" in str(exc_info.value)
+
+
+async def test_validation_with_resource_template(app_with_middleware):
+    """Test validation with a resource template."""
+    async with Client(app_with_middleware) as client:
+        # URI matching template should work
+        result = await client.call_tool(
+            "process_resource", {"resource_uri": "resource://config/production"}
+        )
+        assert len(result.content) > 0
+        content = result.content[0]
+        assert isinstance(content, TextContent)
+        assert "Processing: resource://config/production" in content.text
+
+
+async def test_validation_with_anyurl_type(app_with_middleware):
+    """Test validation detects AnyUrl type parameters."""
+    async with Client(app_with_middleware) as client:
+        # Should validate AnyUrl parameters
+        with pytest.raises(ToolError) as exc_info:
+            await client.call_tool("fetch_data", {"url": "https://external.com"})
+
+        assert "Unknown resource URI 'https://external.com'" in str(exc_info.value)
+
+
+async def test_closed_world_tool_validation(app_with_middleware):
+    """Test that tools with openWorldHint=False are validated."""
+    async with Client(app_with_middleware) as client:
+        # Valid resource should work
+        result = await client.call_tool(
+            "secure_process", {"uri": "resource://test-data"}
+        )
+        assert len(result.content) > 0
+        content = result.content[0]
+        assert isinstance(content, TextContent)
+        assert "Secure processing: resource://test-data" in content.text
+
+        # Invalid resource should fail
+        with pytest.raises(ToolError) as exc_info:
+            await client.call_tool("secure_process", {"uri": "https://unknown.com"})
+
+        assert "Unknown resource URI" in str(exc_info.value)
+
+
+async def test_open_world_tool_no_validation(app_with_middleware):
+    """Test that tools with openWorldHint=True are NOT validated."""
+    async with Client(app_with_middleware) as client:
+        # Open world tool should accept any URI
+        result = await client.call_tool(
+            "process_external", {"external_uri": "https://any.external.com"}
+        )
+        assert len(result.content) > 0
+        content = result.content[0]
+        assert isinstance(content, TextContent)
+        assert "Processing external: https://any.external.com" in content.text
+
+
+async def test_non_uri_parameters_not_validated(app_with_middleware):
+    """Test that non-URI parameters are not validated."""
+    app = app_with_middleware
+
+    @app.tool()
+    async def process_data(data: str, count: int) -> str:
+        """Process data with non-URI parameters."""
+        return f"Processing {data} {count} times"
+
+    async with Client(app) as client:
+        # Non-URI parameters should not be validated
+        result = await client.call_tool("process_data", {"data": "test", "count": 5})
+        assert len(result.content) > 0
+        content = result.content[0]
+        assert isinstance(content, TextContent)
+        assert "Processing test 5 times" in content.text
+
+
+async def test_missing_tool_handled_gracefully(app_with_middleware):
+    """Test that missing tools are handled by the normal error path."""
+    async with Client(app_with_middleware) as client:
+        # Missing tool should raise normal error, not validation error
+        with pytest.raises(Exception) as exc_info:
+            await client.call_tool("missing_tool", {"uri": "resource://test"})
+
+        # Should not be a validation error
+        assert "Unknown resource URI" not in str(exc_info.value)
+
+
+async def test_mixed_parameters_validation(app_with_middleware):
+    """Test validation with mixed parameter types."""
+    app = app_with_middleware
+
+    @app.tool()
+    async def analyze(name: str, source: AnyUrl, verbose: bool = False) -> str:
+        """Analyze a resource with mixed parameters."""
+        return f"Analyzing {name} from {source} (verbose={verbose})"
+
+    async with Client(app) as client:
+        # Valid resource
+        result = await client.call_tool(
+            "analyze",
+            {"name": "test", "source": "resource://test-data", "verbose": True},
+        )
+        assert len(result.content) > 0
+        content = result.content[0]
+        assert isinstance(content, TextContent)
+        assert "Analyzing test from resource://test-data" in content.text
+
+        # Invalid resource
+        with pytest.raises(ToolError) as exc_info:
+            await client.call_tool(
+                "analyze",
+                {"name": "test", "source": "https://invalid.com", "verbose": False},
+            )
+
+        assert "Unknown resource URI 'https://invalid.com'" in str(exc_info.value)
+
+
+async def test_empty_arguments_handled(app_with_middleware):
+    """Test that tools with no arguments are handled correctly."""
+    app = app_with_middleware
+
+    @app.tool()
+    async def no_args_tool() -> str:
+        """Tool with no arguments."""
+        return "No arguments"
+
+    async with Client(app) as client:
+        result = await client.call_tool("no_args_tool", {})
+        assert len(result.content) > 0
+        content = result.content[0]
+        assert isinstance(content, TextContent)
+        assert "No arguments" in content.text

--- a/tests/contrib/test_external_resources.py
+++ b/tests/contrib/test_external_resources.py
@@ -3,7 +3,7 @@
 import json
 
 import pytest
-from mcp.types import TextContent, TextResourceContents
+from mcp.types import TextContent
 from pydantic import AnyUrl
 
 from fastmcp import FastMCP
@@ -12,15 +12,15 @@ from fastmcp.contrib.external_resources import (
     ExternalResource,
     ExternalResourceTemplate,
     ValidationMiddleware,
-    register_external_resources,
 )
 from fastmcp.exceptions import ToolError
 
-# Tests for ExternalResource and ExternalResourceTemplate classes
+
+# Tests for ExternalResource and ExternalResourceTemplate specific features
 
 
-async def test_external_resource_basic():
-    """Test basic ExternalResource functionality."""
+async def test_external_resource_returns_metadata():
+    """Test that ExternalResource returns metadata as JSON."""
     resource = ExternalResource(
         uri=AnyUrl("s3://bucket/file.csv"),
         name="Test File",
@@ -29,14 +29,7 @@ async def test_external_resource_basic():
         meta={"size": "100MB", "created": "2024-01-01"},
     )
 
-    # Check attributes
-    assert str(resource.uri) == "s3://bucket/file.csv"
-    assert resource.name == "Test File"
-    assert resource.description == "A test CSV file"
-    assert resource.mime_type == "text/csv"
-    assert resource.meta == {"size": "100MB", "created": "2024-01-01"}
-
-    # Test read method
+    # Test read method returns metadata
     content = await resource.read()
     data = json.loads(content)
     assert data["uri"] == "s3://bucket/file.csv"
@@ -46,30 +39,8 @@ async def test_external_resource_basic():
     assert data["meta"] == {"size": "100MB", "created": "2024-01-01"}
 
 
-async def test_external_resource_minimal():
-    """Test ExternalResource with minimal fields."""
-    resource = ExternalResource(
-        uri=AnyUrl("https://api.example.com/data"),
-        name="API Data",
-    )
-
-    # Default values
-    assert resource.description is None
-    assert resource.mime_type == "text/plain"  # Default from parent
-    assert resource.meta is None
-
-    # Test read
-    content = await resource.read()
-    data = json.loads(content)
-    assert data["uri"] == "https://api.example.com/data"
-    assert data["name"] == "API Data"
-    assert data["description"] is None
-    assert data["mime_type"] == "text/plain"
-    assert data["meta"] is None
-
-
-async def test_external_resource_template_basic():
-    """Test basic ExternalResourceTemplate functionality."""
+async def test_external_resource_template_parameter_generation():
+    """Test ExternalResourceTemplate generates correct parameter schema."""
     template = ExternalResourceTemplate(
         uri_template="s3://bucket/data/{year}/{month}",
         name="Monthly Data",
@@ -79,24 +50,15 @@ async def test_external_resource_template_basic():
         meta={"format": "parquet"},
     )
 
-    # Check attributes
-    assert template.uri_template == "s3://bucket/data/{year}/{month}"
-    assert template.name == "Monthly Data"
-    assert template.description == "Monthly data files"
-    assert template.mime_type == "application/json"
-    assert template.meta == {"format": "parquet"}
-
     # Check generated parameters schema
     assert template.parameters["type"] == "object"
     assert "year" in template.parameters["properties"]
     assert "month" in template.parameters["properties"]
     assert template.parameters["required"] == ["year", "month"]
 
-    # Test read method with arguments
+    # Test read method includes resolved args
     content = await template.read({"year": "2024", "month": "01"})
     data = json.loads(content)
-    assert data["uri_template"] == "s3://bucket/data/{year}/{month}"
-    assert data["name"] == "Monthly Data"
     assert data["resolved_args"] == {"year": "2024", "month": "01"}
 
 
@@ -112,164 +74,6 @@ async def test_external_resource_template_optional_params():
     # Check that only endpoint is required
     assert template.parameters["required"] == ["endpoint"]
     assert "limit" in template.parameters["properties"]
-
-    # Test read
-    content = await template.read({"endpoint": "users", "limit": "10"})
-    data = json.loads(content)
-    assert data["resolved_args"] == {"endpoint": "users", "limit": "10"}
-
-
-async def test_register_external_resources():
-    """Test registering external resources with a FastMCP app."""
-    app = FastMCP("Test External Resources")
-
-    resources = [
-        ExternalResource(
-            uri=AnyUrl("s3://bucket/file1.csv"),
-            name="File 1",
-        ),
-        ExternalResource(
-            uri=AnyUrl("s3://bucket/file2.csv"),
-            name="File 2",
-        ),
-        ExternalResourceTemplate(
-            uri_template="https://api.example.com/{endpoint}",
-            name="API Template",
-            parameters=["endpoint"],
-        ),
-    ]
-
-    register_external_resources(app, resources)
-
-    # Check resources were registered
-    async with Client(app) as client:
-        # List resources
-        resources_list = await client.list_resources()
-        assert len(resources_list) == 2
-        uris = [str(r.uri) for r in resources_list]
-        assert "s3://bucket/file1.csv" in uris
-        assert "s3://bucket/file2.csv" in uris
-
-        # List templates
-        templates_list = await client.list_resource_templates()
-        assert len(templates_list) == 1
-        assert templates_list[0].uriTemplate == "https://api.example.com/{endpoint}"
-
-
-async def test_external_resource_read_through_client():
-    """Test reading external resources through the MCP client."""
-    app = FastMCP("Test Read External Resources")
-
-    resource = ExternalResource(
-        uri=AnyUrl("s3://bucket/important.csv"),
-        name="Important Data",
-        description="Critical business data",
-        mime_type="text/csv",
-        meta={"confidential": True, "size": "500MB"},
-    )
-
-    app.add_resource(resource)
-
-    async with Client(app) as client:
-        # Read the resource
-        contents = await client.read_resource("s3://bucket/important.csv")
-        assert len(contents) == 1
-
-        # Parse the returned content
-        assert isinstance(contents[0], TextResourceContents)
-        data = json.loads(contents[0].text)
-        assert data["uri"] == "s3://bucket/important.csv"
-        assert data["name"] == "Important Data"
-        assert data["description"] == "Critical business data"
-        assert data["mime_type"] == "text/csv"
-        assert data["meta"]["confidential"] is True
-        assert data["meta"]["size"] == "500MB"
-
-
-async def test_external_resource_template_read_through_client():
-    """Test reading template resources through the MCP client."""
-    app = FastMCP("Test Read Template Resources")
-
-    template = ExternalResourceTemplate(
-        uri_template="https://api.weather.com/v1/cities/{city}/forecast",
-        name="Weather API",
-        parameters=["city"],
-        description="Get weather forecast for any city",
-        mime_type="application/json",
-        meta={"api_version": "v1"},
-    )
-
-    app.add_template(template)
-
-    async with Client(app) as client:
-        # Read a specific instance
-        contents = await client.read_resource(
-            "https://api.weather.com/v1/cities/london/forecast"
-        )
-        assert len(contents) == 1
-
-        # Parse the returned content
-        assert isinstance(contents[0], TextResourceContents)
-        data = json.loads(contents[0].text)
-        assert (
-            data["uri_template"] == "https://api.weather.com/v1/cities/{city}/forecast"
-        )
-        assert data["name"] == "Weather API"
-        assert data["resolved_args"]["city"] == "london"
-        assert data["meta"]["api_version"] == "v1"
-
-
-async def test_external_resource_different_uri_schemes():
-    """Test ExternalResource with various URI schemes."""
-    schemes = [
-        ("s3://bucket/file.csv", "S3 File"),
-        ("gs://bucket/data.json", "Google Cloud Storage"),
-        ("https://api.example.com/data", "HTTPS API"),
-        ("http://localhost:8080/test", "HTTP Local"),
-        ("ftp://server.com/file.txt", "FTP File"),
-        ("file:///home/user/data.csv", "Local File"),
-        ("mongodb://localhost:27017/db", "MongoDB"),
-        ("redis://localhost:6379/0", "Redis"),
-    ]
-
-    for uri_str, name in schemes:
-        resource = ExternalResource(
-            uri=AnyUrl(uri_str),
-            name=name,
-        )
-        assert str(resource.uri) == uri_str
-        assert resource.name == name
-
-        # Should be readable
-        content = await resource.read()
-        data = json.loads(content)
-        assert data["uri"] == uri_str
-
-
-async def test_external_resource_inheritance():
-    """Test that ExternalResource properly inherits from Resource."""
-    resource = ExternalResource(
-        uri=AnyUrl("s3://bucket/file.csv"),
-        name="Test Resource",
-    )
-
-    # Should have all Resource base class features
-    assert hasattr(resource, "uri")
-    assert hasattr(resource, "name")
-    assert hasattr(resource, "description")
-    assert hasattr(resource, "mime_type")
-    assert hasattr(resource, "meta")
-    assert hasattr(resource, "enabled")
-    assert hasattr(resource, "tags")
-
-    # Should be enabled by default
-    assert resource.enabled is True
-
-    # Can use tags
-    resource.tags.add("external")
-    resource.tags.add("s3")
-    assert "external" in resource.tags
-    assert "s3" in resource.tags
 
 
 # Tests for ValidationMiddleware
@@ -297,12 +101,6 @@ def app_with_middleware():
     async def process_resource(resource_uri: AnyUrl) -> str:
         """Process a resource by URI."""
         return f"Processing: {resource_uri}"
-
-    # Tool with AnyUrl parameter - will be validated
-    @app.tool()
-    async def fetch_data(url: AnyUrl) -> str:
-        """Fetch data from a URL."""
-        return f"Fetching from: {url}"
 
     # Tool with openWorldHint=False - will be validated
     @app.tool(annotations={"openWorldHint": False})
@@ -359,28 +157,11 @@ async def test_validation_with_anyurl_type(app_with_middleware):
     async with Client(app_with_middleware) as client:
         # Should validate AnyUrl parameters
         with pytest.raises(ToolError) as exc_info:
-            await client.call_tool("fetch_data", {"url": "https://external.com"})
+            await client.call_tool(
+                "process_resource", {"resource_uri": "https://external.com"}
+            )
 
         assert "Unknown resource URI 'https://external.com'" in str(exc_info.value)
-
-
-async def test_closed_world_tool_validation(app_with_middleware):
-    """Test that tools with openWorldHint=False are validated."""
-    async with Client(app_with_middleware) as client:
-        # Valid resource should work
-        result = await client.call_tool(
-            "secure_process", {"uri": "resource://test-data"}
-        )
-        assert len(result.content) > 0
-        content = result.content[0]
-        assert isinstance(content, TextContent)
-        assert "Secure processing: resource://test-data" in content.text
-
-        # Invalid resource should fail
-        with pytest.raises(ToolError) as exc_info:
-            await client.call_tool("secure_process", {"uri": "https://unknown.com"})
-
-        assert "Unknown resource URI" in str(exc_info.value)
 
 
 async def test_open_world_tool_no_validation(app_with_middleware):
@@ -394,35 +175,6 @@ async def test_open_world_tool_no_validation(app_with_middleware):
         content = result.content[0]
         assert isinstance(content, TextContent)
         assert "Processing external: https://any.external.com" in content.text
-
-
-async def test_non_uri_parameters_not_validated(app_with_middleware):
-    """Test that non-URI parameters are not validated."""
-    app = app_with_middleware
-
-    @app.tool()
-    async def process_data(data: str, count: int) -> str:
-        """Process data with non-URI parameters."""
-        return f"Processing {data} {count} times"
-
-    async with Client(app) as client:
-        # Non-URI parameters should not be validated
-        result = await client.call_tool("process_data", {"data": "test", "count": 5})
-        assert len(result.content) > 0
-        content = result.content[0]
-        assert isinstance(content, TextContent)
-        assert "Processing test 5 times" in content.text
-
-
-async def test_missing_tool_handled_gracefully(app_with_middleware):
-    """Test that missing tools are handled by the normal error path."""
-    async with Client(app_with_middleware) as client:
-        # Missing tool should raise normal error, not validation error
-        with pytest.raises(Exception) as exc_info:
-            await client.call_tool("missing_tool", {"uri": "resource://test"})
-
-        # Should not be a validation error
-        assert "Unknown resource URI" not in str(exc_info.value)
 
 
 async def test_mixed_parameters_validation(app_with_middleware):
@@ -453,20 +205,3 @@ async def test_mixed_parameters_validation(app_with_middleware):
             )
 
         assert "Unknown resource URI 'https://invalid.com'" in str(exc_info.value)
-
-
-async def test_empty_arguments_handled(app_with_middleware):
-    """Test that tools with no arguments are handled correctly."""
-    app = app_with_middleware
-
-    @app.tool()
-    async def no_args_tool() -> str:
-        """Tool with no arguments."""
-        return "No arguments"
-
-    async with Client(app) as client:
-        result = await client.call_tool("no_args_tool", {})
-        assert len(result.content) > 0
-        content = result.content[0]
-        assert isinstance(content, TextContent)
-        assert "No arguments" in content.text


### PR DESCRIPTION
This PR introduces a simplified implementation of a pattern I'm exploring for providing a scalable and safe approach to exposing external data through MCP.

The core challenge is that many tools need to operate with external resources—web APIs, database URLs, files, etc. Currently, tools accessing these resources must either be open-world (allowing access to any URL/file) or implement custom guardrails in each client/server-tool combination.

This implementation offers a straightforward solution using middleware to validate resource access, with hints and annotations defining expected behavior. A key design challenge was determining how to define the universe of valid endpoints/URLs that a server should access. My approach uses MCP resources (and resource templates) to declare valid endpoints, which the middleware then queries for validation.

I'm happy to hear thoughts, feedback, and suggestions around this space in general!