### PR TITLE
Fix OAuth redirect URI validation for DCR compatibility

### DIFF
--- a/docs/servers/auth/oauth-proxy.mdx
+++ b/docs/servers/auth/oauth-proxy.mdx
@@ -164,8 +164,8 @@ The `OAuthProxy` class provides the complete proxy implementation:
 
 <ParamField body="allowed_client_redirect_uris" type="list[str] | None">
   List of allowed redirect URI patterns for MCP clients. Patterns support wildcards (e.g., `"http://localhost:*"`, `"https://*.example.com/*"`). 
-  - `None` (default): Only localhost redirect URIs allowed (`http://localhost:*`, `http://127.0.0.1:*`)
-  - Empty list `[]`: All redirect URIs allowed (not recommended for production)
+  - `None` (default): All redirect URIs allowed (for MCP/DCR compatibility)
+  - Empty list `[]`: No redirect URIs allowed
   - Custom list: Only matching patterns allowed
   
   These patterns apply to MCP client loopback redirects, NOT the upstream OAuth app redirect URI.
@@ -230,29 +230,45 @@ The proxy automatically:
 
 ## Client Redirect URI Security
 
-<Warning>
-By default, OAuth Proxy only accepts localhost redirect URIs from MCP clients for security. You can customize this with the `allowed_client_redirect_uris` parameter:
+<Note>
+OAuth Proxy accepts all redirect URIs by default to maintain compatibility with MCP's Dynamic Client Registration (DCR) pattern, where clients register with unpredictable redirect URIs.
+
+If you know which clients will connect, you can restrict redirect URIs using the `allowed_client_redirect_uris` parameter:
 
 ```python
-# Default: localhost only (secure)
+# Default: allow all (for DCR compatibility)
 auth = OAuthProxy(...) 
+
+# Restrict to localhost only
+auth = OAuthProxy(
+    ...,
+    allowed_client_redirect_uris=[
+        "http://localhost:*",
+        "http://127.0.0.1:*"
+    ]
+)
+
+# Allow specific known clients (e.g., Claude.ai)
+auth = OAuthProxy(
+    ...,
+    allowed_client_redirect_uris=[
+        "http://localhost:*",
+        "https://claude.ai/api/mcp/auth_callback"
+    ]
+)
 
 # Custom patterns with wildcards
 auth = OAuthProxy(
     ...,
     allowed_client_redirect_uris=[
         "http://localhost:*",
-        "https://app.example.com/auth/*"
+        "https://*.example.com/auth/*"
     ]
 )
-
-# Allow all (NOT recommended for production)
-auth = OAuthProxy(
-    ...,
-    allowed_client_redirect_uris=[]
-)
 ```
-</Warning>
+
+**Tip:** Check your server logs for debug messages that say "Client registered with redirect_uri" messages to see what redirect URIs your clients are using.
+</Note>
 
 ## Client Compatibility
 

--- a/src/fastmcp/server/auth/oauth_proxy.py
+++ b/src/fastmcp/server/auth/oauth_proxy.py
@@ -422,6 +422,15 @@ class OAuthProxy(OAuthProvider):
         # Store the ProxyDCRClient using the upstream ID
         self._clients[upstream_id] = proxy_client
 
