### PR TITLE
feat: add component_filter for dynamic per-request filtering based on tags and request context

### DIFF
--- a/docs/servers/server.mdx
+++ b/docs/servers/server.mdx
@@ -64,6 +64,12 @@ The `FastMCP` constructor accepts several arguments:
   Hide components with any matching tag
 </ParamField>
 
+<ParamField body="component_filter" type="Callable[[set[str]], bool | Awaitable[bool]] | None">
+  <VersionBadge version="2.12.0" />
+  
+  A custom function to determine component availability based on tags. Receives a component's tags and returns `True` to enable or `False` to disable the component. Supports both sync and async functions. This filter is applied in addition to `include_tags` and `exclude_tags`, enabling dynamic per-request filtering based on user permissions, request context, or complex tag logic
+</ParamField>
+
 <ParamField body="on_duplicate_tools" type='Literal["error", "warn", "replace"]' default="error">
   How to handle duplicate tool registrations
 </ParamField>
@@ -182,6 +188,50 @@ mcp = FastMCP(include_tags={"admin"}, exclude_tags={"deprecated"})
 ```
 
 This filtering applies to all component types (tools, resources, resource templates, and prompts) and affects both listing and access.
+
+### Advanced Component Filtering
+
+<VersionBadge version="2.12.0" />
+
+For more sophisticated filtering beyond static tags, the `component_filter` parameter accepts a custom function that receives component tags and returns whether the component should be enabled. This enables **per-request dynamic filtering** based on user permissions, request context, or complex tag logic.
+
+```python
+from fastmcp import FastMCP
+from fastmcp.server.dependencies import get_http_request
+
+def permission_filter(tags: set[str]) -> bool:
+    """Filter components based on current request context."""
+    request = get_http_request()  # Access current HTTP request
+    user_role = request.headers.get("X-User-Role", "guest")
+    
+    if user_role == "admin":
+        return True  # Admins see everything
+    elif user_role == "user":
+        return "public" in tags  # Users only see public components
+    else:
+        return False  # Guests see nothing
+
+mcp = FastMCP(
+    include_tags={"api"},  # Must have 'api' tag (ANY logic)
+    component_filter=permission_filter  # Plus custom per-request logic
+)
+
+@mcp.tool(tags={"api", "public"})
+def public_api() -> str:
+    """Available to users and admins."""
+    return "Public API data"
+
+@mcp.tool(tags={"api", "admin"})
+def admin_api() -> str:
+    """Available only to admins."""
+    return "Admin-only data"
+```
+
+The component filter supports both sync and async functions, and is applied in addition to `include_tags` and `exclude_tags`. Unlike `include_tags` which uses ANY matching logic, custom filters enable complex requirements like requiring ALL tags or conditional logic based on request context.
+
+<Tip>
+Component filters are powerful for multi-tenant applications, user role-based access control, feature flags, and any scenario requiring dynamic component availability based on request context. As it also supports async functions, you can perform database queries, API calls, or other asynchronous operations to determine component availability.
+</Tip>
 
 ## Running the Server
 


### PR DESCRIPTION
## Add component_filter parameter for dynamic per-request component filtering

I built this because I needed per-user component filtering in my project and figured others might run into the same problem.
This PR adds a `component_filter` parameter to the FastMCP constructor that enables advanced, per-request filtering of components based on their tags and request context.

### What it enables

- **Per-request filtering**: Access current HTTP request via `get_http_request()` to filter components based on user roles, authentication headers, tenant information, or any request data
- **Complex tag logic**: Unlike with `include_tags` or `exclude_tags` which are per server instance, implement custom logic like requiring ALL tags to be included for a component to be enabled, conditional requirements, or version-based filtering  
- **Dynamic policies**: Filter components based on user permissions, feature flags, tenant isolation, or business logic
- **Async functions**: For complex operations like database permission lookups or external API calls to authorization services

### Example use cases

```python
# Role-based filtering using request headers
def permission_filter(tags: set[str]) -> bool:
    request = get_http_request()
    user_role = request.headers.get("X-User-Role", "guest")
    
    if user_role == "admin":
        return True
    elif user_role == "user":
        return "public" in tags
    return False

mcp = FastMCP(component_filter=permission_filter)
```

The filter works alongside existing `include_tags`, `exclude_tags` and `enabled` for layered filtering.

**Note**: I looked at solutions like permit.io but they require external service integrations. This provides a lightweight, built-in approach for component-level dynamic access control.