### PR TITLE
Enable Protected Resource Metadata to provide resource_name and resou…

### DIFF
--- a/src/fastmcp/server/auth/auth.py
+++ b/src/fastmcp/server/auth/auth.py
@@ -130,6 +130,8 @@ class RemoteAuthProvider(AuthProvider):
         token_verifier: TokenVerifier,
         authorization_servers: list[AnyHttpUrl],
         resource_server_url: AnyHttpUrl | str,
+        resource_name: str | None = None,
+        resource_documentation: AnyHttpUrl | None = None,
     ):
         """Initialize the remote auth provider.
 
@@ -143,6 +145,8 @@ class RemoteAuthProvider(AuthProvider):
         super().__init__(resource_server_url=resource_server_url)
         self.token_verifier = token_verifier
         self.authorization_servers = authorization_servers
+        self.resource_name = resource_name
+        self.resource_documentation = resource_documentation
 
     async def verify_token(self, token: str) -> AccessToken | None:
         """Verify token using the configured token verifier."""
@@ -161,6 +165,8 @@ class RemoteAuthProvider(AuthProvider):
             resource_url=self.resource_server_url,
             authorization_servers=self.authorization_servers,
             scopes_supported=self.token_verifier.required_scopes,
+            resource_name=self.resource_name,
+            resource_documentation=self.resource_documentation,
         )
 
 


### PR DESCRIPTION
This PR is improving support of RFC 9728 for FastMCP.

It relies on the recently merged commit in mcp/python-sdk  https://github.com/modelcontextprotocol/python-sdk/commit/68e25d478b3b6a026b2d9a30b3e5f34f3b1290de

With this PR, developers can provide the resource_name (RECOMMENDED in RFC9728) and the resource_documentation in RemoteOauthServer.