### PR TITLE
Fix : subprocess termination in MCPConfigTransport | Fixes #1311

### DIFF
--- a/src/fastmcp/client/transports.py
+++ b/src/fastmcp/client/transports.py
@@ -858,6 +858,10 @@ class MCPConfigTransport(ClientTransport):
         async with self.transport.connect_session(**session_kwargs) as session:
             yield session
 
+    async def close(self):
+        """Close the underlying transport to ensure proper cleanup of subprocesses."""
+        await self.transport.close()
+
     def __repr__(self) -> str:
         return f"<MCPConfigTransport(config='{self.config}')>"
 


### PR DESCRIPTION
Fix subprocess termination in MCPConfigTransport 


Description :
Fixes subprocess termination issue where FastMCP Client failed to properly terminate stdio MCP subprocesses after calling [client.close()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). This caused resource leaks as subprocesses remained running even after the client was closed.

Related Issue
Closes #1311

Type of Change

<input checked="" disabled="" type="checkbox"> Bug fix (non-breaking change which fixes an issue)
<input disabled="" type="checkbox"> New feature (non-breaking change which adds functionality)
<input disabled="" type="checkbox"> Breaking change (fix or feature that would cause existing functionality to not work as expected)
<input disabled="" type="checkbox"> Documentation update



Root Cause
The [MCPConfigTransport](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) class wraps other transports but didn't implement a [close()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) method to delegate cleanup to the underlying transport. It inherited the base class's empty [close()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) method instead of calling the wrapped transport's proper cleanup logic.



Testing
Automated Tests
<input checked="" disabled="" type="checkbox"> All existing stdio tests pass (8/8)
<input checked="" disabled="" type="checkbox"> All existing client tests pass (72/72)
<input checked="" disabled="" type="checkbox"> No regressions introduced


Manual Verification
<input checked="" disabled="" type="checkbox"> MCPConfig Dict format subprocess termination ✅
<input checked="" disabled="" type="checkbox"> Direct StdioTransport subprocess termination ✅
<input checked="" disabled="" type="checkbox"> PythonStdioTransport subprocess termination ✅