### PR TITLE
fix: Fix missing server name prefixes in resource/template names (#1390)

### DIFF
--- a/src/fastmcp/resources/resource_manager.py
+++ b/src/fastmcp/resources/resource_manager.py
@@ -103,6 +103,10 @@ class ResourceManager:
                         )
                         # Create a copy of the resource with the prefixed key
                         prefixed_resource = resource.with_key(prefixed_uri)
+                        # Also prefix the name field to match tool/prompt behavior
+                        prefixed_resource = prefixed_resource.model_copy(
+                            update={"name": f"{mounted.prefix}_{resource.name}"}
+                        )
                         all_resources[prefixed_uri] = prefixed_resource
                 else:
                     all_resources.update(child_resources)
@@ -151,6 +155,10 @@ class ResourceManager:
                         )
                         # Create a copy of the template with the prefixed key
                         prefixed_template = template.with_key(prefixed_uri_template)
+                        # Also prefix the name field to match tool/prompt behavior
+                        prefixed_template = prefixed_template.model_copy(
+                            update={"name": f"{mounted.prefix}_{template.name}"}
+                        )
                         all_templates[prefixed_uri_template] = prefixed_template
                 else:
                     all_templates.update(child_dict)


### PR DESCRIPTION
#1390 In multi-server configurations, resource and resource template names were not getting server prefixes, making it impossible for users to distinguish which server owns which resource. Only the URI/uriTemplate fields had prefixes.

This change adds server name prefixes to the 'name' field of both resources and resource templates when they are mounted, matching the existing behavior of tools and prompts.

Now all MCP object types (tools, prompts, resources, resource templates) consistently show server prefixes in their names when mounted, preventing user confusion and mis-operations in multi-server setups.