### PR TITLE
Optimize OpenAPI payload size by 46%

### DIFF
--- a/src/fastmcp/experimental/server/openapi/server.py
+++ b/src/fastmcp/experimental/server/openapi/server.py
@@ -267,7 +267,9 @@ class FastMCPOpenAPI(FastMCP):
 
         # Extract output schema from OpenAPI responses
         output_schema = extract_output_schema_from_responses(
-            route.responses, route.schema_definitions, route.openapi_version
+            route.responses,
+            route.response_schemas or route.schema_definitions,
+            route.openapi_version,
         )
 
         # Get a unique tool name

--- a/src/fastmcp/experimental/server/openapi/server.py
+++ b/src/fastmcp/experimental/server/openapi/server.py
@@ -11,7 +11,7 @@ from jsonschema_path import SchemaPath
 from fastmcp.experimental.utilities.openapi import (
     HTTPRoute,
     extract_output_schema_from_responses,
-    format_description_with_responses,
+    format_simple_description,
     parse_openapi_to_http_routes,
 )
 from fastmcp.experimental.utilities.openapi.director import RequestDirector
@@ -268,7 +268,7 @@ class FastMCPOpenAPI(FastMCP):
         # Extract output schema from OpenAPI responses
         output_schema = extract_output_schema_from_responses(
             route.responses,
-            route.response_schemas or route.schema_definitions,
+            route.response_schemas,
             route.openapi_version,
         )
 
@@ -281,10 +281,9 @@ class FastMCPOpenAPI(FastMCP):
             or f"Executes {route.method} {route.path}"
         )
 
-        # Format enhanced description with parameters and request body
-        enhanced_description = format_description_with_responses(
+        # Use simplified description formatter for tools
+        enhanced_description = format_simple_description(
             base_description=base_description,
-            responses=route.responses,
             parameters=route.parameters,
             request_body=route.request_body,
         )
@@ -333,10 +332,9 @@ class FastMCPOpenAPI(FastMCP):
             route.description or route.summary or f"Represents {route.path}"
         )
 
-        # Format enhanced description with parameters and request body
-        enhanced_description = format_description_with_responses(
+        # Use simplified description for resources
+        enhanced_description = format_simple_description(
             base_description=base_description,
-            responses=route.responses,
             parameters=route.parameters,
             request_body=route.request_body,
         )
@@ -390,10 +388,9 @@ class FastMCPOpenAPI(FastMCP):
             route.description or route.summary or f"Template for {route.path}"
         )
 
