### PR TITLE
Feature/server side configurable ping

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -397,7 +397,7 @@ class FastMCP(Generic[LifespanResultT]):
                     # uses the built-in send_ping method from the mcp library
                     await session.send_ping()
                     logger.debug(
-                        f"Sent ping to client (interval: {self.ping_config}ms)"
+                        f"Sent ping to client (interval: {self.ping_config.interval_ms}ms)"
                     )
                 except Exception as e:
                     logger.error(f"Failed to send ping: {e}")

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -1598,27 +1598,6 @@ def create_ping_server(host: str, port: int) -> None:
     server.run(host=host, port=port, transport="http")
 
 
-def create_ping_via_run_server(host: str, port: int) -> None:
-    """Create and run a server with ping configured via run parameter."""
-    server = FastMCP(name="Test Server")
-    # This tests the main requested feature: ping parameter in run()
-    server.run(host=host, port=port, transport="http", ping=250)
-
-
-def create_no_ping_server(host: str, port: int) -> None:
-    """Create and run a server with ping disabled."""
-    server = FastMCP(
-        name="Test Server",
-        ping=PingConfig(enabled=False, interval_ms=100),
-    )
-
-    @server.tool
-    def test_tool() -> str:
-        return "Test result"
-
-    server.run(host=host, port=port, transport="http")
-
-
 class TestServerSideConfigurablePing:
     async def test_ping_integration_with_server(self):
         """Test the server-side configurable ping."""

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -1588,7 +1588,7 @@ def create_ping_server(host: str, port: int) -> None:
     server = FastMCP(
         name="Test Server",
         version="1.0.0",
-        ping=PingConfig(enabled=True, interval_ms=500),  # Faster for testing
+        ping=PingConfig(enabled=True, interval_ms=500),
     )
 
     @server.tool
@@ -1618,10 +1618,9 @@ class TestServerSideConfigurablePing:
             def emit(self, record):
                 nonlocal ping_count
                 # Look for ping messages in the debug logs
-                if (
-                    record.name == "mcp.client.streamable_http"
-                    and "SSE message: root=JSONRPCRequest(method='ping'"
-                    in record.getMessage()
+                if record.name == "mcp.client.streamable_http" and (
+                    "ping" in record.getMessage().lower()
+                    or "JSONRPCRequest(method='ping'" in record.getMessage()
                 ):
                     ping_count += 1
 


### PR DESCRIPTION
I added an optional configurable ping feature (issue #1212 )  that the server can send to the client. The feature is implemented through middleware that creates a background task for each client session and uses the mcp built-in 'send_ping()' method.

Note: At least one tool must be defined for the server to establish connections

EDIT: I'm not sure why the [Run tests: Python 3.10 on windows-latest] test is failing