### PR TITLE
Fix pytest warnings

### DIFF
--- a/src/fastmcp/tools/tool_transform.py
+++ b/src/fastmcp/tools/tool_transform.py
@@ -439,7 +439,7 @@ class TransformedTool(Tool):
             })
 
             # Disable structured outputs
-            Tool.from_tool(parent, output_schema=False)
+            Tool.from_tool(parent, output_schema=None)
 
             # Return ToolResult for full control
             async def custom_output(**kwargs) -> ToolResult:

--- a/tests/server/test_server_interactions.py
+++ b/tests/server/test_server_interactions.py
@@ -981,13 +981,13 @@ class TestToolOutputSchema:
             assert result.structured_content == {"message": "Hello, world!"}
             assert result.data == {"message": "Hello, world!"}
 
-    async def test_output_schema_false_full_handshake(self):
-        """Test that output_schema=False works through full client/server
+    async def test_output_schema_none_full_handshake(self):
+        """Test that output_schema=None works through full client/server
         handshake. We test this by returning a scalar, which requires an output
         schema to serialize."""
         mcp = FastMCP()
 
-        @mcp.tool(output_schema=False)  # type: ignore[arg-type]
+        @mcp.tool(output_schema=None)
         def simple_tool() -> int:
             return 42
 

--- a/tests/tools/test_tool_manager.py
+++ b/tests/tools/test_tool_manager.py
@@ -1033,5 +1033,7 @@ class TestMountedComponentsRaiseOnLoadError:
         # Use temporary settings context manager
         with temporary_settings(mounted_components_raise_on_load_error=True):
             # Should raise the exception
-            with pytest.raises(AttributeError, match=""):
+            with pytest.raises(
+                AttributeError, match="'str' object has no attribute 'server'"
+            ):
                 await parent_mcp._tool_manager.list_tools()


### PR DESCRIPTION
Fixes #1547

This PR addresses two pytest warnings identified in the test output:

1. **DeprecationWarning:** Updated `output_schema=False` to `output_schema=None` in tool_transform.py documentation and test_server_interactions.py
2. **PytestWarning:** Fixed empty string matching in pytest.raises by providing specific AttributeError message

All tests pass and warnings are eliminated.

Generated with [Claude Code](https://claude.ai/code)