+        # Log redirect URIs to help users discover what patterns they might need
+        if client_info.redirect_uris:
+            for uri in client_info.redirect_uris:
+                logger.debug(
+                    "Client registered with redirect_uri: %s - if restricting redirect URIs, "
+                    "ensure this pattern is allowed in allowed_client_redirect_uris",
+                    uri,
+                )
+
         logger.debug(
             "Registered client %s with %d redirect URIs",
             upstream_id,

--- a/src/fastmcp/server/auth/redirect_validation.py
+++ b/src/fastmcp/server/auth/redirect_validation.py
@@ -33,8 +33,9 @@ def validate_redirect_uri(
 
     Args:
         redirect_uri: The redirect URI to validate
-        allowed_patterns: List of allowed patterns. If None, defaults to localhost.
-                         If empty list, all URIs are allowed.
+        allowed_patterns: List of allowed patterns. If None, all URIs are allowed (for DCR compatibility).
+                         If empty list, no URIs are allowed.
+                         To restrict to localhost only, explicitly pass DEFAULT_LOCALHOST_PATTERNS.
 
     Returns:
         True if the redirect URI is allowed
@@ -44,15 +45,9 @@ def validate_redirect_uri(
 
     uri_str = str(redirect_uri)
 
-    # If no patterns specified, default to localhost only
+    # If no patterns specified, allow all for DCR compatibility
+    # (clients need to dynamically register with their own redirect URIs)
     if allowed_patterns is None:
-        allowed_patterns = [
-            "http://localhost:*",
-            "http://127.0.0.1:*",
-        ]
-
-    # Empty list means allow all
-    if len(allowed_patterns) == 0:
         return True
 
     # Check if URI matches any allowed pattern

--- a/tests/server/auth/test_redirect_validation.py
+++ b/tests/server/auth/test_redirect_validation.py
@@ -66,21 +66,20 @@ class TestValidateRedirectUri:
         assert validate_redirect_uri(None, [])
         assert validate_redirect_uri(None, ["http://localhost:*"])
 
-    def test_default_localhost_patterns(self):
-        """Test default localhost-only patterns when None is provided."""
-        # Localhost patterns should be allowed by default
+    def test_default_allows_all(self):
+        """Test that None (default) allows all URIs for DCR compatibility."""
+        # All URIs should be allowed when None is provided (DCR compatibility)
         assert validate_redirect_uri("http://localhost:3000", None)
         assert validate_redirect_uri("http://127.0.0.1:8080", None)
+        assert validate_redirect_uri("http://example.com", None)
+        assert validate_redirect_uri("https://app.example.com", None)
+        assert validate_redirect_uri("https://claude.ai/api/mcp/auth_callback", None)
 
-        # Non-localhost should be rejected by default
-        assert not validate_redirect_uri("http://example.com", None)
-        assert not validate_redirect_uri("https://app.example.com", None)
-
-    def test_empty_list_allows_all(self):
-        """Test that empty list allows all redirect URIs."""
-        assert validate_redirect_uri("http://localhost:3000", [])
-        assert validate_redirect_uri("http://example.com", [])
-        assert validate_redirect_uri("https://anywhere.com:9999/path", [])
+    def test_empty_list_allows_none(self):
+        """Test that empty list allows no redirect URIs."""
+        assert not validate_redirect_uri("http://localhost:3000", [])
+        assert not validate_redirect_uri("http://example.com", [])
+        assert not validate_redirect_uri("https://anywhere.com:9999/path", [])
 
     def test_custom_patterns(self):
         """Test validation with custom pattern list."""
@@ -122,3 +121,21 @@ class TestDefaultPatterns:
         """Test that default patterns include localhost variations."""
         assert "http://localhost:*" in DEFAULT_LOCALHOST_PATTERNS
         assert "http://127.0.0.1:*" in DEFAULT_LOCALHOST_PATTERNS
+
+    def test_explicit_localhost_patterns(self):
+        """Test that explicitly passing DEFAULT_LOCALHOST_PATTERNS restricts to localhost."""
+        # Localhost patterns should be allowed
+        assert validate_redirect_uri(
+            "http://localhost:3000", DEFAULT_LOCALHOST_PATTERNS
+        )
+        assert validate_redirect_uri(
+            "http://127.0.0.1:8080", DEFAULT_LOCALHOST_PATTERNS
+        )
+
+        # Non-localhost should be rejected
+        assert not validate_redirect_uri(
+            "http://example.com", DEFAULT_LOCALHOST_PATTERNS
+        )
+        assert not validate_redirect_uri(
+            "https://claude.ai/api/mcp/auth_callback", DEFAULT_LOCALHOST_PATTERNS
+        )


### PR DESCRIPTION
The current localhost-only default breaks MCP's Dynamic Client Registration pattern where clients register with unpredictable redirect URIs. This particularly affects hosted clients like Claude.ai (#1628).

Note this relaxes the stance taken in #1582 which fails for hosted clients

## Changes
- Default (`None`): Allow all URIs for DCR compatibility  
- Empty list: Block all URIs (more intuitive than allowing all)
- Custom patterns: Only allow matches

Users can still restrict redirect URIs if they know their clients, but most MCP servers need the flexibility of DCR.

Closes #1564, closes #1628