### PR TITLE
Fix documentation: use StreamableHttpTransport for headers in testing

### DIFF
--- a/docs/deployment/testing.mdx
+++ b/docs/deployment/testing.mdx
@@ -133,11 +133,15 @@ async def test_deployed_server():
 The FastMCP Client handles authentication transparently, making it easy to test secured servers:
 
 ```python
+from fastmcp.client.transports import StreamableHttpTransport
+
 async def test_authenticated_server():
     # Bearer token authentication
     async with Client(
-        "https://api.example.com/mcp",
-        headers={"Authorization": "Bearer test-token"}
+        StreamableHttpTransport(
+            "https://api.example.com/mcp",
+            headers={"Authorization": "Bearer test-token"}
+        )
     ) as client:
         await client.ping()
         tools = await client.list_tools()


### PR DESCRIPTION
The authentication testing example incorrectly showed headers being passed directly to the Client constructor. Headers must be passed to the transport instance (StreamableHttpTransport) instead.

This fixes the issue reported in #807 and #1697 where users encountered `TypeError: Client.__init__() got an unexpected keyword argument 'headers'`.

Generated with [Claude Code](https://claude.ai/code)