### PR TITLE
refactor: standardize logging usage across OpenAPI utilities

### DIFF
--- a/src/fastmcp/experimental/utilities/openapi/json_schema_converter.py
+++ b/src/fastmcp/experimental/utilities/openapi/json_schema_converter.py
@@ -6,10 +6,11 @@ to JSON Schema, inspired by py-openapi-schema-to-json-schema but optimized
 for our specific use case.
 """
 
-import logging
 from typing import Any
 
-logger = logging.getLogger(__name__)
+from fastmcp.utilities.logging import get_logger
+
+logger = get_logger(__name__)
 
 # OpenAPI-specific fields that should be removed from JSON Schema
 OPENAPI_SPECIFIC_FIELDS = {

--- a/src/fastmcp/experimental/utilities/openapi/parser.py
+++ b/src/fastmcp/experimental/utilities/openapi/parser.py
@@ -1,6 +1,5 @@
 """OpenAPI parsing logic for converting OpenAPI specs to HTTPRoute objects."""
 
-import logging
 from typing import Any, Generic, TypeVar
 
 from openapi_pydantic import (
@@ -25,6 +24,8 @@ from openapi_pydantic.v3.v3_0 import Response as Response_30
 from openapi_pydantic.v3.v3_0 import Schema as Schema_30
 from pydantic import BaseModel, ValidationError
 
+from fastmcp.utilities.logging import get_logger
+
 from .models import (
     HTTPRoute,
     JsonSchema,
@@ -35,7 +36,7 @@ from .models import (
 )
 from .schemas import _combine_schemas_and_map_params, _replace_ref_with_defs
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Type variables for generic parser
 TOpenAPI = TypeVar("TOpenAPI", OpenAPI, OpenAPI_30)

--- a/src/fastmcp/experimental/utilities/openapi/schemas.py
+++ b/src/fastmcp/experimental/utilities/openapi/schemas.py
@@ -1,11 +1,12 @@
 """Schema manipulation utilities for OpenAPI operations."""
 
-import logging
 from typing import Any
+
+from fastmcp.utilities.logging import get_logger
 
 from .models import HTTPRoute, JsonSchema, ResponseInfo
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def clean_schema_for_display(schema: JsonSchema | None) -> JsonSchema | None:

--- a/src/fastmcp/utilities/openapi.py
+++ b/src/fastmcp/utilities/openapi.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from typing import Any, Generic, Literal, TypeVar, cast
 
 from openapi_pydantic import (
@@ -24,9 +23,10 @@ from openapi_pydantic.v3.v3_0 import Response as Response_30
 from openapi_pydantic.v3.v3_0 import Schema as Schema_30
 from pydantic import BaseModel, Field, ValidationError
 
+from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import FastMCPBaseModel
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # --- Intermediate Representation (IR) Definition ---
 # (IR models remain the same)


### PR DESCRIPTION
Replace inconsistent direct logging.getLogger(__name__) usage with FastMCP's standardized get_logger utility function across OpenAPI modules to ensure consistent logging behavior and namespace.

Changes:
- Replace logging.getLogger(__name__) with get_logger(__name__) in:
  - src/fastmcp/utilities/openapi.py
  - src/fastmcp/experimental/utilities/openapi/parser.py
  - src/fastmcp/experimental/utilities/openapi/schemas.py
  - src/fastmcp/experimental/utilities/openapi/json_schema_converter.py
- Remove direct logging imports where no longer needed
- Ensure all loggers use FastMCP namespace (FastMCP.<module>)

Benefits:
- Consistent logging configuration across all modules
- Proper integration with FastMCP's logging infrastructure
- Unified namespace for better log filtering and debugging
- Follows project logging conventions established in utilities/logging.py