### PR TITLE
Remove redundant resource_metadata_url assignment

### DIFF
--- a/src/fastmcp/server/http.py
+++ b/src/fastmcp/server/http.py
@@ -327,14 +327,6 @@ def create_streamable_http_app(
 
     # Add StreamableHTTP routes with or without auth
     if auth:
-        resource_metadata_url = None
-
-        if isinstance(auth, TokenVerifier) and auth.resource_server_url:
-            resource_metadata_url = AnyHttpUrl(
-                str(auth.resource_server_url).rstrip("/")
-                + "/.well-known/oauth-protected-resource"
-            )
-
         auth_middleware, auth_routes, required_scopes = (
             setup_auth_middleware_and_routes(auth)
         )


### PR DESCRIPTION
This PR removes redundant code that was setting `resource_metadata_url` with identical logic in two separate places within the HTTP auth setup.

The issue was identified in #1318 where the same logic for constructing the resource metadata URL was duplicated:

```python
# Before - duplicated logic in two places
resource_metadata_url = AnyHttpUrl(
    str(auth.resource_server_url).rstrip("/")
    + "/.well-known/oauth-protected-resource"
)
```

The fix eliminates this duplication by removing the redundant assignment that occurred earlier in the auth setup flow, keeping only the instance that's actually used in the subsequent code.

Closes #1318