### PR TITLE
Added import of AuthProxy to auth __init__

### DIFF
--- a/docs/servers/auth/oauth-proxy.mdx
+++ b/docs/servers/auth/oauth-proxy.mdx
@@ -165,7 +165,7 @@ The `OAuthProxy` class provides the complete proxy implementation:
 
 ```python
 from fastmcp import FastMCP
-from fastmcp.server.auth.proxy import OAuthProxy
+from fastmcp.server.auth import OAuthProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 
 # Configure token validation for your provider

--- a/src/fastmcp/server/auth/__init__.py
+++ b/src/fastmcp/server/auth/__init__.py
@@ -6,6 +6,7 @@ from .auth import (
     AuthProvider,
 )
 from .providers.jwt import JWTVerifier, StaticTokenVerifier
+from .oauth_proxy import OAuthProxy
 
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     "StaticTokenVerifier",
     "RemoteAuthProvider",
     "AccessToken",
+    "OAuthProxy",
 ]
 
 


### PR DESCRIPTION
I fixed import path in docs, but this time I've added import to auth `__init__.py`, so next time it won't be required to update docs, if something will be updated again ;)