### PR TITLE
Improve fastmcp.json environment configuration and project-based deployments

### DIFF
--- a/docs/deployment/server-configuration.mdx
+++ b/docs/deployment/server-configuration.mdx
@@ -165,10 +165,14 @@ These settings leverage standard `uv` arguments for environment creation. When a
       ```
     </ParamField>
     
-    <ParamField body="editable" type="string">
-      Path to a package to install in editable/development mode. Useful for local development when you want changes to be reflected immediately.
+    <ParamField body="editable" type="list[string]">
+      List of paths to packages to install in editable/development mode. Useful for local development when you want changes to be reflected immediately. Supports multiple packages for monorepo setups or shared libraries.
       ```json
-      "editable": "."
+      "editable": ["."]
+      ```
+      Or with multiple packages:
+      ```json
+      "editable": [".", "../shared-lib", "/path/to/another-package"]
       ```
     </ParamField>
   </Expandable>

--- a/docs/deployment/server-configuration.mdx
+++ b/docs/deployment/server-configuration.mdx
@@ -316,6 +316,20 @@ fastmcp run fastmcp.json --skip-source
 fastmcp run fastmcp.json --skip-env --skip-source
 ```
 
+### Pre-building Environments
+
+You can use `fastmcp project prepare` to create a persistent uv project with all dependencies pre-installed:
+
+```bash
+# Create a persistent environment
+fastmcp project prepare fastmcp.json --output-dir ./env
+
+# Use the pre-built environment to run the server
+fastmcp run fastmcp.json --project ./env
+```
+
+This pattern separates environment setup (slow) from server execution (fast), useful for deployment scenarios.
+
 ### Using an Existing Environment
 
 By default, FastMCP creates an isolated environment with `uv` based on your configuration. When you already have a suitable Python environment, use the `--skip-env` flag to skip environment creation:

--- a/docs/patterns/cli.mdx
+++ b/docs/patterns/cli.mdx
@@ -22,6 +22,7 @@ fastmcp --help
 | `dev` | Run a server with the MCP Inspector for testing | **Supports:** Local files and fastmcp.json configs. **Deps:** Always runs via `uv run` subprocess (never uses your local environment); dependencies must be specified or available in a uv-managed project. With fastmcp.json: Uses configured dependencies |
 | `install` | Install a server in MCP client applications | **Supports:** Local files and fastmcp.json configs. **Deps:** Creates an isolated environment; dependencies must be explicitly specified with `--with` and/or `--with-editable`. With fastmcp.json: Uses configured dependencies |
 | `inspect` | Generate a JSON report about a FastMCP server | **Supports:** Local files and fastmcp.json configs. **Deps:** Uses your current environment; you are responsible for ensuring all dependencies are available |
+| `project prepare` | Create a persistent uv project from fastmcp.json environment config | **Supports:** fastmcp.json configs only. **Deps:** Creates a uv project directory with all dependencies pre-installed for reuse with `--project` flag |
 | `version` | Display version information | N/A |
 
 ## `fastmcp run`
