### PR TITLE
feat: support comma separated oauth scopes

### DIFF
--- a/docs/integrations/azure.mdx
+++ b/docs/integrations/azure.mdx
@@ -212,7 +212,7 @@ Redirect path configured in your Azure App registration
 </ParamField>
 
 <ParamField path="FASTMCP_SERVER_AUTH_AZURE_REQUIRED_SCOPES" default='["User.Read", "email", "openid", "profile"]'>
-Comma-separated list of required Microsoft Graph scopes
+Comma-, space-, or JSON-separated list of required Microsoft Graph scopes
 </ParamField>
 
 <ParamField path="FASTMCP_SERVER_AUTH_AZURE_TIMEOUT_SECONDS" default="10">

--- a/docs/integrations/github.mdx
+++ b/docs/integrations/github.mdx
@@ -169,7 +169,7 @@ Redirect path configured in your GitHub OAuth App
 </ParamField>
 
 <ParamField path="FASTMCP_SERVER_AUTH_GITHUB_REQUIRED_SCOPES" default='["user"]'>
-Comma-separated list of required GitHub scopes (e.g., `user,repo`)
+Comma-, space-, or JSON-separated list of required GitHub scopes (e.g., `user repo` or `["user","repo"]`)
 </ParamField>
 
 <ParamField path="FASTMCP_SERVER_AUTH_GITHUB_TIMEOUT_SECONDS" default="10">

--- a/docs/integrations/google.mdx
+++ b/docs/integrations/google.mdx
@@ -179,7 +179,7 @@ Redirect path configured in your Google OAuth Client
 </ParamField>
 
 <ParamField path="FASTMCP_SERVER_AUTH_GOOGLE_REQUIRED_SCOPES" default="[]">
-Comma-separated list of required Google scopes (e.g., `openid`)
+Comma-, space-, or JSON-separated list of required Google scopes (e.g., `openid,profile` or `["openid","profile"]`)
 </ParamField>
 
 <ParamField path="FASTMCP_SERVER_AUTH_GOOGLE_TIMEOUT_SECONDS" default="10">

--- a/docs/integrations/workos-oauth.mdx
+++ b/docs/integrations/workos-oauth.mdx
@@ -166,7 +166,7 @@ Redirect path configured in your WorkOS OAuth App
 </ParamField>
 
 <ParamField path="FASTMCP_SERVER_AUTH_WORKOS_REQUIRED_SCOPES" default="[]">
-List of required OAuth scopes (e.g., `["openid", "profile", "email"]`)
+Comma-, space-, or JSON-separated list of required OAuth scopes (e.g., `openid profile email` or `["openid","profile","email"]`)
 </ParamField>
 
 <ParamField path="FASTMCP_SERVER_AUTH_WORKOS_TIMEOUT_SECONDS" default="10">

--- a/src/fastmcp/server/auth/providers/azure.py
+++ b/src/fastmcp/server/auth/providers/azure.py
@@ -7,12 +7,13 @@ using the OAuth Proxy pattern for non-DCR OAuth flows.
 from __future__ import annotations
 
 import httpx
-from pydantic import SecretStr
+from pydantic import SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from fastmcp.server.auth import AccessToken, TokenVerifier
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.registry import register_provider
+from fastmcp.utilities.auth import parse_scopes
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import NotSet, NotSetT
 
@@ -35,6 +36,11 @@ class AzureProviderSettings(BaseSettings):
     redirect_path: str | None = None
     required_scopes: list[str] | None = None
     timeout_seconds: int | None = None
+
+    @field_validator("required_scopes", mode="before")
+    @classmethod
+    def _parse_scopes(cls, v):
+        return parse_scopes(v)
 
 
 class AzureTokenVerifier(TokenVerifier):

--- a/src/fastmcp/server/auth/providers/github.py
+++ b/src/fastmcp/server/auth/providers/github.py
@@ -22,13 +22,14 @@ Example:
 from __future__ import annotations
 
 import httpx
-from pydantic import AnyHttpUrl, SecretStr
+from pydantic import AnyHttpUrl, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from fastmcp.server.auth import TokenVerifier
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.registry import register_provider
+from fastmcp.utilities.auth import parse_scopes
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import NotSet, NotSetT
 
@@ -50,6 +51,11 @@ class GitHubProviderSettings(BaseSettings):
     redirect_path: str | None = None
     required_scopes: list[str] | None = None
     timeout_seconds: int | None = None
