### PR TITLE
Document symmetric key JWT verification support

### DIFF
--- a/docs/servers/auth/token-verification.mdx
+++ b/docs/servers/auth/token-verification.mdx
@@ -80,9 +80,48 @@ This configuration creates a server that validates JWTs issued by `auth.yourcomp
 
 The `issuer` parameter ensures tokens come from your trusted authentication system, while `audience` validation prevents tokens intended for other services from being accepted by your MCP server.
 
+#### Symmetric Key Verification (HMAC)
+
+Symmetric key verification uses a shared secret for both signing and validation, making it ideal for internal microservices and trusted environments where the same secret can be securely distributed to both token issuers and validators.
+
+This approach is commonly used in microservices architectures where services share a secret key, or when your authentication service and MCP server are both managed by the same organization. The HMAC algorithms (HS256, HS384, HS512) provide strong security when the shared secret is properly managed.
+
+```python
+from fastmcp import FastMCP
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+# Use a shared secret for symmetric key verification
+verifier = JWTVerifier(
+    public_key="your-shared-secret-key-minimum-32-chars",  # Despite the name, this accepts symmetric secrets
+    issuer="internal-auth-service",
+    audience="mcp-internal-api",
+    algorithm="HS256"  # or HS384, HS512 for stronger security
+)
+
+mcp = FastMCP(name="Internal API", auth=verifier)
+```
+
+The verifier will validate tokens signed with the same secret using the specified HMAC algorithm. This approach offers several advantages for internal systems:
+
+- **Simplicity**: No key pair management or certificate distribution
+- **Performance**: HMAC operations are typically faster than RSA
+- **Compatibility**: Works well with existing microservice authentication patterns
+
+<Note>
+The parameter is named `public_key` for backwards compatibility, but when using HMAC algorithms (HS256/384/512), it accepts the symmetric secret string.
+</Note>
+
+<Warning>
+**Security Considerations for Symmetric Keys:**
+- Use a strong, randomly generated secret (minimum 32 characters recommended)
+- Never expose the secret in logs, error messages, or version control
+- Implement secure key distribution and rotation mechanisms
+- Consider using asymmetric keys (RSA/ECDSA) for external-facing APIs
+</Warning>
+
 #### Static Public Key Verification
 
-Static public key verification works when you have a fixed signing key and don't need automatic key rotation. This approach simplifies deployment in environments where JWKS endpoints aren't available.
+Static public key verification works when you have a fixed RSA or ECDSA signing key and don't need automatic key rotation. This approach is primarily useful for development environments or controlled deployments where JWKS endpoints aren't available.
 
 ```python
 from fastmcp import FastMCP
@@ -102,7 +141,7 @@ verifier = JWTVerifier(
 mcp = FastMCP(name="Protected API", auth=verifier)
 ```
 
-This configuration validates tokens using a specific public key. The key must correspond to the private key used by your token issuer. While less flexible than JWKS endpoints, this approach works well for controlled environments or when using dedicated signing keys.
+This configuration validates tokens using a specific RSA or ECDSA public key. The key must correspond to the private key used by your token issuer. While less flexible than JWKS endpoints, this approach can be useful in development environments or when testing with fixed keys.
 
 ### Development and Testing
 
@@ -180,11 +219,17 @@ Environment-based configuration separates authentication settings from applicati
 # Enable JWT verification
 export FASTMCP_SERVER_AUTH=JWT
 
-# Configure JWT verification parameters  
+# For asymmetric verification with JWKS endpoint:
 export FASTMCP_SERVER_AUTH_JWT_JWKS_URI="https://auth.company.com/.well-known/jwks.json"
 export FASTMCP_SERVER_AUTH_JWT_ISSUER="https://auth.company.com"
 export FASTMCP_SERVER_AUTH_JWT_AUDIENCE="mcp-production-api"
 export FASTMCP_SERVER_AUTH_JWT_REQUIRED_SCOPES="read:data,write:data"
+
+# OR for symmetric key verification (HMAC):
+export FASTMCP_SERVER_AUTH_JWT_PUBLIC_KEY="your-shared-secret-key-minimum-32-chars"
+export FASTMCP_SERVER_AUTH_JWT_ALGORITHM="HS256"  # or HS384, HS512
+export FASTMCP_SERVER_AUTH_JWT_ISSUER="internal-auth-service"
+export FASTMCP_SERVER_AUTH_JWT_AUDIENCE="mcp-internal-api"
 ```
 
 With these environment variables configured, your FastMCP server automatically enables JWT verification:

--- a/src/fastmcp/server/auth/providers/jwt.py
+++ b/src/fastmcp/server/auth/providers/jwt.py
@@ -159,17 +159,20 @@ class JWTVerifierSettings(BaseSettings):
 @register_provider("JWT")
 class JWTVerifier(TokenVerifier):
     """
-    JWT token verifier using public key or JWKS.
+    JWT token verifier supporting both asymmetric (RSA/ECDSA) and symmetric (HMAC) algorithms.
 
-    This verifier validates JWT tokens signed by an external issuer. It's ideal for
-    scenarios where you have a centralized identity provider (like Auth0, Okta, or
-    your own OAuth server) that issues JWTs, and your FastMCP server acts as a
-    resource server validating those tokens.
+    This verifier validates JWT tokens using various signing algorithms:
+    - **Asymmetric algorithms** (RS256/384/512, ES256/384/512, PS256/384/512):
+      Uses public/private key pairs. Ideal for external clients and services where
+      only the authorization server has the private key.
+    - **Symmetric algorithms** (HS256/384/512): Uses a shared secret for both
+      signing and verification. Perfect for internal microservices and trusted
+      environments where the secret can be securely shared.
 
     Use this when:
-    - You have JWT tokens issued by an external service
-    - You want asymmetric key verification (public/private key pairs)
-    - You need JWKS support for automatic key rotation
+    - You have JWT tokens issued by an external service (asymmetric)
+    - You need JWKS support for automatic key rotation (asymmetric)
+    - You have internal microservices sharing a secret key (symmetric)
     - Your tokens contain standard OAuth scopes and claims
     """
 
@@ -188,11 +191,14 @@ class JWTVerifier(TokenVerifier):
         Initialize the JWT token verifier.
 
         Args:
-            public_key: PEM-encoded public key for verification
-            jwks_uri: URI to fetch JSON Web Key Set
+            public_key: For asymmetric algorithms (RS256, ES256, etc.): PEM-encoded public key.
+                       For symmetric algorithms (HS256, HS384, HS512): The shared secret string.
+            jwks_uri: URI to fetch JSON Web Key Set (only for asymmetric algorithms)
             issuer: Expected issuer claim
             audience: Expected audience claim(s)
-            algorithm: JWT signing algorithm (default: RS256)
+            algorithm: JWT signing algorithm. Supported algorithms:
+                      - Asymmetric: RS256/384/512, ES256/384/512, PS256/384/512 (default: RS256)
+                      - Symmetric: HS256, HS384, HS512
             required_scopes: Required scopes for all tokens
             resource_server_url: Resource server URL for TokenVerifier protocol
         """


### PR DESCRIPTION
FastMCP's JWTVerifier has always supported symmetric key algorithms (HS256/384/512), but this capability was undocumented. This PR adds comprehensive documentation for this feature, which is particularly useful for internal microservices that share secret keys.

The documentation now clearly explains that the `public_key` parameter accepts both RSA/ECDSA public keys for asymmetric algorithms and shared secrets for HMAC algorithms. Examples and security considerations for symmetric key usage in production environments have been added.

Closes #1584