### PR TITLE
feat: trigger Marvin workflow on PR body content

### DIFF
--- a/.github/workflows/marvin.yml
+++ b/.github/workflows/marvin.yml
@@ -4,6 +4,7 @@ on:
   issue_comment: { types: [created] }
   pull_request_review_comment: { types: [created] }
   pull_request_review: { types: [submitted] }
+  pull_request: { types: [opened, edited] }
   issues: { types: [opened, edited, assigned, labeled] }
   discussion: { types: [created, edited, labeled] }
   discussion_comment: { types: [created] }
@@ -22,6 +23,7 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/marvin')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/marvin')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '/marvin')) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.body, '/marvin')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '/marvin')) ||
       (github.event_name == 'discussion' && contains(github.event.discussion.body, '/marvin')) ||
       (github.event_name == 'discussion_comment' && contains(github.event.comment.body, '/marvin')) ||


### PR DESCRIPTION
Adds support for triggering the Marvin workflow when `/marvin` appears in pull request bodies, not just in comments.

This allows Marvin to respond immediately when PRs are opened or edited with the trigger phrase.