+
+    @field_validator("required_scopes", mode="before")
+    @classmethod
+    def _parse_scopes(cls, v):
+        return parse_scopes(v)
 
 
 class GitHubTokenVerifier(TokenVerifier):

--- a/src/fastmcp/server/auth/providers/google.py
+++ b/src/fastmcp/server/auth/providers/google.py
@@ -24,13 +24,14 @@ from __future__ import annotations
 import time
 
 import httpx
-from pydantic import AnyHttpUrl, SecretStr
+from pydantic import AnyHttpUrl, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from fastmcp.server.auth import TokenVerifier
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.registry import register_provider
+from fastmcp.utilities.auth import parse_scopes
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import NotSet, NotSetT
 
@@ -52,6 +53,11 @@ class GoogleProviderSettings(BaseSettings):
     redirect_path: str | None = None
     required_scopes: list[str] | None = None
     timeout_seconds: int | None = None
+
+    @field_validator("required_scopes", mode="before")
+    @classmethod
+    def _parse_scopes(cls, v):
+        return parse_scopes(v)
 
 
 class GoogleTokenVerifier(TokenVerifier):

--- a/src/fastmcp/server/auth/providers/jwt.py
+++ b/src/fastmcp/server/auth/providers/jwt.py
@@ -11,12 +11,13 @@ from authlib.jose import JsonWebKey, JsonWebToken
 from authlib.jose.errors import JoseError
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from pydantic import AnyHttpUrl, SecretStr
+from pydantic import AnyHttpUrl, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import TypedDict
 
 from fastmcp.server.auth import AccessToken, TokenVerifier
 from fastmcp.server.auth.registry import register_provider
+from fastmcp.utilities.auth import parse_scopes
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import NotSet, NotSetT
 
@@ -154,6 +155,11 @@ class JWTVerifierSettings(BaseSettings):
     audience: str | list[str] | None = None
     required_scopes: list[str] | None = None
     resource_server_url: AnyHttpUrl | str | None = None
+
+    @field_validator("required_scopes", mode="before")
+    @classmethod
+    def _parse_scopes(cls, v):
+        return parse_scopes(v)
 
 
 @register_provider("JWT")

--- a/src/fastmcp/server/auth/providers/workos.py
+++ b/src/fastmcp/server/auth/providers/workos.py
@@ -11,7 +11,7 @@ Choose based on your WorkOS setup and authentication requirements.
 from __future__ import annotations
 
 import httpx
-from pydantic import AnyHttpUrl, SecretStr
+from pydantic import AnyHttpUrl, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from starlette.responses import JSONResponse
 from starlette.routing import Route
@@ -20,6 +20,7 @@ from fastmcp.server.auth import AccessToken, RemoteAuthProvider, TokenVerifier
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from fastmcp.server.auth.registry import register_provider
+from fastmcp.utilities.auth import parse_scopes
 from fastmcp.utilities.logging import get_logger
 from fastmcp.utilities.types import NotSet, NotSetT
 
@@ -42,6 +43,11 @@ class WorkOSProviderSettings(BaseSettings):
     redirect_path: str | None = None
     required_scopes: list[str] | None = None
     timeout_seconds: int | None = None
+
+    @field_validator("required_scopes", mode="before")
+    @classmethod
+    def _parse_scopes(cls, v):
+        return parse_scopes(v)
 
 
 class WorkOSTokenVerifier(TokenVerifier):
@@ -254,6 +260,11 @@ class AuthKitProviderSettings(BaseSettings):
     authkit_domain: AnyHttpUrl
     base_url: AnyHttpUrl
     required_scopes: list[str] | None = None
+
+    @field_validator("required_scopes", mode="before")
+    @classmethod
+    def _parse_scopes(cls, v):
+        return parse_scopes(v)
 
 
 @register_provider("AUTHKIT")

