### PR TITLE
Add allowed_client_redirect_uris to OAuth provider subclasses

### DIFF
--- a/src/fastmcp/server/auth/providers/azure.py
+++ b/src/fastmcp/server/auth/providers/azure.py
@@ -160,6 +160,7 @@ class AzureProvider(OAuthProxy):
         redirect_path: str | NotSetT = NotSet,
         required_scopes: list[str] | None | NotSetT = NotSet,
         timeout_seconds: int | NotSetT = NotSet,
+        allowed_client_redirect_uris: list[str] | None = None,
     ):
         """Initialize Azure OAuth provider.
 
@@ -171,6 +172,8 @@ class AzureProvider(OAuthProxy):
             redirect_path: Redirect path configured in Azure (defaults to "/auth/callback")
             required_scopes: Required scopes (defaults to ["User.Read", "email", "openid", "profile"])
             timeout_seconds: HTTP request timeout for Azure API calls
+            allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
+                If None (default), all URIs are allowed. If empty list, no URIs are allowed.
         """
         settings = AzureProviderSettings.model_validate(
             {
@@ -247,6 +250,7 @@ class AzureProvider(OAuthProxy):
             base_url=base_url_final,
             redirect_path=redirect_path_final,
             issuer_url=base_url_final,
+            allowed_client_redirect_uris=allowed_client_redirect_uris,
         )
 
         logger.info(

--- a/src/fastmcp/server/auth/providers/github.py
+++ b/src/fastmcp/server/auth/providers/github.py
@@ -201,6 +201,7 @@ class GitHubProvider(OAuthProxy):
         redirect_path: str | NotSetT = NotSet,
         required_scopes: list[str] | None | NotSetT = NotSet,
         timeout_seconds: int | NotSetT = NotSet,
+        allowed_client_redirect_uris: list[str] | None = None,
     ):
         """Initialize GitHub OAuth provider.
 
@@ -211,6 +212,8 @@ class GitHubProvider(OAuthProxy):
             redirect_path: Redirect path configured in GitHub OAuth app (defaults to "/auth/callback")
             required_scopes: Required GitHub scopes (defaults to ["user"])
             timeout_seconds: HTTP request timeout for GitHub API calls
+            allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
+                If None (default), all URIs are allowed. If empty list, no URIs are allowed.
         """
         settings = GitHubProviderSettings.model_validate(
             {
@@ -264,6 +267,7 @@ class GitHubProvider(OAuthProxy):
             base_url=base_url_final,
             redirect_path=redirect_path_final,
             issuer_url=base_url_final,  # We act as the issuer for client registration
+            allowed_client_redirect_uris=allowed_client_redirect_uris,
         )
 
         logger.info(

--- a/src/fastmcp/server/auth/providers/google.py
+++ b/src/fastmcp/server/auth/providers/google.py
@@ -217,6 +217,7 @@ class GoogleProvider(OAuthProxy):
         redirect_path: str | NotSetT = NotSet,
         required_scopes: list[str] | None | NotSetT = NotSet,
         timeout_seconds: int | NotSetT = NotSet,
+        allowed_client_redirect_uris: list[str] | None = None,
     ):
         """Initialize Google OAuth provider.
 
@@ -230,6 +231,8 @@ class GoogleProvider(OAuthProxy):
                 - "https://www.googleapis.com/auth/userinfo.email" for email access
                 - "https://www.googleapis.com/auth/userinfo.profile" for profile info
             timeout_seconds: HTTP request timeout for Google API calls
+            allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
+                If None (default), all URIs are allowed. If empty list, no URIs are allowed.
         """
         settings = GoogleProviderSettings.model_validate(
             {
@@ -284,6 +287,7 @@ class GoogleProvider(OAuthProxy):
             base_url=base_url_final,
             redirect_path=redirect_path_final,
             issuer_url=base_url_final,  # We act as the issuer for client registration
+            allowed_client_redirect_uris=allowed_client_redirect_uris,
         )
 
         logger.info(

--- a/src/fastmcp/server/auth/providers/workos.py
+++ b/src/fastmcp/server/auth/providers/workos.py
@@ -167,6 +167,7 @@ class WorkOSProvider(OAuthProxy):
         redirect_path: str | NotSetT = NotSet,
         required_scopes: list[str] | None | NotSetT = NotSet,
         timeout_seconds: int | NotSetT = NotSet,
+        allowed_client_redirect_uris: list[str] | None = None,
     ):
         """Initialize WorkOS OAuth provider.
 
@@ -178,6 +179,8 @@ class WorkOSProvider(OAuthProxy):
             redirect_path: Redirect path configured in WorkOS (defaults to "/auth/callback")
             required_scopes: Required OAuth scopes (no default)
             timeout_seconds: HTTP request timeout for WorkOS API calls
+            allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
+                If None (default), all URIs are allowed. If empty list, no URIs are allowed.
         """
         settings = WorkOSProviderSettings.model_validate(
             {
@@ -241,6 +244,7 @@ class WorkOSProvider(OAuthProxy):
             base_url=base_url_final,
             redirect_path=redirect_path_final,
             issuer_url=base_url_final,
+            allowed_client_redirect_uris=allowed_client_redirect_uris,
         )
 
         logger.info(


### PR DESCRIPTION
All OAuthProxy subclasses (Google, GitHub, Azure, WorkOS) now accept the `allowed_client_redirect_uris` parameter, completing the redirect URI restriction feature.

Closes #1658