### PR TITLE
Experiment with haiku for limited workflows

### DIFF
--- a/.github/workflows/marvin-dedupe-issues.yml
+++ b/.github/workflows/marvin-dedupe-issues.yml
@@ -72,8 +72,9 @@ jobs:
       - name: Run Marvin dedupe command
         uses: anthropics/claude-code-base-action@beta
         with:
+          model: claude-3-5-haiku-latest
           prompt_file: /tmp/claude-prompts/dedupe-prompt.txt
           allowed_tools: "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh api:*),Bash(gh issue comment:*),Task"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_FOR_CI }}
           claude_env: |
             GH_TOKEN: ${{ steps.marvin-token.outputs.token }}

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -148,10 +148,11 @@ jobs:
       - name: Run Marvin for Issue Triage
         uses: anthropics/claude-code-base-action@beta
         with:
+          model: claude-3-5-haiku-latest
           prompt_file: /tmp/claude-prompts/triage-prompt.txt
           allowed_tools: "Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__get_pull_request_files"
           timeout_minutes: "5"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_FOR_CI }}
           mcp_config: /tmp/mcp-config/mcp-servers.json
           claude_env: |
             GH_TOKEN: ${{ steps.marvin-token.outputs.token }}


### PR DESCRIPTION
This PR switches our two Marvin "restricted" workflows to use Haiku (as an experiment) and a separate API key for cost tracking.