### PR TITLE
fix: enable triage bot for fork PRs using pull_request_target

### DIFF
--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -3,7 +3,7 @@ description: Automatically triage GitHub issues and PRs using Marvin
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
   workflow_dispatch:
     inputs:
@@ -26,8 +26,11 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout repository
+      - name: Checkout base repository
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Generate Marvin App token
         id: marvin-token
@@ -47,7 +50,7 @@ jobs:
           Issue/PR Information:
           - REPO: ${{ github.repository }}
           - NUMBER: ${{ github.event.issue.number || github.event.pull_request.number || inputs.issue_number }}
-          - TYPE: ${{ github.event.issue && 'issue' || github.event.pull_request && 'pull_request' || 'unknown' }}
+          - TYPE: ${{ github.event.issue && 'issue' || (github.event.pull_request && 'pull_request') || 'unknown' }}
 
           TRIAGE PROCESS:
 


### PR DESCRIPTION
The triage bot was failing on PRs from forks because the `pull_request` event doesn't have access to repository secrets when triggered by forks. This PR switches to `pull_request_target` which runs in the base repository context with access to secrets.

## Changes
- Switch from `pull_request` to `pull_request_target` event  
- Explicitly checkout the base repository (not fork code) for security
- Bot can now triage and label PRs from forks automatically

The workflow remains secure because we never execute fork code - we only checkout our base repository and use the GitHub API to read PR metadata and apply labels.