### PR TITLE
docs: Fix type annotation in return value documentation

### DIFF
--- a/docs/servers/prompts.mdx
+++ b/docs/servers/prompts.mdx
@@ -188,10 +188,10 @@ FastMCP intelligently handles different return types from your prompt function:
 -   **`Any`**: If the return type is not one of the above, the return value is attempted to be converted to a string and used as a `PromptMessage`.
 
 ```python
-from fastmcp.prompts.prompt import Message
+from fastmcp.prompts.prompt import PromptMessage
 
 @mcp.prompt
-def roleplay_scenario(character: str, situation: str) -> list[Message]:
+def roleplay_scenario(character: str, situation: str) -> list[PromptMessage]:
     """Sets up a roleplaying scenario with initial messages."""
     return [
         Message(f"Let's roleplay. You are {character}. The situation is: {situation}"),


### PR DESCRIPTION
This PR fixes a small documentation issue I came across whilst reading the docs. When using this code directly from the example, one would get  the following type checker error:

```
error: Expected class but received "(content: ContentBlock | str, role: Role | None = None, **kwargs: Any) -> PromptMessage" (reportGeneralTypeIssues)
```

The return type annotation should be `PromptMessage` here I believe. Thanks for the work on the package! 