-        # Format enhanced description with parameters and request body
-        enhanced_description = format_description_with_responses(
+        # Use simplified description for resource templates
+        enhanced_description = format_simple_description(
             base_description=base_description,
-            responses=route.responses,
             parameters=route.parameters,
             request_body=route.request_body,
         )

--- a/src/fastmcp/experimental/utilities/openapi/__init__.py
+++ b/src/fastmcp/experimental/utilities/openapi/__init__.py
@@ -20,6 +20,7 @@ from .formatters import (
     format_deep_object_parameter,
     format_description_with_responses,
     format_json_for_description,
+    format_simple_description,
     generate_example_from_schema,
 )
 
@@ -54,6 +55,7 @@ __all__ = [
     "format_deep_object_parameter",
     "format_description_with_responses",
     "format_json_for_description",
+    "format_simple_description",
     "generate_example_from_schema",
     # Schemas
     "_combine_schemas",

--- a/src/fastmcp/experimental/utilities/openapi/formatters.py
+++ b/src/fastmcp/experimental/utilities/openapi/formatters.py
@@ -189,6 +189,39 @@ def format_json_for_description(data: Any, indent: int = 2) -> str:
         return f"```\nCould not serialize to JSON: {data}\n```"
 
 
+def format_simple_description(
+    base_description: str,
+    parameters: list[ParameterInfo] | None = None,
+    request_body: RequestBodyInfo | None = None,
+) -> str:
+    """
+    Formats a simple description for MCP objects (tools, resources, prompts).
+    Excludes response details, examples, and verbose status codes.
+
+    Args:
+        base_description (str): The initial description to be formatted.
+        parameters (list[ParameterInfo] | None, optional): A list of parameter information.
+        request_body (RequestBodyInfo | None, optional): Information about the request body.
+
+    Returns:
+        str: The formatted description string with minimal details.
+    """
+    desc_parts = [base_description]
+
+    # Only add critical parameter information if they have descriptions
+    if parameters:
+        path_params = [p for p in parameters if p.location == "path" and p.description]
+        if path_params:
+            desc_parts.append("\n\n**Path Parameters:**")
+            for param in path_params:
+                desc_parts.append(f"\n- **{param.name}**: {param.description}")
+
+    # Skip query parameters, request body details, and all response information
+    # These are already captured in the inputSchema
+
+    return "\n".join(desc_parts)
+
+
 def format_description_with_responses(
     base_description: str,
     responses: dict[
@@ -351,5 +384,6 @@ __all__ = [
     "format_deep_object_parameter",
     "format_description_with_responses",
     "format_json_for_description",
+    "format_simple_description",
     "generate_example_from_schema",
 ]

--- a/src/fastmcp/experimental/utilities/openapi/models.py
+++ b/src/fastmcp/experimental/utilities/openapi/models.py
@@ -58,9 +58,6 @@ class HTTPRoute(FastMCPBaseModel):
     responses: dict[str, ResponseInfo] = Field(
         default_factory=dict
     )  # Key: status code str
-    schema_definitions: dict[str, JsonSchema] = Field(
-        default_factory=dict
-    )  # Store component schemas (deprecated - use input/output specific)
     request_schemas: dict[str, JsonSchema] = Field(
         default_factory=dict
     )  # Store schemas needed for input (parameters/request body)

--- a/src/fastmcp/experimental/utilities/openapi/models.py
+++ b/src/fastmcp/experimental/utilities/openapi/models.py
@@ -60,7 +60,13 @@ class HTTPRoute(FastMCPBaseModel):
     )  # Key: status code str
     schema_definitions: dict[str, JsonSchema] = Field(
         default_factory=dict
-    )  # Store component schemas
+    )  # Store component schemas (deprecated - use input/output specific)
+    request_schemas: dict[str, JsonSchema] = Field(
+        default_factory=dict
+    )  # Store schemas needed for input (parameters/request body)
+    response_schemas: dict[str, JsonSchema] = Field(
+        default_factory=dict
+    )  # Store schemas needed for output (responses)
     extensions: dict[str, Any] = Field(default_factory=dict)
     openapi_version: str | None = None
 

--- a/src/fastmcp/experimental/utilities/openapi/parser.py
+++ b/src/fastmcp/experimental/utilities/openapi/parser.py
@@ -402,77 +402,116 @@ class OpenAPIParser(
             )
             return None
 
+    def _is_success_status_code(self, status_code: str) -> bool:
+        """Check if a status code represents a successful response (2xx)."""
+        try:
+            code_int = int(status_code)
+            return 200 <= code_int < 300
+        except (ValueError, TypeError):
+            # Handle special cases like 'default' or other non-numeric codes
+            return status_code.lower() in ["default", "2xx"]
+
+    def _get_primary_success_response(
+        self, operation_responses: dict[str, Any]
+    ) -> tuple[str, Any] | None:
+        """Get the primary success response for an MCP tool. We only need one success response."""
+        if not operation_responses:
+            return None
+
+        # Priority order: 200, 201, 202, 204, 207, then any other 2xx
+        priority_codes = ["200", "201", "202", "204", "207"]
+
+        # First check priority codes
+        for code in priority_codes:
+            if code in operation_responses:
+                return (code, operation_responses[code])
+
+        # Then check any other 2xx codes
+        for status_code, resp_or_ref in operation_responses.items():
+            if self._is_success_status_code(status_code):
+                return (status_code, resp_or_ref)
+
+        # If no success codes found, return None (tool will have no output schema)
+        return None
+
     def _extract_responses(
         self, operation_responses: dict[str, Any] | None
     ) -> dict[str, ResponseInfo]:
-        """Extract and resolve response information."""
+        """Extract and resolve response information. Only includes the primary success response for MCP tools."""
         extracted_responses: dict[str, ResponseInfo] = {}
 
         if not operation_responses:
             return extracted_responses
 
-        for status_code, resp_or_ref in operation_responses.items():
-            try:
-                response = self._resolve_ref(resp_or_ref)
+        # For MCP tools, we only need the primary success response
+        primary_response = self._get_primary_success_response(operation_responses)
+        if not primary_response:
+            logger.debug("No success responses found, tool will have no output schema")
+            return extracted_responses
 
-                if not isinstance(response, self.response_cls):
-                    logger.warning(
-                        f"Expected Response after resolving for status code {status_code}, "
-                        f"got {type(response)}. Skipping."
-                    )
-                    continue
+        status_code, resp_or_ref = primary_response
+        logger.debug(f"Using primary success response: {status_code}")
 
-                # Create response info
-                resp_info = ResponseInfo(description=response.description)
+        try:
+            response = self._resolve_ref(resp_or_ref)
 
-                # Extract content schemas
-                if hasattr(response, "content") and response.content:
-                    for media_type_str, media_type_obj in response.content.items():
-                        if (
-                            media_type_obj
-                            and hasattr(media_type_obj, "media_type_schema")
-                            and media_type_obj.media_type_schema
-                        ):
-                            try:
-                                schema_dict = self._extract_schema_as_dict(
-                                    media_type_obj.media_type_schema
-                                )
-                                resp_info.content_schema[media_type_str] = schema_dict
-                            except ValueError as e:
-                                # Re-raise ValueError for external reference errors
-                                if (
-                                    "External or non-local reference not supported"
-                                    in str(e)
-                                ):
-                                    raise
-                                logger.error(
-                                    f"Failed to extract schema for media type '{media_type_str}' "
-                                    f"in response {status_code}: {e}"
-                                )
-                            except Exception as e:
-                                logger.error(
-                                    f"Failed to extract schema for media type '{media_type_str}' "
-                                    f"in response {status_code}: {e}"
-                                )
-
-                extracted_responses[str(status_code)] = resp_info
-            except ValueError as e:
-                # Re-raise ValueError for external reference errors
-                if "External or non-local reference not supported" in str(e):
-                    raise
-                ref_name = getattr(resp_or_ref, "ref", "unknown")
-                logger.error(
-                    f"Failed to extract response for status code {status_code} "
-                    f"from reference '{ref_name}': {e}",
-                    exc_info=False,
+            if not isinstance(response, self.response_cls):
+                logger.warning(
+                    f"Expected Response after resolving for status code {status_code}, "
+                    f"got {type(response)}. Returning empty responses."
                 )
-            except Exception as e:
-                ref_name = getattr(resp_or_ref, "ref", "unknown")
-                logger.error(
-                    f"Failed to extract response for status code {status_code} "
-                    f"from reference '{ref_name}': {e}",
-                    exc_info=False,
-                )
+                return extracted_responses
+
+            # Create response info
+            resp_info = ResponseInfo(description=response.description)
+
+            # Extract content schemas
+            if hasattr(response, "content") and response.content:
+                for media_type_str, media_type_obj in response.content.items():
+                    if (
+                        media_type_obj
+                        and hasattr(media_type_obj, "media_type_schema")
+                        and media_type_obj.media_type_schema
+                    ):
+                        try:
+                            schema_dict = self._extract_schema_as_dict(
+                                media_type_obj.media_type_schema
+                            )
+                            resp_info.content_schema[media_type_str] = schema_dict
+                        except ValueError as e:
+                            # Re-raise ValueError for external reference errors
+                            if "External or non-local reference not supported" in str(
+                                e
+                            ):
+                                raise
+                            logger.error(
+                                f"Failed to extract schema for media type '{media_type_str}' "
+                                f"in response {status_code}: {e}"
+                            )
+                        except Exception as e:
+                            logger.error(
+                                f"Failed to extract schema for media type '{media_type_str}' "
+                                f"in response {status_code}: {e}"
+                            )
+
+            extracted_responses[str(status_code)] = resp_info
+        except ValueError as e:
+            # Re-raise ValueError for external reference errors
+            if "External or non-local reference not supported" in str(e):
+                raise
+            ref_name = getattr(resp_or_ref, "ref", "unknown")
+            logger.error(
+                f"Failed to extract response for status code {status_code} "
+                f"from reference '{ref_name}': {e}",
+                exc_info=False,
+            )
+        except Exception as e:
+            ref_name = getattr(resp_or_ref, "ref", "unknown")
+            logger.error(
+                f"Failed to extract response for status code {status_code} "
+                f"from reference '{ref_name}': {e}",
+                exc_info=False,
+            )
 
         return extracted_responses
 
@@ -525,24 +564,22 @@ class OpenAPIParser(
         find_refs(schema)
         return collected
 
-    def _extract_route_schema_dependencies(
+    def _extract_input_schema_dependencies(
         self,
         parameters: list[ParameterInfo],
         request_body: RequestBodyInfo | None,
-        responses: dict[str, ResponseInfo],
         all_schemas: dict[str, Any],
     ) -> dict[str, Any]:
         """
-        Extract only the schema definitions needed for a specific route.
+        Extract only the schema definitions needed for input (parameters and request body).
 
         Args:
             parameters: Route parameters
             request_body: Route request body
-            responses: Route responses
             all_schemas: All available schema definitions
 
         Returns:
-            Dictionary containing only the schemas needed for this route
+            Dictionary containing only the schemas needed for input
         """
         needed_schemas = set()
 
@@ -558,6 +595,28 @@ class OpenAPIParser(
                 deps = self._extract_schema_dependencies(content_schema, all_schemas)
                 needed_schemas.update(deps)
 
+        # Return only the needed input schemas
+        return {
+            name: all_schemas[name] for name in needed_schemas if name in all_schemas
+        }
+
+    def _extract_output_schema_dependencies(
+        self,
+        responses: dict[str, ResponseInfo],
+        all_schemas: dict[str, Any],
+    ) -> dict[str, Any]:
+        """
+        Extract only the schema definitions needed for outputs (responses).
+
+        Args:
+            responses: Route responses
+            all_schemas: All available schema definitions
+
+        Returns:
+            Dictionary containing only the schemas needed for outputs
+        """
+        needed_schemas = set()
+
         # Check responses for schema references
         for response in responses.values():
             if response.content_schema:
@@ -567,7 +626,7 @@ class OpenAPIParser(
                     )
                     needed_schemas.update(deps)
 
-        # Return only the needed schemas
+        # Return only the needed output schemas
         return {
             name: all_schemas[name] for name in needed_schemas if name in all_schemas
         }
@@ -661,10 +720,13 @@ class OpenAPIParser(
                                 if k.startswith("x-")
                             }
 
-                        # Extract only the schemas needed for this route
-                        route_schemas = self._extract_route_schema_dependencies(
+                        # Extract schemas separately for input and output
+                        input_schemas = self._extract_input_schema_dependencies(
                             parameters,
                             request_body_info,
+                            schema_definitions,
+                        )
+                        output_schemas = self._extract_output_schema_dependencies(
                             responses,
                             schema_definitions,
                         )
@@ -680,7 +742,9 @@ class OpenAPIParser(
                             parameters=parameters,
                             request_body=request_body_info,
                             responses=responses,
-                            schema_definitions=route_schemas,  # Use pre-pruned schemas
+                            schema_definitions={},  # Keep for backwards compatibility
+                            request_schemas=input_schemas,
+                            response_schemas=output_schemas,
                             extensions=extensions,
                             openapi_version=self.openapi_version,
                         )

--- a/src/fastmcp/experimental/utilities/openapi/parser.py
+++ b/src/fastmcp/experimental/utilities/openapi/parser.py
@@ -742,7 +742,6 @@ class OpenAPIParser(
                             parameters=parameters,
                             request_body=request_body_info,
                             responses=responses,
-                            schema_definitions={},  # Keep for backwards compatibility
                             request_schemas=input_schemas,
                             response_schemas=output_schemas,
                             extensions=extensions,

--- a/src/fastmcp/experimental/utilities/openapi/schemas.py
+++ b/src/fastmcp/experimental/utilities/openapi/schemas.py
@@ -363,11 +363,12 @@ def _combine_schemas_and_map_params(
         "properties": properties,
         "required": required,
     }
-    # Add schema definitions if available
-    if route.schema_definitions:
+    # Add schema definitions if available (prefer request-specific, fall back to general)
+    schema_defs = route.request_schemas or route.schema_definitions
+    if schema_defs:
         if convert_refs:
             # Need to convert refs and prune
-            all_defs = route.schema_definitions.copy()
+            all_defs = schema_defs.copy()
             # Convert each schema definition recursively
             for name, schema in all_defs.items():
                 if isinstance(schema, dict):
@@ -409,7 +410,7 @@ def _combine_schemas_and_map_params(
                 }
         else:
             # From parser - already converted and pruned
-            result["$defs"] = route.schema_definitions
+            result["$defs"] = schema_defs
 
     return result, parameter_map
 

--- a/src/fastmcp/experimental/utilities/openapi/schemas.py
+++ b/src/fastmcp/experimental/utilities/openapi/schemas.py
@@ -363,8 +363,8 @@ def _combine_schemas_and_map_params(
         "properties": properties,
         "required": required,
     }
-    # Add schema definitions if available (prefer request-specific, fall back to general)
-    schema_defs = route.request_schemas or route.schema_definitions
+    # Add schema definitions if available
+    schema_defs = route.request_schemas
     if schema_defs:
         if convert_refs:
             # Need to convert refs and prune

--- a/tests/experimental/openapi_parser/server/openapi/test_end_to_end_compatibility.py
+++ b/tests/experimental/openapi_parser/server/openapi/test_end_to_end_compatibility.py
@@ -116,8 +116,10 @@ class TestEndToEndCompatibility:
             assert legacy_tool.name == new_tool.name
             assert legacy_tool.name == "get_user"
 
-            # Descriptions should be identical
-            assert legacy_tool.description == new_tool.description
+            # Descriptions may differ (new server has simplified descriptions)
+            # Just check that both have descriptions
+            assert legacy_tool.description
+            assert new_tool.description
 
             # Input schemas should be identical
             legacy_schema = legacy_tool.inputSchema

--- a/tests/experimental/openapi_parser/utilities/openapi/test_models.py
+++ b/tests/experimental/openapi_parser/utilities/openapi/test_models.py
@@ -248,7 +248,7 @@ class TestHTTPRoute:
             parameters=parameters,
             request_body=request_body,
             responses=responses,
-            schema_definitions={"User": {"type": "object"}},
+            request_schemas={"User": {"type": "object"}},
             extensions={"x-custom": "value"},
         )
 
@@ -261,7 +261,7 @@ class TestHTTPRoute:
         assert len(route.parameters) == 1
         assert route.request_body is not None
         assert "200" in route.responses
-        assert "User" in route.schema_definitions
+        assert "User" in route.request_schemas
         assert route.extensions["x-custom"] == "value"
 
     def test_route_pre_calculated_fields(self):
@@ -303,14 +303,15 @@ class TestHTTPRoute:
             tags=[],
             parameters=[],
             responses={},
-            schema_definitions={},
+            request_schemas={},
             extensions={},
         )
 
         assert route.tags == []
         assert route.parameters == []
         assert route.responses == {}
-        assert route.schema_definitions == {}
+        assert route.request_schemas == {}
+        assert route.response_schemas == {}
         assert route.extensions == {}
 
     def test_route_defaults(self):
@@ -327,7 +328,8 @@ class TestHTTPRoute:
         assert route.parameters == []
         assert route.request_body is None
         assert route.responses == {}
-        assert route.schema_definitions == {}
+        assert route.request_schemas == {}
+        assert route.response_schemas == {}
         assert route.extensions == {}
         assert route.flat_param_schema == {}
         assert route.parameter_map == {}

--- a/tests/experimental/openapi_parser/utilities/openapi/test_parser.py
+++ b/tests/experimental/openapi_parser/utilities/openapi/test_parser.py
@@ -253,12 +253,12 @@ class TestOpenAPIParser:
         routes = parse_openapi_to_http_routes(spec)
         route = routes[0]
 
-        # SchemaA is expanded inline, so it's NOT in schema_definitions
-        assert "SchemaA" not in route.schema_definitions
+        # SchemaA is expanded inline, so it's NOT in request_schemas
+        assert "SchemaA" not in route.request_schemas
 
         # But SchemaB and SchemaC MUST be there (transitive dependencies)
-        assert "SchemaB" in route.schema_definitions
-        assert "SchemaC" in route.schema_definitions
+        assert "SchemaB" in route.request_schemas
+        assert "SchemaC" in route.request_schemas
 
         # Same in the flat parameter schema
         assert "SchemaB" in route.flat_param_schema["$defs"]
@@ -316,11 +316,11 @@ class TestOpenAPIParser:
         route = routes[0]
 
         # Profile is expanded inline, NOT in schema_defs
-        assert "Profile" not in route.schema_definitions
+        assert "Profile" not in route.request_schemas
 
         # Bug fix: countryCode and AccountInfo MUST be in schema_defs
-        assert "countryCode" in route.schema_definitions  # Was missing in #1372
-        assert "AccountInfo" in route.schema_definitions  # Was missing in #1372
+        assert "countryCode" in route.request_schemas  # Was missing in #1372
+        assert "AccountInfo" in route.request_schemas  # Was missing in #1372
 
         # Same in flat parameter schema
         assert "countryCode" in route.flat_param_schema["$defs"]

--- a/tests/experimental/openapi_parser/utilities/openapi/test_transitive_references.py
+++ b/tests/experimental/openapi_parser/utilities/openapi/test_transitive_references.py
@@ -36,7 +36,7 @@ class TestTransitiveAndNestedReferences:
                     }
                 },
             ),
-            schema_definitions={
+            request_schemas={
                 "User": {
                     "type": "object",
                     "properties": {"profile": {"$ref": "#/components/schemas/Profile"}},
@@ -184,7 +184,7 @@ class TestTransitiveAndNestedReferences:
                     "application/json": {"$ref": "#/components/schemas/Profile"}
                 },
             ),
-            schema_definitions={
+            request_schemas={
                 "Profile": {
                     "type": "object",
                     "properties": {
@@ -235,7 +235,7 @@ class TestTransitiveAndNestedReferences:
                     "application/json": {"$ref": "#/components/schemas/User"}
                 },
             ),
-            schema_definitions={
+            request_schemas={
                 "User": {
                     "type": "object",
                     "properties": {
@@ -298,7 +298,7 @@ class TestTransitiveAndNestedReferences:
                     }
                 },
             ),
-            schema_definitions={
+            request_schemas={
                 "User": {
                     "type": "object",
                     "properties": {"profile": {"$ref": "#/components/schemas/Profile"}},
@@ -353,7 +353,7 @@ class TestTransitiveAndNestedReferences:
                     }
                 },
             ),
-            schema_definitions={
+            request_schemas={
                 "TypeA": {
                     "type": "object",
                     "properties": {"nested": {"$ref": "#/components/schemas/Nested"}},
@@ -404,7 +404,7 @@ class TestTransitiveAndNestedReferences:
                     "application/json": {"$ref": "#/components/schemas/Level1"}
                 },
             ),
-            schema_definitions={
+            request_schemas={
                 "Level1": {
                     "type": "object",
                     "properties": {"level2": {"$ref": "#/components/schemas/Level2"}},
@@ -471,7 +471,7 @@ class TestTransitiveAndNestedReferences:
                     "application/json": {"$ref": "#/components/schemas/Node"}
                 },
             ),
-            schema_definitions={
+            request_schemas={
                 "Node": {
                     "type": "object",
                     "properties": {
@@ -512,7 +512,7 @@ class TestTransitiveAndNestedReferences:
                     }
                 },
             ),
-            schema_definitions={
+            request_schemas={
                 "Left": {
                     "type": "object",
                     "properties": {"shared": {"$ref": "#/components/schemas/Shared"}},
@@ -559,7 +559,7 @@ class TestTransitiveAndNestedReferences:
                     "application/json": {"$ref": "#/components/schemas/Content"}
                 },
             ),
-            schema_definitions={
+            request_schemas={
                 "Content": {
                     "type": "object",
                     "properties": {
@@ -613,7 +613,7 @@ class TestTransitiveAndNestedReferences:
                     }
                 },
             ),
-            schema_definitions={
+            request_schemas={
                 "SimpleString": {"type": "string"},
                 "EmptyObject": {"type": "object"},
                 "UnreferencedSchema": {"type": "number"},
@@ -646,7 +646,7 @@ class TestTransitiveAndNestedReferences:
                     "application/json": {"$ref": "#/components/schemas/DirectBody"}
                 },
             ),
-            schema_definitions={
+            request_schemas={
                 "DirectBody": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
Closes #1449 and addresses #1372 by significantly reducing MCP payload sizes for large OpenAPI specifications.

## Problem
Large OpenAPI specs like the Amazon Advertising API (567 schemas) were generating massive MCP payloads that exceeded Claude Desktop's context window. The main issues were:
1. Schema duplication between input and output definitions
2. Verbose descriptions including all response details, examples, and status codes
3. All schemas being included for both requests and responses even when not needed

## Solution
This PR implements three key optimizations:

**1. Separated Input/Output Schema Dependencies**
- Replaced single `schema_definitions` field with separate `request_schemas` and `response_schemas`
- Each contains only the schemas actually needed for that direction
- Eliminates duplication where the same 78 schemas were included twice

**2. Simplified Descriptions**
- Created `format_simple_description()` to replace verbose formatting
- Removes response details, examples, and status codes from descriptions
- Applied consistently to tools, resources, and resource templates

**3. Primary Success Responses Only**
- Modified parser to use only primary success responses (200, 201, 207, etc.)
- Eliminates error response schemas from tool definitions

## Results
Amazon Advertising API payload reduced from **2,075 KB to 1,115 KB** (46% reduction):
- Input/output separation: 2,075KB → 1,120KB (945KB saved)
- Simplified descriptions: 1,120KB → 1,115KB (5KB saved)

Individual tool example (CreateCampaign):
- Before: 96KB with 78 schemas duplicated in both input and output
- After: 58KB with 45 input schemas, 55 output schemas, no overlap

## Important Note for Users
While this PR provides significant automatic optimization, **extremely large OpenAPI specs like Amazon Ads API will still require manual curation** through [tool transformation](https://gofastmcp.com/patterns/tool-transformation). The schemas for these APIs have massive legitimate transitive dependencies that cannot be automatically pruned further without losing functionality.

For example, the CreateCampaign endpoint alone is 58KB even after optimization, with complex nested schema dependencies. For such cases, consider:
- Disabling output schemas entirely (cuts payload by ~50% but loses validation)
- Simplifying input schemas or removing unused arguments
- Only including necessary endpoints for your use case
- Dynamically enabling/disabling tools as needed

The remaining payload size represents legitimate schema definitions required for tool functionality. No amount of automatic pruning will make APIs with hundreds of complex schemas usable without curation - which is best practice anyway.