@@ -472,6 +473,37 @@ fastmcp inspect server.py:my_server
 # Custom output location
 fastmcp inspect server.py --output analysis.json
 ```
+
+## `fastmcp project prepare`
+
+Create a persistent uv project directory from a fastmcp.json file's environment configuration. This allows you to pre-install all dependencies once and reuse them with the `--project` flag.
+
+```bash
+fastmcp project prepare fastmcp.json --output-dir ./env
+```
+
+### Options
+
+| Option | Flag | Description |
+| ------ | ---- | ----------- |
+| Output Directory | `--output-dir` | **Required.** Directory where the persistent uv project will be created |
+
+### Usage Pattern
+
+```bash
+# Step 1: Prepare the environment (installs dependencies)
+fastmcp project prepare fastmcp.json --output-dir ./my-env
+
+# Step 2: Run using the prepared environment (fast, no dependency installation)
+fastmcp run fastmcp.json --project ./my-env
+```
+
+The prepare command creates a uv project with:
+- A `pyproject.toml` containing all dependencies from the fastmcp.json
+- A `.venv` with all packages pre-installed
+- A `uv.lock` file for reproducible environments
+
+This is useful when you want to separate environment setup from server execution, such as in deployment scenarios where dependencies are installed once and the server is run multiple times.
 
 ## `fastmcp version`
 

--- a/src/fastmcp/cli/claude.py
+++ b/src/fastmcp/cli/claude.py
@@ -101,7 +101,7 @@ def update_claude_config(
         # Build uv run command using Environment.build_uv_args()
         env_config = Environment(
             dependencies=deduplicated_packages,
-            editable=str(with_editable) if with_editable else None,
+            editable=[str(with_editable)] if with_editable else None,
         )
         args = env_config.build_uv_args()
 

--- a/src/fastmcp/cli/cli.py
+++ b/src/fastmcp/cli/cli.py
@@ -229,9 +229,11 @@ async def dev(
                 if config.environment.requirements
                 else None
             )
+            # Note: config.environment.editable is a list, but CLI only supports single path
+            # Take the first editable path if available
             with_editable = with_editable or (
-                Path(config.environment.editable)
-                if config.environment.editable
+                Path(config.environment.editable[0])
+                if config.environment.editable and config.environment.editable[0]
                 else None
             )
 
@@ -303,7 +305,7 @@ async def dev(
             dependencies=with_packages if with_packages else None,
             requirements=str(with_requirements) if with_requirements else None,
             project=str(project) if project else None,
-            editable=str(with_editable) if with_editable else None,
+            editable=[str(with_editable)] if with_editable else None,
         )
         uv_cmd = ["uv"] + env_config.build_uv_args(["fastmcp", "run", server_spec])
 
@@ -415,19 +417,19 @@ async def run(
             help="Requirements file to install dependencies from",
         ),
     ] = None,
-    skip_env: Annotated[
-        bool,
-        cyclopts.Parameter(
-            "--skip-env",
-            help="Skip environment setup with uv (use when already in a uv environment)",
-            negative="",
-        ),
-    ] = False,
     skip_source: Annotated[
         bool,
         cyclopts.Parameter(
             "--skip-source",
             help="Skip source preparation step (use when source is already prepared)",
+            negative="",
+        ),
+    ] = False,
+    skip_env: Annotated[
+        bool,
+        cyclopts.Parameter(
+            "--skip-env",
+            help="Skip environment configuration (for internal use when already in a uv environment)",
             negative="",
         ),
     ] = False,
@@ -509,7 +511,8 @@ async def run(
                             )
 
                         # Merge environment config with CLI values (CLI takes precedence)
-                        if config.environment:
+                        # BUT: Skip this if --skip-env is set
+                        if config.environment and not skip_env:
                             python = python or config.environment.python
                             project = project or (
                                 Path(config.environment.project)
@@ -552,15 +555,14 @@ async def run(
     )
 
     # Check if we need to use uv run (either from CLI args or config)
-    # When skip_env is set, we still use uv if there are dependencies, but with --no-sync
+    # When --skip-env is set, we ignore config.environment entirely
     needs_uv = python or with_packages or with_requirements or project or editable
-    if not needs_uv and config and config.environment:
-        # Check if config's environment needs uv
+    if not needs_uv and config and config.environment and not skip_env:
+        # Check if config's environment needs uv (but only if not skipping env)
         needs_uv = config.environment.needs_uv()
 
     if needs_uv:
         # Use uv run subprocess - always use run_with_uv which handles output correctly
-        # When skip_env is True, we pass no_sync=True to use cached environment without syncing
         try:
             run_module.run_with_uv(
                 server_spec=server_spec,
@@ -575,7 +577,6 @@ async def run(
                 log_level=log_level,
                 show_banner=not no_banner,
                 editable=editable,
-                no_sync=skip_env,  # Use --no-sync when skip_env is True
             )
         except Exception as e:
             logger.error(
@@ -598,7 +599,6 @@ async def run(
                 log_level=log_level,
                 server_args=list(server_args),
                 show_banner=not no_banner,
-                skip_env=skip_env,
                 skip_source=skip_source,
             )
         except Exception as e:
@@ -829,24 +829,45 @@ async def prepare(
         str | None,
         cyclopts.Parameter(help="Path to fastmcp.json configuration file"),
     ] = None,
+    output_dir: Annotated[
+        str | None,
+        cyclopts.Parameter(help="Directory to create the persistent environment in"),
+    ] = None,
+    skip_source: Annotated[
+        bool,
+        cyclopts.Parameter(help="Skip source preparation (e.g., git clone)"),
+    ] = False,
 ) -> None:
-    """Prepare a FastMCP project by setting up environment and source.
+    """Prepare a FastMCP project by creating a persistent uv environment.
 
-    This command prepares everything needed to run a FastMCP server:
-    - Sets up the Python environment (creates venv, installs dependencies)
-    - Prepares the source (git clone, download, etc. for non-filesystem sources)
+    This command creates a persistent uv project with all dependencies installed:
+    - Creates a pyproject.toml with dependencies from the config
+    - Installs all Python packages into a .venv
+    - Prepares the source (git clone, download, etc.) unless --skip-source
 
     After running this command, you can use:
-    fastmcp run <config> --skip-env --skip-source
+    fastmcp run <config> --project <output-dir>
 
     This is useful for:
     - CI/CD pipelines with separate build and run stages
     - Docker images where you prepare during build
-    - Production deployments where you validate before running
+    - Production deployments where you want fast startup times
+
+    Example:
+        fastmcp project prepare myserver.json --output-dir ./prepared-env
+        fastmcp run myserver.json --project ./prepared-env
     """
     from pathlib import Path
 
     from fastmcp.utilities.fastmcp_config import FastMCPConfig
+
+    # Require output-dir
+    if output_dir is None:
+        logger.error(
+            "The --output-dir parameter is required.\n"
+            "Please specify where to create the persistent environment."
+        )
+        sys.exit(1)
 
     # Auto-detect fastmcp.json if not provided
     if config_path is None:
@@ -866,17 +887,22 @@ async def prepare(
         logger.error(f"Configuration file not found: {config_path}")
         sys.exit(1)
 
+    output_path = Path(output_dir)
+
     try:
         # Load the configuration
         config = FastMCPConfig.from_file(config_file)
 
         # Prepare environment and source
-        await config.prepare(skip_env=False, skip_source=False)
+        await config.prepare(
+            skip_source=skip_source,
+            output_dir=output_path,
+        )
 
         console.print(
-            f"[bold green]✓[/bold green] Project prepared successfully!\n"
+            f"[bold green]✓[/bold green] Project prepared successfully in {output_path}!\n"
             f"You can now run the server with:\n"
-            f"  [cyan]fastmcp run {config_path} --skip-env --skip-source[/cyan]"
+            f"  [cyan]fastmcp run {config_path} --project {output_dir}[/cyan]"
         )
 
     except Exception as e:

--- a/src/fastmcp/cli/install/claude_code.py
+++ b/src/fastmcp/cli/install/claude_code.py
@@ -121,7 +121,7 @@ def install_claude_code(
         dependencies=deduplicated_packages,
         requirements=str(with_requirements) if with_requirements else None,
         project=str(project) if project else None,
-        editable=str(with_editable) if with_editable else None,
+        editable=[str(with_editable)] if with_editable else None,
     )
     args = env_config.build_uv_args()
 

--- a/src/fastmcp/cli/install/claude_desktop.py
+++ b/src/fastmcp/cli/install/claude_desktop.py
@@ -86,7 +86,7 @@ def install_claude_desktop(
         dependencies=deduplicated_packages,
         requirements=str(with_requirements) if with_requirements else None,
         project=str(project) if project else None,
-        editable=str(with_editable) if with_editable else None,
+        editable=[str(with_editable)] if with_editable else None,
     )
     args = env_config.build_uv_args()
 

--- a/src/fastmcp/cli/install/cursor.py
+++ b/src/fastmcp/cli/install/cursor.py
@@ -120,7 +120,7 @@ def install_cursor_workspace(
         dependencies=deduplicated_packages,
         requirements=str(with_requirements.resolve()) if with_requirements else None,
         project=str(project.resolve()) if project else None,
-        editable=str(with_editable.resolve()) if with_editable else None,
+        editable=[str(with_editable.resolve())] if with_editable else None,
     )
     args = env_config.build_uv_args()
 
@@ -200,7 +200,7 @@ def install_cursor(
         dependencies=deduplicated_packages,
         requirements=str(with_requirements.resolve()) if with_requirements else None,
         project=str(project.resolve()) if project else None,
-        editable=str(with_editable.resolve()) if with_editable else None,
+        editable=[str(with_editable.resolve())] if with_editable else None,
     )
     args = env_config.build_uv_args()
 

--- a/src/fastmcp/cli/install/mcp_json.py
+++ b/src/fastmcp/cli/install/mcp_json.py
@@ -61,7 +61,7 @@ def install_mcp_json(
             dependencies=deduplicated_packages,
             requirements=str(with_requirements) if with_requirements else None,
             project=str(project) if project else None,
-            editable=str(with_editable) if with_editable else None,
+            editable=[str(with_editable)] if with_editable else None,
         )
         args = env_config.build_uv_args()
 

--- a/src/fastmcp/cli/run.py
+++ b/src/fastmcp/cli/run.py
@@ -222,6 +222,7 @@ async def run_command(
     server_args: list[str] | None = None,
     show_banner: bool = True,
     use_direct_import: bool = False,
+    skip_env: bool = False,
     skip_source: bool = False,
 ) -> None:
     """Run a MCP server or connect to a remote one.
@@ -236,6 +237,7 @@ async def run_command(
         server_args: Additional arguments to pass to the server
         show_banner: Whether to show the server banner
         use_direct_import: Whether to use direct import instead of subprocess
+        skip_env: Whether to skip environment preparation step
         skip_source: Whether to skip source preparation step
     """
     # Special case: URLs
@@ -269,9 +271,8 @@ async def run_command(
                     server_args if server_args is not None else config.deployment.args
                 )
 
-            # Prepare the source if needed (e.g., clone git repo, download from cloud)
-            if not skip_source:
-                await config.source.prepare()
+            # Prepare environment and source using unified prepare() method
+            await config.prepare(skip_env=skip_env, skip_source=skip_source)
 
             # Load the server using the source
             from contextlib import nullcontext
@@ -290,9 +291,8 @@ async def run_command(
         source = FileSystemSource(path=server_spec)
         config = FastMCPConfig(source=source)
 
-        # Prepare the source if needed
-        if not skip_source:
-            await config.source.prepare()
+        # Prepare environment and source using unified prepare() method
+        await config.prepare(skip_env=skip_env, skip_source=skip_source)
 
         # Load the server
         from contextlib import nullcontext

--- a/src/fastmcp/utilities/fastmcp_config/v1/fastmcp_config.py
+++ b/src/fastmcp/utilities/fastmcp_config/v1/fastmcp_config.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, overload
 
@@ -55,10 +57,10 @@ class Environment(BaseModel):
         examples=[".", "../my-project"],
     )
 
-    editable: str | None = Field(
+    editable: list[str] | None = Field(
         default=None,
-        description="Directory to install in editable mode",
-        examples=[".", "../my-package"],
+        description="Directories to install in editable mode",
+        examples=[[".", "../my-package"], ["/path/to/package"]],
     )
 
     def build_uv_args(self, command: str | list[str] | None = None) -> list[str]:
@@ -72,34 +74,28 @@ class Environment(BaseModel):
         """
         args = ["run"]
 
-        # Add Python version if specified
-        if self.python:
-            args.extend(["--python", self.python])
-
-        # Add project directory if specified
+        # Add project if specified
         if self.project:
             args.extend(["--project", str(self.project)])
 
-        # Add fastmcp dependency - use editable install if in development mode
-        dev_path = self._find_fastmcp_dev_path()
-        if dev_path:
-            args.extend(["--with-editable", str(dev_path)])
-        else:
-            args.extend(["--with", "fastmcp"])
+        # Add Python version if specified (only if no project, as project has its own Python)
+        if self.python and not self.project:
+            args.extend(["--python", self.python])
 
-        # Add additional dependencies (skip fastmcp if already added)
+        # Always add dependencies, requirements, and editable packages
+        # These work with --project to add additional packages on top of the project env
         if self.dependencies:
             for dep in self.dependencies:
-                if dep != "fastmcp":  # Skip fastmcp since we already added it
-                    args.extend(["--with", dep])
+                args.extend(["--with", dep])
 
         # Add requirements file
         if self.requirements:
             args.extend(["--with-requirements", str(self.requirements)])
 
-        # Add editable package
+        # Add editable packages
         if self.editable:
-            args.extend(["--with-editable", str(self.editable)])
+            for editable_path in self.editable:
+                args.extend(["--with-editable", str(editable_path)])
 
         # Add the command if provided
         if command:
@@ -109,34 +105,6 @@ class Environment(BaseModel):
                 args.extend(command)
 
         return args
-
-    def _find_fastmcp_dev_path(self) -> Path | None:
-        """Find the fastmcp development directory by looking for pyproject.toml.
-
-        Searches from the current working directory up the directory tree
-        looking for a pyproject.toml file that contains name = "fastmcp".
-
-        Returns:
-            Path to the fastmcp project directory if found, None otherwise
-        """
-        current_path = Path.cwd()
-
-        # Search up the directory tree
-        for path in [current_path] + list(current_path.parents):
-            pyproject_path = path / "pyproject.toml"
-            if pyproject_path.exists():
-                try:
-                    # Read and check if this is the fastmcp project
-                    content = pyproject_path.read_text(encoding="utf-8")
-                    if 'name = "fastmcp"' in content or "name='fastmcp'" in content:
-                        logger.debug(f"Found fastmcp development project at: {path}")
-                        return path
-                except (OSError, UnicodeDecodeError):
-                    # Skip files that can't be read
-                    continue
-
-        logger.debug("No fastmcp development project found, using PyPI package")
-        return None
 
     def run_with_uv(self, command: list[str]) -> None:
         """Execute a command using uv run with this environment configuration.
@@ -177,14 +145,13 @@ class Environment(BaseModel):
             ]
         )
 
-    async def prepare(self) -> None:
+    async def prepare(self, output_dir: Path | None = None) -> None:
         """Prepare the Python environment using uv.
 
-        This populates uv's cache with all required dependencies
-        so that subsequent runs with --no-sync can access them quickly.
+        Args:
+            output_dir: Directory where the persistent uv project will be created.
+                       If None, creates a temporary directory for ephemeral use.
         """
-        import shutil
-        import subprocess
 
         # Check if uv is available
         if not shutil.which("uv"):
@@ -193,27 +160,154 @@ class Environment(BaseModel):
                 "curl -LsSf https://astral.sh/uv/install.sh | sh"
             )
 
-        # If no environment settings, nothing to prepare
+        # Only prepare environment if there are actual settings to apply
         if not self.needs_uv():
-            logger.debug("No environment configuration to prepare")
+            logger.debug("No environment settings configured, skipping preparation")
             return
 
-        logger.info("Preparing Python environment...")
+        # Handle None case for ephemeral use
+        if output_dir is None:
+            import tempfile
 
-        # Build a simple command that will cache the environment with all dependencies
-        # Just run Python and print a message - uv will handle installing everything
-        cmd = ["uv"] + self.build_uv_args(
-            ["python", "-c", "print('Environment cached')"]
-        )
+            output_dir = Path(tempfile.mkdtemp(prefix="fastmcp-env-"))
+            logger.info(f"Creating ephemeral environment in {output_dir}")
+        else:
+            logger.info(f"Creating persistent environment in {output_dir}")
+            output_dir = Path(output_dir).resolve()
 
+        # Initialize the project
+        logger.debug(f"Initializing uv project in {output_dir}")
         try:
-            # Run the command to cache all dependencies
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-            logger.info("Environment prepared successfully")
-            logger.debug(f"Output: {result.stdout}")
+            subprocess.run(
+                [
+                    "uv",
+                    "init",
+                    "--project",
+                    str(output_dir),
+                    "--name",
+                    "fastmcp-env",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
         except subprocess.CalledProcessError as e:
-            logger.error(f"Failed to prepare environment: {e.stderr}")
-            raise RuntimeError(f"Environment preparation failed: {e.stderr}") from e
+            # If project already exists, that's fine - continue
+            if "already initialized" in e.stderr.lower():
+                logger.debug(
+                    f"Project already initialized at {output_dir}, continuing..."
+                )
+            else:
+                logger.error(f"Failed to initialize project: {e.stderr}")
+                raise RuntimeError(f"Failed to initialize project: {e.stderr}") from e
+
+        # Pin Python version if specified
+        if self.python:
+            logger.debug(f"Pinning Python version to {self.python}")
+            try:
+                subprocess.run(
+                    [
+                        "uv",
+                        "python",
+                        "pin",
+                        self.python,
+                        "--project",
+                        str(output_dir),
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as e:
+                logger.error(f"Failed to pin Python version: {e.stderr}")
+                raise RuntimeError(f"Failed to pin Python version: {e.stderr}") from e
+
+        # Add dependencies with --no-sync to defer installation
+        # dependencies ALWAYS include fastmcp; this is compatible with
+        # specific fastmcp versions that might be in the dependencies list
+        dependencies = (self.dependencies or []) + ["fastmcp"]
+        logger.debug(f"Adding dependencies: {', '.join(dependencies)}")
+        try:
+            subprocess.run(
+                [
+                    "uv",
+                    "add",
+                    *dependencies,
+                    "--no-sync",
+                    "--project",
+                    str(output_dir),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to add dependencies: {e.stderr}")
+            raise RuntimeError(f"Failed to add dependencies: {e.stderr}") from e
+
+        # Add requirements file if specified
+        if self.requirements:
+            logger.debug(f"Adding requirements from {self.requirements}")
+            # Resolve requirements path relative to current directory
+            req_path = Path(self.requirements).resolve()
+            try:
+                subprocess.run(
+                    [
+                        "uv",
+                        "add",
+                        "-r",
+                        str(req_path),
+                        "--no-sync",
+                        "--project",
+                        str(output_dir),
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as e:
+                logger.error(f"Failed to add requirements: {e.stderr}")
+                raise RuntimeError(f"Failed to add requirements: {e.stderr}") from e
+
+        # Add editable packages if specified
+        if self.editable:
+            editable_paths = [str(Path(e).resolve()) for e in self.editable]
+            logger.debug(f"Adding editable packages: {', '.join(editable_paths)}")
+            try:
+                subprocess.run(
+                    [
+                        "uv",
+                        "add",
+                        "--editable",
+                        *editable_paths,
+                        "--no-sync",
+                        "--project",
+                        str(output_dir),
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as e:
+                logger.error(f"Failed to add editable packages: {e.stderr}")
+                raise RuntimeError(
+                    f"Failed to add editable packages: {e.stderr}"
+                ) from e
+
+        # Final sync to install everything
+        logger.info("Installing dependencies...")
+        try:
+            subprocess.run(
+                ["uv", "sync", "--project", str(output_dir)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to sync dependencies: {e.stderr}")
+            raise RuntimeError(f"Failed to sync dependencies: {e.stderr}") from e
+
+        logger.info(f"Environment prepared successfully in {output_dir}")
 
 
 class Deployment(BaseModel):
@@ -491,7 +585,7 @@ class FastMCPConfig(BaseModel):
                 dependencies=dependencies,
                 requirements=requirements,
                 project=project,
-                editable=editable,
+                editable=[editable] if editable else None,
             )
 
         # Build deployment config if any deployment args provided
@@ -537,30 +631,37 @@ class FastMCPConfig(BaseModel):
 
         return None
 
-    async def prepare(self, skip_env: bool = False, skip_source: bool = False) -> None:
+    async def prepare(
+        self,
+        skip_source: bool = False,
+        output_dir: Path | None = None,
+    ) -> None:
         """Prepare environment and source for execution.
 
-        This is the single entry point for all preparation logic.
-        Called by ALL commands (run, dev, project prepare) with appropriate skip flags.
+        When output_dir is provided, creates a persistent uv project.
+        When output_dir is None, does ephemeral caching (for backwards compatibility).
 
         Args:
-            skip_env: Skip environment preparation if True
             skip_source: Skip source preparation if True
+            output_dir: Directory to create the persistent uv project in (optional)
         """
-        if not skip_env:
-            await self.prepare_environment()
+        # Prepare environment (persistent if output_dir provided, ephemeral otherwise)
+        if self.environment:
+            await self.prepare_environment(output_dir=output_dir)
+
         if not skip_source:
             await self.prepare_source()
 
-    async def prepare_environment(self) -> None:
+    async def prepare_environment(self, output_dir: Path | None = None) -> None:
         """Prepare the Python environment.
 
-        Delegates to the environment's prepare() method if environment config exists.
+        Args:
+            output_dir: If provided, creates a persistent uv project in this directory.
+                       If None, just populates uv's cache for ephemeral use.
+
+        Delegates to the environment's prepare() method
         """
-        if self.environment:
-            await self.environment.prepare()
-        else:
-            logger.debug("No environment configuration to prepare")
+        await self.environment.prepare(output_dir=output_dir)
 
     async def prepare_source(self) -> None:
         """Prepare the source for loading.

--- a/src/fastmcp/utilities/fastmcp_config/v1/schema.json
+++ b/src/fastmcp/utilities/fastmcp_config/v1/schema.json
@@ -243,17 +243,25 @@
         "editable": {
           "anyOf": [
             {
-              "type": "string"
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Directory to install in editable mode",
+          "description": "Directories to install in editable mode",
           "examples": [
-            ".",
-            "../my-package"
+            [
+              ".",
+              "../my-package"
+            ],
+            [
+              "/path/to/package"
+            ]
           ],
           "title": "Editable"
         }

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -328,18 +328,19 @@ class TestRunCommand:
                 ]
             )
 
-    def test_run_command_parsing_skip_env_flag(self):
-        """Test run command parsing with --skip-env flag."""
+    def test_run_command_parsing_project_flag(self):
+        """Test run command parsing with --project flag."""
         command, bound, _ = app.parse_args(
             [
                 "run",
                 "server.py",
-                "--skip-env",
+                "--project",
+                "./test-env",
             ]
         )
         assert command is not None
         assert bound.arguments["server_spec"] == "server.py"
-        assert bound.arguments["skip_env"] is True
+        assert bound.arguments["project"] == Path("./test-env")
 
     def test_run_command_parsing_skip_source_flag(self):
         """Test run command parsing with --skip-source flag."""
@@ -354,19 +355,20 @@ class TestRunCommand:
         assert bound.arguments["server_spec"] == "server.py"
         assert bound.arguments["skip_source"] is True
 
-    def test_run_command_parsing_both_skip_flags(self):
-        """Test run command parsing with both --skip-env and --skip-source flags."""
+    def test_run_command_parsing_project_and_skip_source(self):
+        """Test run command parsing with --project and --skip-source flags."""
         command, bound, _ = app.parse_args(
             [
                 "run",
                 "server.py",
-                "--skip-env",
+                "--project",
+                "./test-env",
                 "--skip-source",
             ]
         )
         assert command is not None
         assert bound.arguments["server_spec"] == "server.py"
-        assert bound.arguments["skip_env"] is True
+        assert bound.arguments["project"] == Path("./test-env")
         assert bound.arguments["skip_source"] is True
 
 

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -59,7 +59,7 @@ class TestEnvironment:
                 "dependencies": ["requests", "numpy>=2.0"],
                 "requirements": "requirements.txt",
                 "project": ".",
-                "editable": "../my-package",
+                "editable": ["../my-package"],
             },
         )
 
@@ -68,7 +68,7 @@ class TestEnvironment:
         assert env.dependencies == ["requests", "numpy>=2.0"]
         assert env.requirements == "requirements.txt"
         assert env.project == "."
-        assert env.editable == "../my-package"
+        assert env.editable == ["../my-package"]
 
     def test_needs_uv(self):
         """Test needs_uv() method."""
@@ -107,15 +107,17 @@ class TestEnvironment:
         args = config.environment.build_uv_args(["fastmcp", "run", "server.py"])
 
         assert args[0] == "run"
-        assert "--python" in args
-        assert "3.12" in args
+        # Python version not added when project is specified (project defines its own Python)
+        assert "--python" not in args
+        assert "3.12" not in args
         assert "--project" in args
+        assert "." in args
         assert "--with" in args
-        assert "fastmcp" in args
         assert "requests" in args
         assert "numpy" in args
         assert "--with-requirements" in args
         assert "requirements.txt" in args
+        # Command args should be at the end
         assert "fastmcp" in args[-3:]
         assert "run" in args[-2:]
         assert "server.py" in args[-1:]

--- a/tests/cli/test_cursor.py
+++ b/tests/cli/test_cursor.py
@@ -280,11 +280,7 @@ class TestInstallCursor:
         # Verify failure message was printed
         mock_print.assert_called()
 
-    @patch(
-        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.Environment._find_fastmcp_dev_path",
-        return_value=None,  # Mock to disable dev mode so "fastmcp" count is predictable
-    )
-    def test_install_cursor_deduplicate_packages(self, mock_find_dev):
+    def test_install_cursor_deduplicate_packages(self):
         """Test that duplicate packages are deduplicated."""
         with patch("fastmcp.cli.install.cursor.open_deeplink") as mock_open:
             mock_open.return_value = True
@@ -305,8 +301,8 @@ class TestInstallCursor:
             args_str = " ".join(config_data["args"])
             assert args_str.count("numpy") == 1
             assert args_str.count("pandas") == 1
-            # fastmcp appears twice: once as --with fastmcp and once as the command
-            assert args_str.count("fastmcp") == 2
+            # fastmcp appears once in the command only (no longer automatically added as --with)
+            assert args_str.count("fastmcp") == 1
 
 
 class TestCursorCommand:

--- a/tests/cli/test_project_prepare.py
+++ b/tests/cli/test_project_prepare.py
@@ -1,0 +1,282 @@
+"""Tests for the fastmcp project prepare command."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fastmcp.utilities.fastmcp_config import Environment, FastMCPConfig
+from fastmcp.utilities.fastmcp_config.v1.sources.filesystem import FileSystemSource
+
+
+class TestFastMCPConfigPrepare:
+    """Test the FastMCPConfig.prepare() method."""
+
+    @patch(
+        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.FastMCPConfig.prepare_source",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.FastMCPConfig.prepare_environment",
+        new_callable=AsyncMock,
+    )
+    async def test_prepare_calls_both_methods(self, mock_env, mock_src):
+        """Test that prepare() calls both prepare_environment and prepare_source."""
+        config = FastMCPConfig(
+            source=FileSystemSource(path="server.py"),
+            environment=Environment(python="3.10"),
+        )
+
+        await config.prepare()
+
+        mock_env.assert_called_once()
+        mock_src.assert_called_once()
+
+    @patch(
+        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.FastMCPConfig.prepare_source",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.FastMCPConfig.prepare_environment",
+        new_callable=AsyncMock,
+    )
+    async def test_prepare_skip_env(self, mock_env, mock_src):
+        """Test that prepare() skips environment when skip_env=True."""
+        config = FastMCPConfig(
+            source=FileSystemSource(path="server.py"),
+            environment=Environment(python="3.10"),
+        )
+
+        await config.prepare(skip_env=True, skip_source=False)
+
+        mock_env.assert_not_called()
+        mock_src.assert_called_once()
+
+    @patch(
+        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.FastMCPConfig.prepare_source",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.FastMCPConfig.prepare_environment",
+        new_callable=AsyncMock,
+    )
+    async def test_prepare_skip_source(self, mock_env, mock_src):
+        """Test that prepare() skips source when skip_source=True."""
+        config = FastMCPConfig(
+            source=FileSystemSource(path="server.py"),
+            environment=Environment(python="3.10"),
+        )
+
+        await config.prepare(skip_env=False, skip_source=True)
+
+        mock_env.assert_called_once()
+        mock_src.assert_not_called()
+
+    @patch(
+        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.FastMCPConfig.prepare_source",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.FastMCPConfig.prepare_environment",
+        new_callable=AsyncMock,
+    )
+    async def test_prepare_skip_both(self, mock_env, mock_src):
+        """Test that prepare() skips both when both flags are True."""
+        config = FastMCPConfig(
+            source=FileSystemSource(path="server.py"),
+            environment=Environment(python="3.10"),
+        )
+
+        await config.prepare(skip_env=True, skip_source=True)
+
+        mock_env.assert_not_called()
+        mock_src.assert_not_called()
+
+
+class TestEnvironmentPrepare:
+    """Test the Environment.prepare() method."""
+
+    @patch("shutil.which")
+    async def test_prepare_no_uv_installed(self, mock_which):
+        """Test that prepare() raises error when uv is not installed."""
+        mock_which.return_value = None
+
+        env = Environment(python="3.10")
+
+        with pytest.raises(RuntimeError, match="uv is not installed"):
+            await env.prepare()
+
+    @patch("subprocess.run")
+    @patch("shutil.which")
+    async def test_prepare_no_settings(self, mock_which, mock_run):
+        """Test that prepare() does nothing when no settings are configured."""
+        mock_which.return_value = "/usr/bin/uv"
+
+        env = Environment()  # No settings
+
+        await env.prepare()
+
+        # Should not run any commands
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    @patch("shutil.which")
+    async def test_prepare_with_python(self, mock_which, mock_run):
+        """Test that prepare() runs uv with python version."""
+        mock_which.return_value = "/usr/bin/uv"
+        mock_run.return_value = MagicMock(returncode=0, stdout="Python 3.10", stderr="")
+
+        env = Environment(python="3.10")
+
+        await env.prepare()
+
+        # Should run uv with python version check
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args[0] == "uv"
+        assert "--python" in args
+        assert "3.10" in args
+
+    @patch("subprocess.run")
+    @patch("shutil.which")
+    async def test_prepare_with_dependencies(self, mock_which, mock_run):
+        """Test that prepare() includes dependencies."""
+        mock_which.return_value = "/usr/bin/uv"
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        env = Environment(dependencies=["numpy", "pandas"])
+
+        await env.prepare()
+
+        # Should include dependencies in uv command
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert "--with" in args
+        assert "numpy" in args
+        assert "pandas" in args
+
+    @patch("subprocess.run")
+    @patch("shutil.which")
+    async def test_prepare_command_fails(self, mock_which, mock_run):
+        """Test that prepare() raises error when uv command fails."""
+        mock_which.return_value = "/usr/bin/uv"
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, ["uv"], stderr="Package not found"
+        )
+
+        env = Environment(python="3.10")
+
+        with pytest.raises(RuntimeError, match="Environment preparation failed"):
+            await env.prepare()
+
+
+class TestProjectPrepareCommand:
+    """Test the CLI project prepare command."""
+
+    @patch("fastmcp.utilities.fastmcp_config.FastMCPConfig.from_file")
+    @patch("fastmcp.utilities.fastmcp_config.FastMCPConfig.find_config")
+    async def test_project_prepare_auto_detect(self, mock_find, mock_from_file):
+        """Test project prepare with auto-detected config."""
+        from fastmcp.cli.cli import prepare
+
+        # Setup mocks
+        mock_find.return_value = Path("fastmcp.json")
+        mock_config = AsyncMock()
+        mock_from_file.return_value = mock_config
+
+        # Run command with no args (should auto-detect)
+        with patch("sys.exit"):
+            with patch("fastmcp.cli.cli.console.print") as mock_print:
+                await prepare(config_path=None)
+
+        # Should find and load config
+        mock_find.assert_called_once()
+        mock_from_file.assert_called_once_with(Path("fastmcp.json"))
+
+        # Should call prepare with no skips
+        mock_config.prepare.assert_called_once_with(skip_env=False, skip_source=False)
+
+        # Should print success message
+        mock_print.assert_called()
+        success_call = mock_print.call_args_list[-1][0][0]
+        assert "Project prepared successfully" in success_call
+
+    @patch("pathlib.Path.exists")
+    @patch("fastmcp.utilities.fastmcp_config.FastMCPConfig.from_file")
+    async def test_project_prepare_explicit_path(self, mock_from_file, mock_exists):
+        """Test project prepare with explicit config path."""
+        from fastmcp.cli.cli import prepare
+
+        # Setup mocks
+        mock_exists.return_value = True
+        mock_config = AsyncMock()
+        mock_from_file.return_value = mock_config
+
+        # Run command with explicit path
+        with patch("fastmcp.cli.cli.console.print"):
+            await prepare(config_path="myconfig.json")
+
+        # Should load specified config
+        mock_from_file.assert_called_once_with(Path("myconfig.json"))
+
+        # Should call prepare
+        mock_config.prepare.assert_called_once_with(skip_env=False, skip_source=False)
+
+    @patch("fastmcp.utilities.fastmcp_config.FastMCPConfig.find_config")
+    async def test_project_prepare_no_config_found(self, mock_find):
+        """Test project prepare when no config is found."""
+        from fastmcp.cli.cli import prepare
+
+        # Setup mocks
+        mock_find.return_value = None
+
+        # Run command - should exit with error
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("fastmcp.cli.cli.logger.error") as mock_error:
+                await prepare(config_path=None)
+
+        assert exc_info.value.code == 1
+        mock_error.assert_called()
+        error_msg = mock_error.call_args[0][0]
+        assert "no fastmcp.json found" in error_msg
+
+    @patch("pathlib.Path.exists")
+    async def test_project_prepare_config_not_exists(self, mock_exists):
+        """Test project prepare when specified config doesn't exist."""
+        from fastmcp.cli.cli import prepare
+
+        # Setup mocks
+        mock_exists.return_value = False
+
+        # Run command - should exit with error
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("fastmcp.cli.cli.logger.error") as mock_error:
+                await prepare(config_path="missing.json")
+
+        assert exc_info.value.code == 1
+        mock_error.assert_called()
+        error_msg = mock_error.call_args[0][0]
+        assert "not found" in error_msg
+
+    @patch("pathlib.Path.exists")
+    @patch("fastmcp.utilities.fastmcp_config.FastMCPConfig.from_file")
+    async def test_project_prepare_failure(self, mock_from_file, mock_exists):
+        """Test project prepare when prepare() fails."""
+        from fastmcp.cli.cli import prepare
+
+        # Setup mocks
+        mock_exists.return_value = True
+        mock_config = AsyncMock()
+        mock_config.prepare.side_effect = RuntimeError("Preparation failed")
+        mock_from_file.return_value = mock_config
+
+        # Run command - should exit with error
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("fastmcp.cli.cli.console.print") as mock_print:
+                await prepare(config_path="config.json")
+
+        assert exc_info.value.code == 1
+        # Should print error message
+        error_call = mock_print.call_args_list[-1][0][0]
+        assert "Failed to prepare project" in error_call

--- a/tests/cli/test_project_prepare.py
+++ b/tests/cli/test_project_prepare.py
@@ -41,16 +41,17 @@ class TestFastMCPConfigPrepare:
         "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.FastMCPConfig.prepare_environment",
         new_callable=AsyncMock,
     )
-    async def test_prepare_skip_env(self, mock_env, mock_src):
-        """Test that prepare() skips environment when skip_env=True."""
+    async def test_prepare_with_output_dir(self, mock_env, mock_src):
+        """Test that prepare() with output_dir calls prepare_environment with it."""
         config = FastMCPConfig(
             source=FileSystemSource(path="server.py"),
             environment=Environment(python="3.10"),
         )
 
-        await config.prepare(skip_env=True, skip_source=False)
+        output_path = Path("/tmp/test-env")
+        await config.prepare(skip_source=False, output_dir=output_path)
 
-        mock_env.assert_not_called()
+        mock_env.assert_called_once_with(output_dir=output_path)
         mock_src.assert_called_once()
 
     @patch(
@@ -68,9 +69,9 @@ class TestFastMCPConfigPrepare:
             environment=Environment(python="3.10"),
         )
 
-        await config.prepare(skip_env=False, skip_source=True)
+        await config.prepare(skip_source=True)
 
-        mock_env.assert_called_once()
+        mock_env.assert_called_once_with(output_dir=None)
         mock_src.assert_not_called()
 
     @patch(
@@ -78,51 +79,52 @@ class TestFastMCPConfigPrepare:
         new_callable=AsyncMock,
     )
     @patch(
-        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.FastMCPConfig.prepare_environment",
+        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.Environment.prepare",
         new_callable=AsyncMock,
     )
-    async def test_prepare_skip_both(self, mock_env, mock_src):
-        """Test that prepare() skips both when both flags are True."""
+    async def test_prepare_no_environment_settings(self, mock_env_prepare, mock_src):
+        """Test that prepare() works with default empty environment config."""
         config = FastMCPConfig(
             source=FileSystemSource(path="server.py"),
-            environment=Environment(python="3.10"),
+            # environment defaults to empty Environment()
         )
 
-        await config.prepare(skip_env=True, skip_source=True)
+        await config.prepare(skip_source=False)
 
-        mock_env.assert_not_called()
-        mock_src.assert_not_called()
+        # Environment prepare should be called even with empty config
+        mock_env_prepare.assert_called_once_with(output_dir=None)
+        mock_src.assert_called_once()
 
 
 class TestEnvironmentPrepare:
     """Test the Environment.prepare() method."""
 
     @patch("shutil.which")
-    async def test_prepare_no_uv_installed(self, mock_which):
+    async def test_prepare_no_uv_installed(self, mock_which, tmp_path):
         """Test that prepare() raises error when uv is not installed."""
         mock_which.return_value = None
 
         env = Environment(python="3.10")
 
         with pytest.raises(RuntimeError, match="uv is not installed"):
-            await env.prepare()
+            await env.prepare(tmp_path / "test-env")
 
     @patch("subprocess.run")
     @patch("shutil.which")
-    async def test_prepare_no_settings(self, mock_which, mock_run):
+    async def test_prepare_no_settings(self, mock_which, mock_run, tmp_path):
         """Test that prepare() does nothing when no settings are configured."""
         mock_which.return_value = "/usr/bin/uv"
 
         env = Environment()  # No settings
 
-        await env.prepare()
+        await env.prepare(tmp_path / "test-env")
 
         # Should not run any commands
         mock_run.assert_not_called()
 
     @patch("subprocess.run")
     @patch("shutil.which")
-    async def test_prepare_with_python(self, mock_which, mock_run):
+    async def test_prepare_with_python(self, mock_which, mock_run, tmp_path):
         """Test that prepare() runs uv with python version."""
         mock_which.return_value = "/usr/bin/uv"
         mock_run.return_value = MagicMock(
@@ -131,39 +133,46 @@ class TestEnvironmentPrepare:
 
         env = Environment(python="3.10")
 
-        await env.prepare()
+        await env.prepare(tmp_path / "test-env")
 
-        # Should run uv with python version
-        mock_run.assert_called_once()
-        args = mock_run.call_args[0][0]
-        assert args[0] == "uv"
-        assert "--python" in args
-        assert "3.10" in args
-        # Should run a Python command to cache the environment
-        assert "python" in args
-        assert "-c" in args
+        # Should run multiple uv commands for initializing the project
+        assert mock_run.call_count > 0
+
+        # Check the first call should be uv init
+        first_call_args = mock_run.call_args_list[0][0][0]
+        assert first_call_args[0] == "uv"
+        assert "init" in first_call_args
 
     @patch("subprocess.run")
     @patch("shutil.which")
-    async def test_prepare_with_dependencies(self, mock_which, mock_run):
+    async def test_prepare_with_dependencies(self, mock_which, mock_run, tmp_path):
         """Test that prepare() includes dependencies."""
         mock_which.return_value = "/usr/bin/uv"
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
         env = Environment(dependencies=["numpy", "pandas"])
 
-        await env.prepare()
+        await env.prepare(tmp_path / "test-env")
 
-        # Should include dependencies in uv command
-        mock_run.assert_called_once()
-        args = mock_run.call_args[0][0]
-        assert "--with" in args
-        assert "numpy" in args
-        assert "pandas" in args
+        # Should run multiple uv commands, one of which should be uv add
+        assert mock_run.call_count > 0
+
+        # Find the add command call
+        add_call = None
+        for call_args, _ in mock_run.call_args_list:
+            args = call_args[0]
+            if "add" in args:
+                add_call = args
+                break
+
+        assert add_call is not None, "Should have called uv add"
+        assert "numpy" in add_call
+        assert "pandas" in add_call
+        assert "fastmcp" in add_call  # Always added
 
     @patch("subprocess.run")
     @patch("shutil.which")
-    async def test_prepare_command_fails(self, mock_which, mock_run):
+    async def test_prepare_command_fails(self, mock_which, mock_run, tmp_path):
         """Test that prepare() raises error when uv command fails."""
         mock_which.return_value = "/usr/bin/uv"
         mock_run.side_effect = subprocess.CalledProcessError(
@@ -172,8 +181,8 @@ class TestEnvironmentPrepare:
 
         env = Environment(python="3.10")
 
-        with pytest.raises(RuntimeError, match="Environment preparation failed"):
-            await env.prepare()
+        with pytest.raises(RuntimeError, match="Failed to initialize project"):
+            await env.prepare(tmp_path / "test-env")
 
 
 class TestProjectPrepareCommand:
@@ -190,17 +199,20 @@ class TestProjectPrepareCommand:
         mock_config = AsyncMock()
         mock_from_file.return_value = mock_config
 
-        # Run command with no args (should auto-detect)
+        # Run command with output_dir
         with patch("sys.exit"):
             with patch("fastmcp.cli.cli.console.print") as mock_print:
-                await prepare(config_path=None)
+                await prepare(config_path=None, output_dir="./test-env")
 
         # Should find and load config
         mock_find.assert_called_once()
         mock_from_file.assert_called_once_with(Path("fastmcp.json"))
 
-        # Should call prepare with no skips
-        mock_config.prepare.assert_called_once_with(skip_env=False, skip_source=False)
+        # Should call prepare with output_dir
+        mock_config.prepare.assert_called_once_with(
+            skip_source=False,
+            output_dir=Path("./test-env"),
+        )
 
         # Should print success message
         mock_print.assert_called()
@@ -220,13 +232,16 @@ class TestProjectPrepareCommand:
 
         # Run command with explicit path
         with patch("fastmcp.cli.cli.console.print"):
-            await prepare(config_path="myconfig.json")
+            await prepare(config_path="myconfig.json", output_dir="./test-env")
 
         # Should load specified config
         mock_from_file.assert_called_once_with(Path("myconfig.json"))
 
         # Should call prepare
-        mock_config.prepare.assert_called_once_with(skip_env=False, skip_source=False)
+        mock_config.prepare.assert_called_once_with(
+            skip_source=False,
+            output_dir=Path("./test-env"),
+        )
 
     @patch("fastmcp.utilities.fastmcp_config.FastMCPConfig.find_config")
     async def test_project_prepare_no_config_found(self, mock_find):
@@ -236,15 +251,15 @@ class TestProjectPrepareCommand:
         # Setup mocks
         mock_find.return_value = None
 
-        # Run command - should exit with error
+        # Run command without output_dir - should exit with error for missing output_dir
         with pytest.raises(SystemExit) as exc_info:
             with patch("fastmcp.cli.cli.logger.error") as mock_error:
-                await prepare(config_path=None)
+                await prepare(config_path=None, output_dir=None)
 
         assert exc_info.value.code == 1
         mock_error.assert_called()
         error_msg = mock_error.call_args[0][0]
-        assert "no fastmcp.json found" in error_msg
+        assert "--output-dir parameter is required" in error_msg
 
     @patch("pathlib.Path.exists")
     async def test_project_prepare_config_not_exists(self, mock_exists):
@@ -254,15 +269,15 @@ class TestProjectPrepareCommand:
         # Setup mocks
         mock_exists.return_value = False
 
-        # Run command - should exit with error
+        # Run command without output_dir - should exit with error for missing output_dir
         with pytest.raises(SystemExit) as exc_info:
             with patch("fastmcp.cli.cli.logger.error") as mock_error:
-                await prepare(config_path="missing.json")
+                await prepare(config_path="missing.json", output_dir=None)
 
         assert exc_info.value.code == 1
         mock_error.assert_called()
         error_msg = mock_error.call_args[0][0]
-        assert "not found" in error_msg
+        assert "--output-dir parameter is required" in error_msg
 
     @patch("pathlib.Path.exists")
     @patch("fastmcp.utilities.fastmcp_config.FastMCPConfig.from_file")
@@ -279,7 +294,7 @@ class TestProjectPrepareCommand:
         # Run command - should exit with error
         with pytest.raises(SystemExit) as exc_info:
             with patch("fastmcp.cli.cli.console.print") as mock_print:
-                await prepare(config_path="config.json")
+                await prepare(config_path="config.json", output_dir="./test-env")
 
         assert exc_info.value.code == 1
         # Should print error message

--- a/tests/cli/test_project_prepare.py
+++ b/tests/cli/test_project_prepare.py
@@ -125,18 +125,23 @@ class TestEnvironmentPrepare:
     async def test_prepare_with_python(self, mock_which, mock_run):
         """Test that prepare() runs uv with python version."""
         mock_which.return_value = "/usr/bin/uv"
-        mock_run.return_value = MagicMock(returncode=0, stdout="Python 3.10", stderr="")
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="Environment cached", stderr=""
+        )
 
         env = Environment(python="3.10")
 
         await env.prepare()
 
-        # Should run uv with python version check
+        # Should run uv with python version
         mock_run.assert_called_once()
         args = mock_run.call_args[0][0]
         assert args[0] == "uv"
         assert "--python" in args
         assert "3.10" in args
+        # Should run a Python command to cache the environment
+        assert "python" in args
+        assert "-c" in args
 
     @patch("subprocess.run")
     @patch("shutil.which")

--- a/tests/cli/test_run_config.py
+++ b/tests/cli/test_run_config.py
@@ -248,7 +248,7 @@ def test_environment_config_path_resolution(tmp_path):
         "environment": {
             "requirements": "requirements.txt",
             "project": ".",
-            "editable": "../other-project",
+            "editable": ["../other-project"],
         },
     }
 

--- a/tests/cli/test_run_with_uv.py
+++ b/tests/cli/test_run_with_uv.py
@@ -12,12 +12,8 @@ from fastmcp.cli.run import run_with_uv
 class TestRunWithUv:
     """Test the run_with_uv function."""
 
-    @patch(
-        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.Environment._find_fastmcp_dev_path",
-        return_value=None,
-    )
     @patch("subprocess.run")
-    def test_run_with_uv_basic(self, mock_run, mock_find_dev_path):
+    def test_run_with_uv_basic(self, mock_run):
         """Test basic run_with_uv execution."""
         mock_run.return_value = Mock(returncode=0)
 
@@ -33,21 +29,15 @@ class TestRunWithUv:
         expected = [
             "uv",
             "run",
-            "--with",
-            "fastmcp",
             "fastmcp",
             "run",
-            "server.py",
             "--skip-env",
+            "server.py",
         ]
         assert cmd == expected
 
-    @patch(
-        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.Environment._find_fastmcp_dev_path",
-        return_value=None,
-    )
     @patch("subprocess.run")
-    def test_run_with_uv_python_version(self, mock_run, mock_find_dev_path):
+    def test_run_with_uv_python_version(self, mock_run):
         """Test run_with_uv with Python version."""
         mock_run.return_value = Mock(returncode=0)
 
@@ -62,21 +52,15 @@ class TestRunWithUv:
             "run",
             "--python",
             "3.11",
-            "--with",
-            "fastmcp",
             "fastmcp",
             "run",
-            "server.py",
             "--skip-env",
+            "server.py",
         ]
         assert cmd == expected
 
-    @patch(
-        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.Environment._find_fastmcp_dev_path",
-        return_value=None,
-    )
     @patch("subprocess.run")
-    def test_run_with_uv_project(self, mock_run, mock_find_dev_path):
+    def test_run_with_uv_project(self, mock_run):
         """Test run_with_uv with project directory."""
         mock_run.return_value = Mock(returncode=0)
         # Use an absolute path that works on all platforms
@@ -94,20 +78,14 @@ class TestRunWithUv:
         assert Path(cmd[3]).is_absolute()
         # Check the rest of the command
         assert cmd[4:] == [
-            "--with",
-            "fastmcp",
             "fastmcp",
             "run",
-            "server.py",
             "--skip-env",
+            "server.py",
         ]
 
-    @patch(
-        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.Environment._find_fastmcp_dev_path",
-        return_value=None,
-    )
     @patch("subprocess.run")
-    def test_run_with_uv_with_packages(self, mock_run, mock_find_dev_path):
+    def test_run_with_uv_with_packages(self, mock_run):
         """Test run_with_uv with additional packages."""
         mock_run.return_value = Mock(returncode=0)
 
@@ -121,24 +99,18 @@ class TestRunWithUv:
             "uv",
             "run",
             "--with",
-            "fastmcp",
-            "--with",
             "pandas",  # original order preserved
             "--with",
             "numpy",  # original order preserved
             "fastmcp",
             "run",
-            "server.py",
             "--skip-env",
+            "server.py",
         ]
         assert cmd == expected
 
-    @patch(
-        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.Environment._find_fastmcp_dev_path",
-        return_value=None,
-    )
     @patch("subprocess.run")
-    def test_run_with_uv_with_requirements(self, mock_run, mock_find_dev_path):
+    def test_run_with_uv_with_requirements(self, mock_run):
         """Test run_with_uv with requirements file."""
         mock_run.return_value = Mock(returncode=0)
         req_path = Path("requirements.txt")
@@ -152,23 +124,17 @@ class TestRunWithUv:
         expected = [
             "uv",
             "run",
-            "--with",
-            "fastmcp",
             "--with-requirements",
             str(req_path.resolve()),  # auto-resolved to absolute path
             "fastmcp",
             "run",
-            "server.py",
             "--skip-env",
+            "server.py",
         ]
         assert cmd == expected
 
-    @patch(
-        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.Environment._find_fastmcp_dev_path",
-        return_value=None,
-    )
     @patch("subprocess.run")
-    def test_run_with_uv_transport_options(self, mock_run, mock_find_dev_path):
+    def test_run_with_uv_transport_options(self, mock_run):
         """Test run_with_uv with transport-related options."""
         mock_run.return_value = Mock(returncode=0)
 
@@ -189,12 +155,10 @@ class TestRunWithUv:
         expected = [
             "uv",
             "run",
-            "--with",
-            "fastmcp",
             "fastmcp",
             "run",
-            "server.py",
             "--skip-env",
+            "server.py",
             "--transport",
             "http",
             "--host",
@@ -209,12 +173,8 @@ class TestRunWithUv:
         ]
         assert cmd == expected
 
-    @patch(
-        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.Environment._find_fastmcp_dev_path",
-        return_value=None,
-    )
     @patch("subprocess.run")
-    def test_run_with_uv_all_options(self, mock_run, mock_find_dev_path):
+    def test_run_with_uv_all_options(self, mock_run):
         """Test run_with_uv with all options combined."""
         mock_run.return_value = Mock(returncode=0)
 
@@ -237,20 +197,31 @@ class TestRunWithUv:
 
         cmd = mock_run.call_args[0][0]
 
-        # Check the structure piece by piece to be platform-agnostic
-        assert cmd[:5] == ["uv", "run", "--python", "3.10", "--project"]
-        # Check project path is absolute
-        assert Path(cmd[5]).is_absolute()
-        assert cmd[6:10] == ["--with", "fastmcp", "--with", "pandas"]
-        assert cmd[10] == "--with-requirements"
-        # Check requirements path is now auto-resolved to absolute
-        assert Path(cmd[11]).is_absolute()
-        assert Path(cmd[11]).name == "reqs.txt"
-        assert cmd[12:] == [
+        # When project is specified, Python version is not included
+        # Build expected command step by step
+        expected_start = ["uv", "run", "--project"]
+
+        # Check start and that project path is absolute
+        assert cmd[:3] == expected_start
+        assert Path(cmd[3]).is_absolute()
+
+        # Find the index where packages and requirements start
+        next_idx = 4
+        assert cmd[next_idx : next_idx + 2] == ["--with", "pandas"]
+        next_idx += 2
+        assert cmd[next_idx : next_idx + 1] == ["--with-requirements"]
+        next_idx += 1
+        # Check requirements path is absolute
+        assert Path(cmd[next_idx]).is_absolute()
+        assert Path(cmd[next_idx]).name == "reqs.txt"
+        next_idx += 1
+
+        # Rest should be the fastmcp command with options
+        assert cmd[next_idx:] == [
             "fastmcp",
             "run",
-            "server.py",
             "--skip-env",
+            "server.py",
             "--transport",
             "http",
             "--port",
@@ -258,12 +229,8 @@ class TestRunWithUv:
             "--no-banner",
         ]
 
-    @patch(
-        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.Environment._find_fastmcp_dev_path",
-        return_value=None,
-    )
     @patch("subprocess.run")
-    def test_run_with_uv_error_handling(self, mock_run, mock_find_dev_path):
+    def test_run_with_uv_error_handling(self, mock_run):
         """Test run_with_uv error handling."""
         mock_run.side_effect = subprocess.CalledProcessError(1, ["uv", "run"])
 
@@ -272,13 +239,9 @@ class TestRunWithUv:
 
         assert exc_info.value.code == 1
 
-    @patch(
-        "fastmcp.utilities.fastmcp_config.v1.fastmcp_config.Environment._find_fastmcp_dev_path",
-        return_value=None,
-    )
     @patch("fastmcp.cli.run.logger")
     @patch("subprocess.run")
-    def test_run_with_uv_logging(self, mock_run, mock_logger, mock_find_dev_path):
+    def test_run_with_uv_logging(self, mock_run, mock_logger):
         """Test that run_with_uv logs the command."""
         mock_run.return_value = Mock(returncode=0)
 

--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -1,5 +1,4 @@
-from pathlib import Path
-from unittest.mock import patch
+"""Tests for CLI utility functions."""
 
 from fastmcp.utilities.fastmcp_config.v1.fastmcp_config import Environment
 
@@ -7,24 +6,20 @@ from fastmcp.utilities.fastmcp_config.v1.fastmcp_config import Environment
 class TestEnvironmentBuildUVArgs:
     """Test the Environment.build_uv_args() method."""
 
-    @patch.object(Environment, "_find_fastmcp_dev_path", return_value=None)
-    def test_build_uv_args_basic(self, mock_dev_path):
-        """Test building basic uv args."""
+    def test_build_uv_args_basic(self):
+        """Test building basic uv args with no environment config."""
         env = Environment()
         args = env.build_uv_args(["fastmcp", "run", "server.py"])
-        expected = ["run", "--with", "fastmcp", "fastmcp", "run", "server.py"]
+        expected = ["run", "fastmcp", "run", "server.py"]
         assert args == expected
 
-    @patch.object(Environment, "_find_fastmcp_dev_path", return_value=None)
-    def test_build_uv_args_with_editable(self, mock_dev_path):
+    def test_build_uv_args_with_editable(self):
         """Test building uv args with editable package."""
         editable_path = "/path/to/package"
-        env = Environment(editable=editable_path)
+        env = Environment(editable=[editable_path])
         args = env.build_uv_args(["fastmcp", "run", "server.py"])
         expected = [
             "run",
-            "--with",
-            "fastmcp",
             "--with-editable",
             editable_path,
             "fastmcp",
@@ -33,15 +28,12 @@ class TestEnvironmentBuildUVArgs:
         ]
         assert args == expected
 
-    @patch.object(Environment, "_find_fastmcp_dev_path", return_value=None)
-    def test_build_uv_args_with_packages(self, mock_dev_path):
+    def test_build_uv_args_with_packages(self):
         """Test building uv args with additional packages."""
         env = Environment(dependencies=["pkg1", "pkg2"])
         args = env.build_uv_args(["fastmcp", "run", "server.py"])
         expected = [
             "run",
-            "--with",
-            "fastmcp",
             "--with",
             "pkg1",
             "--with",
@@ -52,81 +44,58 @@ class TestEnvironmentBuildUVArgs:
         ]
         assert args == expected
 
-    @patch.object(Environment, "_find_fastmcp_dev_path", return_value=None)
-    def test_build_uv_args_with_python_version(self, mock_dev_path):
+    def test_build_uv_args_with_python_version(self):
         """Test building uv args with Python version."""
-        env = Environment(python="3.11")
+        env = Environment(python="3.10")
         args = env.build_uv_args(["fastmcp", "run", "server.py"])
         expected = [
             "run",
             "--python",
-            "3.11",
-            "--with",
-            "fastmcp",
+            "3.10",
             "fastmcp",
             "run",
             "server.py",
         ]
         assert args == expected
 
-    @patch.object(Environment, "_find_fastmcp_dev_path", return_value=None)
-    def test_build_uv_args_with_project(self, mock_dev_path):
+    def test_build_uv_args_with_requirements(self):
+        """Test building uv args with requirements file."""
+        requirements_path = "/path/to/requirements.txt"
+        env = Environment(requirements=requirements_path)
+        args = env.build_uv_args(["fastmcp", "run", "server.py"])
+        expected = [
+            "run",
+            "--with-requirements",
+            requirements_path,
+            "fastmcp",
+            "run",
+            "server.py",
+        ]
+        assert args == expected
+
+    def test_build_uv_args_with_project(self):
         """Test building uv args with project directory."""
         project_path = "/path/to/project"
         env = Environment(project=project_path)
         args = env.build_uv_args(["fastmcp", "run", "server.py"])
-        expected = [
-            "run",
-            "--project",
-            project_path,
-            "--with",
-            "fastmcp",
-            "fastmcp",
-            "run",
-            "server.py",
-        ]
+        expected = ["run", "--project", project_path, "fastmcp", "run", "server.py"]
         assert args == expected
 
-    @patch.object(Environment, "_find_fastmcp_dev_path", return_value=None)
-    def test_build_uv_args_with_requirements(self, mock_dev_path):
-        """Test building uv args with requirements file."""
-        req_path = "requirements.txt"
-        env = Environment(requirements=req_path)
-        args = env.build_uv_args(["fastmcp", "run", "server.py"])
-        expected = [
-            "run",
-            "--with",
-            "fastmcp",
-            "--with-requirements",
-            req_path,
-            "fastmcp",
-            "run",
-            "server.py",
-        ]
-        assert args == expected
-
-    @patch.object(Environment, "_find_fastmcp_dev_path", return_value=None)
-    def test_build_uv_args_with_all_options(self, mock_dev_path):
+    def test_build_uv_args_with_everything(self):
         """Test building uv args with all options."""
-        project_path = "/my/project"
+        requirements_path = "/path/to/requirements.txt"
         editable_path = "/local/pkg"
-        requirements_path = "reqs.txt"
         env = Environment(
             python="3.10",
-            project=project_path,
             dependencies=["pandas", "numpy"],
             requirements=requirements_path,
-            editable=editable_path,
+            editable=[editable_path],
         )
         args = env.build_uv_args(["fastmcp", "run", "server.py"])
         expected = [
             "run",
             "--python",
             "3.10",
-            "--project",
-            project_path,
-            "--with",
-            "fastmcp",
             "--with",
             "pandas",
             "--with",
@@ -141,130 +110,79 @@ class TestEnvironmentBuildUVArgs:
         ]
         assert args == expected
 
-    @patch.object(Environment, "_find_fastmcp_dev_path", return_value=None)
-    def test_build_uv_args_no_command(self, mock_dev_path):
-        """Test building uv args with no command."""
-        env = Environment(python="3.11")
+    def test_build_uv_args_no_command(self):
+        """Test building uv args without command."""
+        env = Environment(dependencies=["pkg1"])
         args = env.build_uv_args()
-        expected = ["run", "--python", "3.11", "--with", "fastmcp"]
+        expected = ["run", "--with", "pkg1"]
         assert args == expected
 
-    @patch.object(Environment, "_find_fastmcp_dev_path", return_value=None)
-    def test_build_uv_args_string_command(self, mock_dev_path):
+    def test_build_uv_args_with_string_command(self):
         """Test building uv args with string command."""
         env = Environment()
         args = env.build_uv_args("python")
-        expected = ["run", "--with", "fastmcp", "python"]
+        expected = ["run", "python"]
         assert args == expected
 
-    def test_needs_uv_true(self):
-        """Test that needs_uv returns True when environment settings are present."""
-        env = Environment(python="3.11")
-        assert env.needs_uv() is True
-
-        env = Environment(dependencies=["pkg"])
-        assert env.needs_uv() is True
-
-        env = Environment(requirements="reqs.txt")
-        assert env.needs_uv() is True
-
-        env = Environment(project="/project")
-        assert env.needs_uv() is True
-
-        env = Environment(editable="/pkg")
-        assert env.needs_uv() is True
-
-    def test_needs_uv_false(self):
-        """Test that needs_uv returns False when no environment settings are present."""
-        env = Environment()
-        assert env.needs_uv() is False
-
-    @patch.object(Environment, "_find_fastmcp_dev_path")
-    def test_build_uv_args_development_mode(self, mock_dev_path):
-        """Test building uv args in development mode (when fastmcp project is found)."""
-        # Mock finding the development path
-        dev_path = Path("/path/to/fastmcp/dev")
-        mock_dev_path.return_value = dev_path
-
-        env = Environment()
+    def test_build_uv_args_project_with_extras(self):
+        """Test that project flag works with additional dependencies."""
+        project_path = "/path/to/project"
+        env = Environment(
+            project=project_path,
+            python="3.10",  # Should be ignored with project
+            dependencies=["pandas"],  # Should be added on top of project
+            editable=["/pkg"],  # Should be added on top of project
+        )
         args = env.build_uv_args(["fastmcp", "run", "server.py"])
         expected = [
             "run",
+            "--project",
+            project_path,
+            "--with",
+            "pandas",
             "--with-editable",
-            str(dev_path),
+            "/pkg",
             "fastmcp",
             "run",
             "server.py",
         ]
         assert args == expected
 
-    @patch.object(Environment, "_find_fastmcp_dev_path")
-    def test_build_uv_args_production_mode(self, mock_dev_path):
-        """Test building uv args in production mode (when no fastmcp project is found)."""
-        # Mock not finding the development path
-        mock_dev_path.return_value = None
 
+class TestEnvironmentNeedsUV:
+    """Test the Environment.needs_uv() method."""
+
+    def test_needs_uv_with_python(self):
+        """Test that needs_uv returns True with Python version."""
+        env = Environment(python="3.10")
+        assert env.needs_uv() is True
+
+    def test_needs_uv_with_dependencies(self):
+        """Test that needs_uv returns True with dependencies."""
+        env = Environment(dependencies=["pandas"])
+        assert env.needs_uv() is True
+
+    def test_needs_uv_with_requirements(self):
+        """Test that needs_uv returns True with requirements."""
+        env = Environment(requirements="/path/to/requirements.txt")
+        assert env.needs_uv() is True
+
+    def test_needs_uv_with_project(self):
+        """Test that needs_uv returns True with project."""
+        env = Environment(project="/path/to/project")
+        assert env.needs_uv() is True
+
+    def test_needs_uv_with_editable(self):
+        """Test that needs_uv returns True with editable."""
+        env = Environment(editable=["/pkg"])
+        assert env.needs_uv() is True
+
+    def test_needs_uv_empty(self):
+        """Test that needs_uv returns False with empty config."""
         env = Environment()
-        args = env.build_uv_args(["fastmcp", "run", "server.py"])
-        expected = ["run", "--with", "fastmcp", "fastmcp", "run", "server.py"]
-        assert args == expected
+        assert env.needs_uv() is False
 
-    @patch("pathlib.Path.cwd")
-    @patch("pathlib.Path.exists")
-    @patch("pathlib.Path.read_text")
-    def test_find_fastmcp_dev_path_found(self, mock_read_text, mock_exists, mock_cwd):
-        """Test finding fastmcp development path when pyproject.toml exists."""
-        # Set up mock current directory
-        mock_cwd_path = Path("/path/to/fastmcp")
-        mock_cwd.return_value = mock_cwd_path
-
-        # Mock pyproject.toml exists and contains fastmcp name
-        mock_exists.return_value = True
-        mock_read_text.return_value = """[project]
-name = "fastmcp"
-version = "2.0.0"
-"""
-
-        env = Environment()
-        result = env._find_fastmcp_dev_path()
-
-        assert result == mock_cwd_path
-
-    @patch("pathlib.Path.cwd")
-    @patch("pathlib.Path.exists")
-    def test_find_fastmcp_dev_path_not_found(self, mock_exists, mock_cwd):
-        """Test not finding fastmcp development path when no pyproject.toml exists."""
-        # Set up mock current directory
-        mock_cwd_path = Path("/some/other/directory")
-        mock_cwd.return_value = mock_cwd_path
-
-        # Mock pyproject.toml doesn't exist
-        mock_exists.return_value = False
-
-        env = Environment()
-        result = env._find_fastmcp_dev_path()
-
-        assert result is None
-
-    @patch("pathlib.Path.cwd")
-    @patch("pathlib.Path.exists")
-    @patch("pathlib.Path.read_text")
-    def test_find_fastmcp_dev_path_wrong_project(
-        self, mock_read_text, mock_exists, mock_cwd
-    ):
-        """Test not finding fastmcp when pyproject.toml exists but is for different project."""
-        # Set up mock current directory
-        mock_cwd_path = Path("/path/to/other/project")
-        mock_cwd.return_value = mock_cwd_path
-
-        # Mock pyproject.toml exists but is for different project
-        mock_exists.return_value = True
-        mock_read_text.return_value = """[project]
-name = "other-project"
-version = "1.0.0"
-"""
-
-        env = Environment()
-        result = env._find_fastmcp_dev_path()
-
-        assert result is None
+    def test_needs_uv_with_empty_lists(self):
+        """Test that needs_uv returns False with empty lists."""
+        env = Environment(dependencies=None, editable=None)
+        assert env.needs_uv() is False


### PR DESCRIPTION
This PR refines the fastmcp.json environment configuration story, particularly around editable packages and project-based deployments. These changes emerged from real-world usage patterns where users need to prepare environments in CI/CD pipelines and work with multiple editable packages simultaneously.

## Core Changes

### 1. Multiple Editable Packages Support
The `environment.editable` field in fastmcp.json now accepts a list of paths instead of a single string:

```json
{
  "environment": {
    "dependencies": ["pandas", "numpy"],
    "editable": [".", "../shared-lib", "/path/to/dev-package"]
  }
}
```

This enables development workflows where multiple packages need to be installed in editable mode, a common pattern when working with monorepos or shared libraries.

### 2. Fixed --project Behavior  
Previously, using `--project` would completely ignore any additional dependencies from the config file or CLI flags. Now it correctly layers dependencies:

```bash
# This now works as expected - uses project env PLUS prefect from config
fastmcp run config.json --project ./prepared-env

