### PR TITLE
Remove client info modifications

### DIFF
--- a/src/fastmcp/server/auth/oauth_proxy.py
+++ b/src/fastmcp/server/auth/oauth_proxy.py
@@ -419,15 +419,6 @@ class OAuthProxy(OAuthProvider):
             allowed_redirect_uri_patterns=self._allowed_client_redirect_uris,
         )
 
-        # Modify the client_info object in place (framework ignores return values)
-        client_info.client_id = upstream_id
-        client_info.client_secret = upstream_secret
-        client_info.token_endpoint_auth_method = "none"
-
-        # Ensure correct grant types
-        if not client_info.grant_types:
-            client_info.grant_types = ["authorization_code", "refresh_token"]
-
         # Store the ProxyDCRClient using the upstream ID
         self._clients[upstream_id] = proxy_client
 


### PR DESCRIPTION
Closes #1618

The OAuthProxy is inadvertently sending the "true" client secret back to the MCP client, which is obviously bad. I think these assignments were part of testing visibility that should have been deleted, though I was under the impression that the SDK did not use this object (in fact, it doesn't depend on it being returned from the function that was modifying it, but it does send the modified object back to the client, hence the bug)