--- a/src/fastmcp/utilities/auth.py
+++ b/src/fastmcp/utilities/auth.py
@@ -1,0 +1,34 @@
+"""Authentication utility helpers."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def parse_scopes(value: Any) -> list[str] | None:
+    """Parse scopes from environment variables or settings values.
+
+    Accepts either a JSON array string, a comma- or space-separated string,
+    a list of strings, or ``None``. Returns a list of scopes or ``None`` if
+    no value is provided.
+    """
+    if value is None or value == "":
+        return None if value is None else []
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return []
+        # Try JSON array first
+        if value.startswith("["):
+            try:
+                data = json.loads(value)
+                if isinstance(data, list):
+                    return [str(v).strip() for v in data if str(v).strip()]
+            except Exception:
+                pass
+        # Fallback to comma/space separated list
+        return [s.strip() for s in value.replace(",", " ").split() if s.strip()]
+    return value

--- a/tests/server/auth/providers/test_github.py
+++ b/tests/server/auth/providers/test_github.py
@@ -83,7 +83,14 @@ class TestGitHubProvider:
         )  # URLs get normalized with trailing slash
         assert provider._redirect_path == "/custom/callback"
 
-    def test_init_with_env_vars(self):
+    @pytest.mark.parametrize(
+        "scopes_env",
+        [
+            "user,repo",
+            '["user", "repo"]',
+        ],
+    )
+    def test_init_with_env_vars(self, scopes_env):
         """Test initialization with environment variables."""
         with patch.dict(
             os.environ,
@@ -91,6 +98,7 @@ class TestGitHubProvider:
                 "FASTMCP_SERVER_AUTH_GITHUB_CLIENT_ID": "env_client_id",
                 "FASTMCP_SERVER_AUTH_GITHUB_CLIENT_SECRET": "env_secret",
                 "FASTMCP_SERVER_AUTH_GITHUB_BASE_URL": "https://env-example.com",
+                "FASTMCP_SERVER_AUTH_GITHUB_REQUIRED_SCOPES": scopes_env,
             },
         ):
             provider = GitHubProvider()
@@ -98,6 +106,7 @@ class TestGitHubProvider:
             assert provider._upstream_client_id == "env_client_id"
             assert provider._upstream_client_secret.get_secret_value() == "env_secret"
             assert str(provider.base_url) == "https://env-example.com/"
+            assert provider._token_validator.required_scopes == ["user", "repo"]
 
     def test_init_explicit_overrides_env(self):
         """Test that explicit parameters override environment variables."""

--- a/tests/server/auth/providers/test_workos.py
+++ b/tests/server/auth/providers/test_workos.py
@@ -26,7 +26,14 @@ class TestWorkOSProvider:
         assert provider._upstream_client_secret.get_secret_value() == "secret_test456"
         assert str(provider.base_url) == "https://myserver.com/"
 
-    def test_init_with_env_vars(self):
+    @pytest.mark.parametrize(
+        "scopes_env",
+        [
+            "openid,email",
+            '["openid", "email"]',
+        ],
+    )
+    def test_init_with_env_vars(self, scopes_env):
         """Test WorkOSProvider initialization from environment variables."""
         with patch.dict(
             os.environ,
@@ -35,7 +42,7 @@ class TestWorkOSProvider:
                 "FASTMCP_SERVER_AUTH_WORKOS_CLIENT_SECRET": "env_secret",
                 "FASTMCP_SERVER_AUTH_WORKOS_AUTHKIT_DOMAIN": "https://env.authkit.app",
                 "FASTMCP_SERVER_AUTH_WORKOS_BASE_URL": "https://envserver.com",
-                "FASTMCP_SERVER_AUTH_WORKOS_REQUIRED_SCOPES": '["openid", "email"]',
+                "FASTMCP_SERVER_AUTH_WORKOS_REQUIRED_SCOPES": scopes_env,
             },
         ):
             provider = WorkOSProvider()
@@ -43,6 +50,10 @@ class TestWorkOSProvider:
             assert provider._upstream_client_id == "env_client"
             assert provider._upstream_client_secret.get_secret_value() == "env_secret"
             assert str(provider.base_url) == "https://envserver.com/"
+            assert provider._token_validator.required_scopes == [
+                "openid",
+                "email",
+            ]
 
     def test_init_missing_client_id_raises_error(self):
         """Test that missing client_id raises ValueError."""


### PR DESCRIPTION
OAuth docs recommended comma-separated scope lists but the settings parser only accepted JSON arrays. This caused confusing env var errors across providers.

Closes #1621 

This update normalizes scope parsing so providers accept comma-, space-, or JSON-separated lists. For example:
```bash
FASTMCP_SERVER_AUTH_GOOGLE_REQUIRED_SCOPES=openid,email
```
now configures `GoogleProvider` just like `FASTMCP_SERVER_AUTH_GOOGLE_REQUIRED_SCOPES='["openid","email"]'`.

The shared scope parser now lives in `fastmcp.utilities.auth` and is imported by all OAuth providers.

🤖 Generated with Claude Code

------
https://chatgpt.com/codex/tasks/task_e_68adc21457bc83268db54ad625166a0f