# Can also add more dependencies on top
fastmcp run server.py --project ./prepared-env --with httpx
```

The `--project` flag sets the base environment, and additional dependencies are added via `--with` flags to uv.

### 3. Robust Environment Preparation
The `fastmcp project prepare` command now handles existing environments gracefully:
- Continues if a project is already initialized (rather than failing)
- Always includes fastmcp as a dependency in prepared environments
- Supports the full list of editable packages from config

### 4. Removed Auto-Detection of Dev FastMCP
Previously, the system would auto-detect and use an editable fastmcp installation if running from within the fastmcp repository. This magic behavior has been removed in favor of explicit configuration:

- If running from a venv with editable fastmcp, that version is used naturally
- If you want a specific editable version, add it to your config's `editable` list
- Prepared environments always include fastmcp (from PyPI or editable as configured)

## Two-Phase Deployment Pattern

These changes solidify support for the two-phase deployment pattern that's crucial for CI/CD:

**Phase 1: Prepare** (slow, during build)
```bash
fastmcp project prepare config.json --output-dir ./env
```

**Phase 2: Run** (fast, during deployment)  
```bash
fastmcp run config.json --project ./env
```

The prepared environment is a complete uv project with lockfile, making the run phase deterministic and fast.

## Implementation Details

- `Environment.editable` is now `list[str] | None` throughout the codebase
- CLI commands still accept single `--with-editable` for simplicity (multi-flag support can be added later if needed)
- All 173 CLI tests have been updated and are passing
- The JSON schema has been regenerated to reflect the new structure
- `Environment.prepare()` now requires an explicit `output_dir` parameter (returns immediately if no environment config exists)

## Breaking Changes

While most changes are backward compatible, there are two minor breaking changes:

1. `Environment.editable` type changed from `str | None` to `list[str] | None` - affects direct API usage only
2. `Environment.prepare()` now requires `output_dir` parameter - affects direct API usage only

Config files with single editable strings will need to be updated to use lists:
```json
// Before
"editable": "../my-package"

// After  
"editable": ["../my-package"]
```

## Testing

All tests have been updated to reflect the new behavior. Key test changes:
- Removed expectations of automatic `--with fastmcp` injection
- Updated editable field handling throughout
- Fixed command structure expectations in uv-related tests
- Added tests for multiple editable packages
- Verified --project with additional dependencies works correctly