### PR TITLE
feat: Add fastmcp.json configuration support (#1480) - WIP

### DIFF
--- a/examples/fastmcp-http.json
+++ b/examples/fastmcp-http.json
@@ -1,0 +1,20 @@
+{
+  "name": "http-server",
+  "version": "1.0.0",
+  "entrypoint": "echo.py:mcp",
+  "description": "HTTP echo server with dependencies",
+  "transport": "http",
+  "host": "0.0.0.0",
+  "port": 8080,
+  "path": "/mcp",
+  "dependencies": [
+    "httpx>=0.24.0",
+    "pydantic>=2.0.0"
+  ],
+  "python_version": ">=3.10",
+  "log_level": "DEBUG",
+  "env": {
+    "SERVER_MODE": "production",
+    "MAX_CONNECTIONS": "100"
+  }
+}

--- a/examples/fastmcp-multi.json
+++ b/examples/fastmcp-multi.json
@@ -1,0 +1,27 @@
+{
+  "servers": {
+    "main": {
+      "name": "main-server",
+      "entrypoint": "echo.py:mcp",
+      "transport": "http",
+      "port": 8000,
+      "description": "Main application server"
+    },
+    "worker": {
+      "name": "worker-server",
+      "entrypoint": "memory.py:mcp",
+      "transport": "stdio",
+      "description": "Background worker server"
+    },
+    "api": {
+      "name": "api-server",
+      "entrypoint": "simple_echo.py",
+      "transport": "streamable-http",
+      "port": 8001,
+      "path": "/api",
+      "dependencies": ["fastapi", "uvicorn"],
+      "description": "API server"
+    }
+  },
+  "default": "main"
+}

--- a/examples/fastmcp.json
+++ b/examples/fastmcp.json
@@ -1,0 +1,8 @@
+{
+  "name": "example-server",
+  "version": "1.0.0",
+  "entrypoint": "echo.py:mcp",
+  "description": "Simple echo server example",
+  "transport": "stdio",
+  "log_level": "INFO"
+}

--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -284,8 +284,20 @@ async def dev(
 
 @app.command
 async def run(
-    server_spec: str,
+    server_spec: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            help="Server to run (file, file:obj, URL, or JSON config). Defaults to fastmcp.json if present."
+        ),
+    ] = None,
     *server_args: str,
+    config: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--config", "-c"],
+            help="Path to fastmcp.json configuration file",
+        ),
+    ] = None,
     transport: Annotated[
         run_module.TransportType | None,
         cyclopts.Parameter(
@@ -361,22 +373,29 @@ async def run(
 ) -> None:
     """Run an MCP server or connect to a remote one.
 
-    The server can be specified in four ways:
+    The server can be specified in five ways:
     1. Module approach: "server.py" - runs the module directly, looking for an object named 'mcp', 'server', or 'app'
     2. Import approach: "server.py:app" - imports and runs the specified server object
     3. URL approach: "http://server-url" - connects to a remote server and creates a proxy
     4. MCPConfig file: "mcp.json" - runs as a proxy server for the MCP Servers in the MCPConfig file
+    5. FastMCP config: "fastmcp.json" or no arguments - uses fastmcp.json configuration
 
     Server arguments can be passed after -- :
     fastmcp run server.py -- --config config.json --debug
 
     Args:
-        server_spec: Python file, object specification (file:obj), MCPConfig file, or URL
+        server_spec: Python file, object specification (file:obj), MCPConfig file, URL, or None for fastmcp.json
+        config: Path to fastmcp.json configuration file (overrides default fastmcp.json)
     """
+    # Handle config flag
+    if config:
+        server_spec = config
+
     logger.debug(
         "Running server or client",
         extra={
             "server_spec": server_spec,
+            "config": config,
             "transport": transport,
             "host": host,
             "port": port,

--- a/src/fastmcp/server/config.py
+++ b/src/fastmcp/server/config.py
@@ -1,0 +1,279 @@
+"""FastMCP server configuration management.
+
+This module provides configuration schema and utilities for fastmcp.json files,
+enabling structured server configuration with dependencies, transport settings,
+and runtime parameters.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class FastMCPServerConfig(BaseModel):
+    """Configuration for a single FastMCP server instance.
+    
+    This configuration can be loaded from a fastmcp.json file to specify
+    server settings, dependencies, and runtime parameters.
+    """
+    
+    # Server identification
+    name: str | None = None
+    version: str = "1.0.0"
+    
+    # Entry point specification
+    # Examples: "server.py", "server.py:mcp", "myapp.server:create_server()"
+    entrypoint: str
+    
+    # Dependencies
+    dependencies: list[str] = Field(
+        default_factory=list,
+        description="Python packages required by this server"
+    )
+    python_version: str | None = Field(
+        default=None,
+        description="Python version constraint (e.g., '3.10', '>=3.10,<3.12')"
+    )
+    requirements_file: str | None = Field(
+        default=None,
+        description="Path to requirements.txt file"
+    )
+    
+    # Transport configuration
+    transport: Literal["stdio", "http", "sse", "streamable-http"] = Field(
+        default="stdio",
+        description="Transport protocol to use"
+    )
+    host: str = Field(
+        default="127.0.0.1",
+        description="Host to bind to (for HTTP transports)"
+    )
+    port: int = Field(
+        default=8000,
+        description="Port to bind to (for HTTP transports)"
+    )
+    path: str = Field(
+        default="/mcp",
+        description="Path to bind to (for HTTP transports)"
+    )
+    
+    # Runtime configuration
+    env: dict[str, str] = Field(
+        default_factory=dict,
+        description="Environment variables to set"
+    )
+    cwd: str | None = Field(
+        default=None,
+        description="Working directory for server execution"
+    )
+    timeout: int | None = Field(
+        default=None,
+        description="Maximum response time in milliseconds"
+    )
+    
+    # Logging
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(
+        default="INFO",
+        description="Logging level"
+    )
+    
+    # Server behavior
+    show_banner: bool = Field(
+        default=True,
+        description="Whether to show the server banner on startup"
+    )
+    
+    # Authentication (optional)
+    auth_provider: str | None = Field(
+        default=None,
+        description="Authentication provider (e.g., 'bearer', 'jwt', 'workos')"
+    )
+    auth_config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Authentication provider configuration"
+    )
+    
+    # Metadata
+    description: str | None = Field(
+        default=None,
+        description="Human-readable server description"
+    )
+    icon: str | None = Field(
+        default=None,
+        description="Icon path or URL for UI display"
+    )
+    
+    model_config = ConfigDict(extra="allow")
+    
+    @field_validator("requirements_file")
+    @classmethod
+    def validate_requirements_file(cls, v: str | None) -> str | None:
+        """Validate that requirements file exists if specified."""
+        if v is not None:
+            path = Path(v)
+            if not path.exists():
+                raise ValueError(f"Requirements file not found: {v}")
+        return v
+    
+    def to_cli_args(self) -> list[str]:
+        """Convert config to CLI arguments for the run command."""
+        args = []
+        
+        # Add transport options
+        if self.transport != "stdio":
+            args.extend(["--transport", self.transport])
+        if self.transport in ["http", "sse", "streamable-http"]:
+            args.extend(["--host", self.host])
+            args.extend(["--port", str(self.port)])
+            args.extend(["--path", self.path])
+        
+        # Add log level
+        if self.log_level != "INFO":
+            args.extend(["--log-level", self.log_level])
+        
+        # Add banner flag
+        if not self.show_banner:
+            args.append("--no-banner")
+        
+        return args
+    
+    def get_dependencies_args(self) -> dict[str, Any]:
+        """Get dependency-related arguments for uv run."""
+        args = {}
+        
+        if self.dependencies:
+            args["with_packages"] = self.dependencies
+        
+        if self.requirements_file:
+            args["with_requirements"] = Path(self.requirements_file)
+        
+        if self.python_version:
+            args["python_version"] = self.python_version
+        
+        return args
+
+
+class FastMCPConfig(BaseModel):
+    """Root configuration that can contain multiple servers."""
+    
+    # Single server mode (when no 'servers' key is present)
+    # All FastMCPServerConfig fields are inherited here
+    
+    # Multi-server mode
+    servers: dict[str, FastMCPServerConfig] | None = None
+    
+    # Default server to use when none specified
+    default: str | None = None
+    
+    model_config = ConfigDict(extra="allow")
+    
+    @classmethod
+    def from_file(cls, file_path: Path) -> FastMCPConfig | None:
+        """Load configuration from a JSON file.
+        
+        Args:
+            file_path: Path to the fastmcp.json file
+            
+        Returns:
+            FastMCPConfig instance or None if file doesn't exist
+        """
+        if not file_path.exists():
+            return None
+        
+        with file_path.open() as f:
+            data = json.load(f)
+        
+        # Check if it's a multi-server config
+        if "servers" in data:
+            return cls(**data)
+        else:
+            # Single server config - wrap it
+            return cls(servers={"default": FastMCPServerConfig(**data)}, default="default")
+    
+    def get_server_config(self, name: str | None = None) -> FastMCPServerConfig | None:
+        """Get a specific server configuration.
+        
+        Args:
+            name: Name of the server to get. If None, uses the default.
+            
+        Returns:
+            Server configuration or None if not found
+        """
+        if self.servers is None:
+            return None
+        
+        if name is None:
+            name = self.default
+        
+        if name is None and len(self.servers) == 1:
+            # If there's only one server and no default specified, use it
+            name = next(iter(self.servers.keys()))
+        
+        if name is None:
+            return None
+        
+        return self.servers.get(name)
+    
+    def write_to_file(self, file_path: Path) -> None:
+        """Write configuration to a JSON file.
+        
+        Args:
+            file_path: Path where to write the configuration
+        """
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        # If single server mode, unwrap it for cleaner JSON
+        if self.servers and len(self.servers) == 1 and self.default:
+            data = self.servers[self.default].model_dump(exclude_none=True)
+        else:
+            data = self.model_dump(exclude_none=True)
+        
+        with file_path.open("w") as f:
+            json.dump(data, f, indent=2)
+
+
+def load_fastmcp_config(path: Path | str | None = None) -> FastMCPServerConfig | None:
+    """Load FastMCP configuration from a file.
+    
+    Args:
+        path: Path to config file. If None, looks for fastmcp.json in current directory.
+        
+    Returns:
+        Server configuration or None if not found
+    """
+    if path is None:
+        path = Path("fastmcp.json")
+    elif isinstance(path, str):
+        path = Path(path)
+    
+    config = FastMCPConfig.from_file(path)
+    if config is None:
+        return None
+    
+    return config.get_server_config()
+
+
+def create_default_config(
+    entrypoint: str = "server.py:mcp",
+    name: str = "my-server",
+    transport: str = "stdio"
+) -> FastMCPServerConfig:
+    """Create a default configuration.
+    
+    Args:
+        entrypoint: Server entrypoint
+        name: Server name
+        transport: Transport type
+        
+    Returns:
+        Default server configuration
+    """
+    return FastMCPServerConfig(
+        name=name,
+        entrypoint=entrypoint,
+        transport=transport  # type: ignore
+    )

--- a/tests/cli/test_run_config.py
+++ b/tests/cli/test_run_config.py
@@ -1,0 +1,235 @@
+"""Tests for CLI run module with fastmcp.json support."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fastmcp.cli.run import parse_entrypoint, parse_file_path
+
+
+class TestEntrypointParsing:
+    """Test entrypoint parsing functionality."""
+
+    def test_parse_simple_file(self):
+        """Test parsing simple file path."""
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
+            temp_path = Path(f.name)
+        
+        try:
+            file_path, obj_name, args = parse_entrypoint(str(temp_path))
+            assert file_path == temp_path
+            assert obj_name is None
+            assert args == []
+        finally:
+            temp_path.unlink()
+
+    def test_parse_file_with_object(self):
+        """Test parsing file:object syntax."""
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
+            temp_path = Path(f.name)
+        
+        try:
+            spec = f"{temp_path}:mcp"
+            file_path, obj_name, args = parse_entrypoint(spec)
+            assert file_path == temp_path
+            assert obj_name == "mcp"
+            assert args == []
+        finally:
+            temp_path.unlink()
+
+    def test_parse_file_with_function_call(self):
+        """Test parsing file:function() syntax."""
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
+            temp_path = Path(f.name)
+        
+        try:
+            spec = f"{temp_path}:create_server()"
+            file_path, obj_name, args = parse_entrypoint(spec)
+            assert file_path == temp_path
+            assert obj_name == "create_server"
+            assert args == []
+        finally:
+            temp_path.unlink()
+
+    def test_parse_module_path(self):
+        """Test parsing module.path:object syntax."""
+        # This test doesn't create actual module files
+        spec = "myapp.server:create_app"
+        file_path, obj_name, args = parse_entrypoint(spec)
+        
+        # Should convert to path form
+        assert file_path == Path("myapp/server.py")
+        assert obj_name == "create_app"
+        assert args == []
+
+    def test_parse_module_with_function_args(self):
+        """Test parsing module:function(args) syntax."""
+        spec = "myapp.factory:create_server(debug=True, port=8080)"
+        file_path, obj_name, args = parse_entrypoint(spec)
+        
+        assert file_path == Path("myapp/factory.py")
+        assert obj_name == "create_server"
+        assert args == ["debug=True", "port=8080"]
+
+    @pytest.mark.skipif(
+        not Path("C:\\").exists(),
+        reason="Windows path test only runs on Windows"
+    )
+    def test_parse_file_path_windows(self):
+        """Test parsing Windows-style paths."""
+        # Mock Windows path
+        spec = "C:\\Users\\test\\server.py:mcp"
+        
+        with patch("pathlib.Path.exists", return_value=True):
+            with patch("pathlib.Path.is_file", return_value=True):
+                file_path, obj_name = parse_file_path(spec)
+                
+                # Should handle Windows drive letter correctly
+                assert str(file_path).startswith("C:")
+                assert obj_name == "mcp"
+
+
+class TestConfigIntegration:
+    """Test integration with fastmcp.json configuration."""
+
+    @pytest.mark.asyncio
+    async def test_run_with_fastmcp_json(self):
+        """Test running with fastmcp.json configuration."""
+        from fastmcp.cli.run import run_command
+        
+        # Create a temporary fastmcp.json
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "fastmcp.json"
+            server_path = Path(tmpdir) / "server.py"
+            
+            # Create a simple server file
+            server_path.write_text("""
+from fastmcp import FastMCP
+
+mcp = FastMCP("test-server")
+
+@mcp.tool
+def test_tool():
+    return "test"
+""")
+            
+            # Create config
+            config_data = {
+                "name": "test-server",
+                "entrypoint": "server.py:mcp",
+                "transport": "stdio",
+                "log_level": "DEBUG",
+            }
+            with config_path.open("w") as f:
+                json.dump(config_data, f)
+            
+            # Mock the server run to avoid actually starting it
+            with patch("fastmcp.server.server.FastMCP.run_async") as mock_run:
+                mock_run.return_value = None
+                
+                # Change to temp directory
+                import os
+                old_cwd = os.getcwd()
+                try:
+                    os.chdir(tmpdir)
+                    
+                    # Run with no arguments should use fastmcp.json
+                    await run_command()
+                    
+                    # Should have called run_async
+                    mock_run.assert_called_once()
+                    
+                    # Check that log_level was applied
+                    call_kwargs = mock_run.call_args.kwargs
+                    assert call_kwargs.get("log_level") == "DEBUG"
+                    
+                finally:
+                    os.chdir(old_cwd)
+
+    @pytest.mark.asyncio 
+    async def test_run_with_explicit_config_path(self):
+        """Test running with explicit config path."""
+        from fastmcp.cli.run import run_command
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "custom.json"
+            server_path = Path(tmpdir) / "app.py"
+            
+            # Create server file
+            server_path.write_text("""
+from fastmcp import FastMCP
+
+server = FastMCP("custom-server")
+""")
+            
+            # Create config
+            config_data = {
+                "name": "custom-server",
+                "entrypoint": str(server_path) + ":server",
+                "transport": "http",
+                "port": 9000,
+            }
+            with config_path.open("w") as f:
+                json.dump(config_data, f)
+            
+            with patch("fastmcp.server.server.FastMCP.run_async") as mock_run:
+                mock_run.return_value = None
+                
+                # Run with explicit config path
+                await run_command(server_spec=str(config_path))
+                
+                mock_run.assert_called_once()
+                call_kwargs = mock_run.call_args.kwargs
+                assert call_kwargs.get("transport") == "http"
+                assert call_kwargs.get("port") == 9000
+
+    def test_run_with_uv_and_dependencies(self):
+        """Test run_with_uv with dependencies from config."""
+        from fastmcp.cli.run import run_with_uv
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "fastmcp.json"
+            
+            config_data = {
+                "entrypoint": "server.py",
+                "dependencies": ["httpx", "pydantic"],
+                "python_version": "3.11",
+                "transport": "http",
+            }
+            with config_path.open("w") as f:
+                json.dump(config_data, f)
+            
+            # Mock subprocess.run
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                
+                import os
+                old_cwd = os.getcwd()
+                try:
+                    os.chdir(tmpdir)
+                    
+                    # This should trigger SystemExit
+                    with pytest.raises(SystemExit) as exc_info:
+                        run_with_uv()
+                    
+                    assert exc_info.value.code == 0
+                    
+                    # Check the command that was run
+                    mock_run.assert_called_once()
+                    cmd = mock_run.call_args[0][0]
+                    
+                    # Should include dependencies
+                    assert "--with" in cmd
+                    httpx_idx = cmd.index("httpx")
+                    assert cmd[httpx_idx - 1] == "--with"
+                    
+                    # Should include Python version
+                    assert "--python" in cmd
+                    py_idx = cmd.index("--python")
+                    assert cmd[py_idx + 1] == "3.11"
+                    
+                finally:
+                    os.chdir(old_cwd)

--- a/tests/server/test_config.py
+++ b/tests/server/test_config.py
@@ -1,0 +1,272 @@
+"""Tests for FastMCP server configuration (fastmcp.json)."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from fastmcp.server.config import (
+    FastMCPConfig,
+    FastMCPServerConfig,
+    create_default_config,
+    load_fastmcp_config,
+)
+
+
+class TestFastMCPServerConfig:
+    """Test FastMCPServerConfig model."""
+
+    def test_minimal_config(self):
+        """Test minimal configuration."""
+        config = FastMCPServerConfig(entrypoint="server.py")
+        assert config.entrypoint == "server.py"
+        assert config.transport == "stdio"
+        assert config.host == "127.0.0.1"
+        assert config.port == 8000
+        assert config.log_level == "INFO"
+
+    def test_full_config(self):
+        """Test full configuration."""
+        config = FastMCPServerConfig(
+            name="test-server",
+            version="2.0.0",
+            entrypoint="myapp.server:create_app",
+            dependencies=["httpx", "pydantic"],
+            python_version=">=3.10",
+            requirements_file=None,
+            transport="http",
+            host="0.0.0.0",
+            port=8080,
+            path="/api",
+            env={"KEY": "value"},
+            cwd="/app",
+            timeout=5000,
+            log_level="DEBUG",
+            show_banner=False,
+            auth_provider="bearer",
+            auth_config={"token": "secret"},
+            description="Test server",
+            icon="icon.png",
+        )
+        
+        assert config.name == "test-server"
+        assert config.version == "2.0.0"
+        assert config.entrypoint == "myapp.server:create_app"
+        assert config.dependencies == ["httpx", "pydantic"]
+        assert config.python_version == ">=3.10"
+        assert config.transport == "http"
+        assert config.host == "0.0.0.0"
+        assert config.port == 8080
+        assert config.path == "/api"
+        assert config.env == {"KEY": "value"}
+        assert config.cwd == "/app"
+        assert config.timeout == 5000
+        assert config.log_level == "DEBUG"
+        assert config.show_banner is False
+        assert config.auth_provider == "bearer"
+        assert config.auth_config == {"token": "secret"}
+        assert config.description == "Test server"
+        assert config.icon == "icon.png"
+
+    def test_to_cli_args(self):
+        """Test conversion to CLI arguments."""
+        config = FastMCPServerConfig(
+            entrypoint="server.py",
+            transport="http",
+            host="0.0.0.0",
+            port=9000,
+            path="/test",
+            log_level="DEBUG",
+            show_banner=False,
+        )
+        
+        args = config.to_cli_args()
+        assert "--transport" in args
+        assert "http" in args
+        assert "--host" in args
+        assert "0.0.0.0" in args
+        assert "--port" in args
+        assert "9000" in args
+        assert "--path" in args
+        assert "/test" in args
+        assert "--log-level" in args
+        assert "DEBUG" in args
+        assert "--no-banner" in args
+
+    def test_get_dependencies_args(self):
+        """Test getting dependency arguments."""
+        config = FastMCPServerConfig(
+            entrypoint="server.py",
+            dependencies=["httpx", "pydantic"],
+            python_version="3.11",
+        )
+        
+        dep_args = config.get_dependencies_args()
+        assert dep_args["with_packages"] == ["httpx", "pydantic"]
+        assert dep_args["python_version"] == "3.11"
+
+
+class TestFastMCPConfig:
+    """Test FastMCPConfig root configuration."""
+
+    def test_single_server_config(self):
+        """Test single server configuration."""
+        config_data = {
+            "name": "my-server",
+            "entrypoint": "server.py:mcp",
+            "transport": "http",
+        }
+        
+        config = FastMCPConfig.from_file(self._create_temp_json(config_data))
+        assert config is not None
+        assert config.servers is not None
+        assert "default" in config.servers
+        assert config.default == "default"
+        
+        server_config = config.get_server_config()
+        assert server_config is not None
+        assert server_config.name == "my-server"
+        assert server_config.entrypoint == "server.py:mcp"
+        assert server_config.transport == "http"
+
+    def test_multi_server_config(self):
+        """Test multi-server configuration."""
+        config_data = {
+            "servers": {
+                "main": {
+                    "entrypoint": "main.py",
+                    "transport": "http",
+                },
+                "worker": {
+                    "entrypoint": "worker.py",
+                    "transport": "stdio",
+                },
+            },
+            "default": "main",
+        }
+        
+        config = FastMCPConfig.from_file(self._create_temp_json(config_data))
+        assert config is not None
+        assert config.servers is not None
+        assert "main" in config.servers
+        assert "worker" in config.servers
+        assert config.default == "main"
+        
+        # Get default server
+        main_config = config.get_server_config()
+        assert main_config is not None
+        assert main_config.entrypoint == "main.py"
+        assert main_config.transport == "http"
+        
+        # Get specific server
+        worker_config = config.get_server_config("worker")
+        assert worker_config is not None
+        assert worker_config.entrypoint == "worker.py"
+        assert worker_config.transport == "stdio"
+
+    def test_write_to_file(self):
+        """Test writing configuration to file."""
+        config = FastMCPConfig(
+            servers={
+                "test": FastMCPServerConfig(
+                    entrypoint="test.py",
+                    transport="http",
+                )
+            },
+            default="test",
+        )
+        
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            temp_path = Path(f.name)
+        
+        try:
+            config.write_to_file(temp_path)
+            
+            # Read back and verify
+            with temp_path.open() as f:
+                data = json.load(f)
+            
+            # Should write single server in simplified format
+            assert "entrypoint" in data
+            assert data["entrypoint"] == "test.py"
+            assert data["transport"] == "http"
+        finally:
+            temp_path.unlink()
+
+    def test_nonexistent_file(self):
+        """Test loading from nonexistent file."""
+        config = FastMCPConfig.from_file(Path("/nonexistent/file.json"))
+        assert config is None
+
+    def _create_temp_json(self, data: dict) -> Path:
+        """Create a temporary JSON file with data."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(data, f)
+            return Path(f.name)
+
+
+class TestConfigLoading:
+    """Test configuration loading functions."""
+
+    def test_load_fastmcp_config_default(self):
+        """Test loading default fastmcp.json."""
+        # Create fastmcp.json in temp directory
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "fastmcp.json"
+            config_data = {
+                "name": "test",
+                "entrypoint": "server.py",
+            }
+            with config_path.open("w") as f:
+                json.dump(config_data, f)
+            
+            # Change to temp directory
+            import os
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                config = load_fastmcp_config()
+                assert config is not None
+                assert config.name == "test"
+                assert config.entrypoint == "server.py"
+            finally:
+                os.chdir(old_cwd)
+
+    def test_load_fastmcp_config_explicit_path(self):
+        """Test loading from explicit path."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            config_data = {
+                "name": "explicit",
+                "entrypoint": "app.py",
+            }
+            json.dump(config_data, f)
+            temp_path = Path(f.name)
+        
+        try:
+            config = load_fastmcp_config(temp_path)
+            assert config is not None
+            assert config.name == "explicit"
+            assert config.entrypoint == "app.py"
+        finally:
+            temp_path.unlink()
+
+    def test_create_default_config(self):
+        """Test creating default configuration."""
+        config = create_default_config()
+        assert config.name == "my-server"
+        assert config.entrypoint == "server.py:mcp"
+        assert config.transport == "stdio"
+        
+        config = create_default_config(
+            entrypoint="custom.py",
+            name="custom-server",
+            transport="http",
+        )
+        assert config.name == "custom-server"
+        assert config.entrypoint == "custom.py"
+        assert config.transport == "http"


### PR DESCRIPTION
This PR introduces `fastmcp.json`, a structured configuration file format that simplifies FastMCP server deployment and management. Instead of passing numerous CLI arguments, users can now define their server configuration in a JSON file and simply run `fastmcp run`.

## Motivation

I took Jeremiah's issue #1480 and attempted to implement a first pass of what it may look like. As discussed, server configuration was becoming unwieldy with multiple parameters (dependencies, transport settings, environment variables) all specified via CLI or runtime. This made it difficult to maintain consistent server configurations across teams and deployments.

## Solution

The new `fastmcp.json` format provides a versioned, structured way to specify all server configuration in one place:

```json
{
  "name": "my-server",
  "entrypoint": "server.py:mcp",
  "transport": "http",
  "port": 8080,
  "dependencies": ["httpx", "pydantic"],
  "log_level": "DEBUG"
}
```

Then simply run:
```bash
fastmcp run  # Automatically uses fastmcp.json
```

## Key Features

- **Flexible entrypoints**: Support for `server.py`, `server.py:mcp`, `myapp.server:create_app`
- **Dependency management**: Specify Python version, packages, or requirements.txt
- **Transport configuration**: Configure stdio, HTTP, SSE with all their parameters
- **Environment variables**: Set env vars directly in the config
- **Multi-server support**: Optional support for multiple server configurations
- **CLI override**: Command-line arguments take precedence over config values
- **Backward compatible**: All existing CLI usage continues to work

`fastmcp init` is still missing.

## Testing

- Added comprehensive unit tests for configuration models
- Added integration tests for CLI with config files
- Added tests for entrypoint parsing logic
- Created example configurations demonstrating different use cases
- All existing tests continue to pass

## Files Changed

- `src/fastmcp/server/config.py` - New configuration model and utilities
- `src/fastmcp/cli/run.py` - Config loading and enhanced entrypoint parsing
- `src/fastmcp/cli/cli.py` - Added `--config` flag
- `examples/fastmcp*.json` - Example configuration files
- Tests for all new functionality

Closes #1480