### PR TITLE
fix #1390: add prefix to name of Resource|ResourceTemplate when mutiple servers in MCPConfig

### DIFF
--- a/src/fastmcp/resources/resource_manager.py
+++ b/src/fastmcp/resources/resource_manager.py
@@ -102,7 +102,13 @@ class ResourceManager:
                             uri, mounted.prefix, mounted.resource_prefix_format
                         )
                         # Create a copy of the resource with the prefixed key
-                        prefixed_resource = resource.with_key(prefixed_uri)
+                        prefixed_resource = resource.with_key(
+                            prefixed_uri,
+                            name=f"{mounted.prefix}_{resource.name}",
+                        )
+                        logger.debug(
+                            f"ResourceManager::_load_resources {prefixed_resource=}"
+                        )
                         all_resources[prefixed_uri] = prefixed_resource
                 else:
                     all_resources.update(child_resources)
@@ -150,7 +156,13 @@ class ResourceManager:
                             uri_template, mounted.prefix, mounted.resource_prefix_format
                         )
                         # Create a copy of the template with the prefixed key
-                        prefixed_template = template.with_key(prefixed_uri_template)
+                        prefixed_template = template.with_key(
+                            prefixed_uri_template,
+                            name=f"{mounted.prefix}_{template.name}",
+                        )
+                        logger.debug(
+                            f"ResourceManager::_load_resource_templates {prefixed_template=}"
+                        )
                         all_templates[prefixed_uri_template] = prefixed_template
                 else:
                     all_templates.update(child_dict)

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -1900,7 +1900,10 @@ class FastMCP(Generic[LifespanResultT]):
                 resource_key = add_resource_prefix(
                     key, prefix, self.resource_prefix_format
                 )
-                resource = resource.with_key(resource_key)
+                resource = resource.with_key(
+                    resource_key, name=f"{prefix}_{resource.name}"
+                )
+                logger.debug(f"FastMCP::import_server()  {resource=}")
             self._resource_manager.add_resource(resource)
 
         for key, template in (await server.get_resource_templates()).items():
@@ -1908,7 +1911,10 @@ class FastMCP(Generic[LifespanResultT]):
                 template_key = add_resource_prefix(
                     key, prefix, self.resource_prefix_format
                 )
-                template = template.with_key(template_key)
+                template = template.with_key(
+                    template_key, name=f"{prefix}_{template.name}"
+                )
+                logger.debug(f"FastMCP::import_server()  {template=}")
             self._resource_manager.add_template(template)
 
         # Import prompts from the server

--- a/src/fastmcp/utilities/components.py
+++ b/src/fastmcp/utilities/components.py
@@ -93,7 +93,7 @@ class FastMCPComponent(FastMCPBaseModel):
 
         return meta or None
 
-    def with_key(self, key: str, **extra_kv) -> Self:
+    def with_key(self, key: str, **extra_kv: Any) -> Self:
         # `model_copy` has an `update` parameter but it doesn't work for certain private attributes
         # https://github.com/pydantic/pydantic/issues/12116
         # So we manually set the private attribute here instead

--- a/src/fastmcp/utilities/components.py
+++ b/src/fastmcp/utilities/components.py
@@ -7,9 +7,11 @@ from pydantic import BeforeValidator, Field, PrivateAttr
 from typing_extensions import Self
 
 import fastmcp
+from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import FastMCPBaseModel
 
 T = TypeVar("T")
+logger = get_logger(__name__)
 
 
 class FastMCPMeta(TypedDict, total=False):
@@ -91,12 +93,15 @@ class FastMCPComponent(FastMCPBaseModel):
 
         return meta or None
 
-    def with_key(self, key: str) -> Self:
+    def with_key(self, key: str, **extra_kv) -> Self:
         # `model_copy` has an `update` parameter but it doesn't work for certain private attributes
         # https://github.com/pydantic/pydantic/issues/12116
         # So we manually set the private attribute here instead
         copy = self.model_copy()
         copy._key = key
+        for k, v in extra_kv.items():
+            setattr(copy, k, v)
+        logger.debug(f"FastMCPComponent::with_key() {copy=}")
         return copy
 
     def __eq__(self, other: object) -> bool:


### PR DESCRIPTION
fix #1390  for all use-cases described in the issue.