### PR TITLE
feat: Improve GitHub workflow automation for schema and SDK docs

### DIFF
--- a/.github/workflows/update-config-schema.yml
+++ b/.github/workflows/update-config-schema.yml
@@ -42,32 +42,29 @@ jobs:
       - name: Generate config schema
         run: |
           echo "🔄 Generating fastmcp.json schema..."
+
+          # Generate schema in docs/public for web access
           uv run python -c "
           from fastmcp.utilities.fastmcp_config import generate_schema
           generate_schema('docs/public/schemas/fastmcp.json/latest.json')
-          print('✅ Schema generated successfully')
+          print('✅ Latest schema generated in docs/public')
           "
 
-          # Also update the v1 schema for consistency
+          # Also update the v1 schema in docs/public
           uv run python -c "
           from fastmcp.utilities.fastmcp_config import generate_schema
           generate_schema('docs/public/schemas/fastmcp.json/v1.json')
-          print('✅ v1 schema updated')
+          print('✅ v1 schema generated in docs/public')
           "
 
-      - name: Check for changes
-        id: check_changes
-        run: |
-          if git diff --quiet docs/public/schemas/fastmcp.json/; then
-            echo "No changes detected in config schema"
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-          else
-            echo "Changes detected in config schema"
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          fi
+          # Generate schema in the source directory for local development
+          uv run python -c "
+          from fastmcp.utilities.fastmcp_config import generate_schema
+          generate_schema('src/fastmcp/utilities/fastmcp_config/v1/schema.json')
+          print('✅ Schema generated in utilities/fastmcp_config/v1/')
+          "
 
       - name: Create Pull Request
-        if: steps.check_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.marvin-token.outputs.token }}
@@ -86,8 +83,5 @@ jobs:
 
       - name: Summary
         run: |
-          if [ "${{ steps.check_changes.outputs.has_changes }}" == "true" ]; then
-            echo "✅ Config schema PR created"
-          else
-            echo "✅ Config schema is already up to date"
-          fi
+          echo "✅ Config schema generation workflow completed"
+          echo "PR will be created if there are changes, or closed if schema is already up to date"

--- a/.github/workflows/update-sdk-docs.yml
+++ b/.github/workflows/update-sdk-docs.yml
@@ -47,19 +47,7 @@ jobs:
           echo "🔄 Generating SDK documentation..."
           just api-ref-all
 
-      - name: Check for changes
-        id: check_changes
-        run: |
-          if git diff --quiet docs/python-sdk/ docs/docs.json; then
-            echo "No changes detected in SDK documentation"
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-          else
-            echo "Changes detected in SDK documentation"
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Create Pull Request
-        if: steps.check_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.marvin-token.outputs.token }}
@@ -78,8 +66,5 @@ jobs:
 
       - name: Summary
         run: |
-          if [ "${{ steps.check_changes.outputs.has_changes }}" == "true" ]; then
-            echo "✅ SDK documentation PR created"
-          else
-            echo "✅ SDK documentation is already up to date"
-          fi
+          echo "✅ SDK documentation generation workflow completed"
+          echo "PR will be created if there are changes, or closed if documentation is already up to date"


### PR DESCRIPTION
Improves the GitHub workflow automation as requested in #1612. The workflows are now simpler and more robust, always running their generation steps and letting the PR action handle whether changes exist.

## Key Changes

**Removed conditional checks**: Both `update-config-schema.yml` and `update-sdk-docs.yml` now always attempt to create PRs. The `peter-evans/create-pull-request` action automatically handles the case where no changes exist by closing the PR.

**Multi-location schema generation**: The schema workflow now generates `fastmcp.json` schema in three locations:
- `docs/public/schemas/fastmcp.json/latest.json` - for web access
- `docs/public/schemas/fastmcp.json/v1.json` - versioned for web
- `src/fastmcp/utilities/fastmcp_config/v1/schema.json` - for local development tooling

This ensures the schema is available wherever it's needed without manual synchronization.

Fixes #1612

🤖 Generated with Claude Code