### PR TITLE
Fix OAuth resource URL handling and WWW-Authenticate header

### DIFF
--- a/examples/auth/azure_oauth/server.py
+++ b/examples/auth/azure_oauth/server.py
@@ -23,7 +23,6 @@ auth = AzureProvider(
     tenant_id=os.getenv("AZURE_TENANT_ID")
     or "",  # Required for single-tenant apps - get from Azure Portal
     base_url="http://localhost:8000",
-    resource_server_url="http://localhost:8000/mcp",
     # redirect_path="/auth/callback",  # Default path - change if using a different callback URL
 )
 

--- a/examples/auth/github_oauth/server.py
+++ b/examples/auth/github_oauth/server.py
@@ -19,7 +19,6 @@ auth = GitHubProvider(
     client_id=os.getenv("FASTMCP_SERVER_AUTH_GITHUB_CLIENT_ID") or "",
     client_secret=os.getenv("FASTMCP_SERVER_AUTH_GITHUB_CLIENT_SECRET") or "",
     base_url="http://localhost:8000",
-    resource_server_url="http://localhost:8000/mcp",
     # redirect_path="/auth/callback",  # Default path - change if using a different callback URL
 )
 

--- a/examples/auth/google_oauth/server.py
+++ b/examples/auth/google_oauth/server.py
@@ -19,7 +19,6 @@ auth = GoogleProvider(
     client_id=os.getenv("FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_ID") or "",
     client_secret=os.getenv("FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_SECRET") or "",
     base_url="http://localhost:8000",
-    resource_server_url="http://localhost:8000/mcp",
     # redirect_path="/auth/callback",  # Default path - change if using a different callback URL
     # Optional: specify required scopes
     # required_scopes=["openid", "https://www.googleapis.com/auth/userinfo.email"],

--- a/examples/auth/workos_oauth/server.py
+++ b/examples/auth/workos_oauth/server.py
@@ -21,7 +21,6 @@ auth = WorkOSProvider(
     client_secret=os.getenv("WORKOS_CLIENT_SECRET") or "",
     authkit_domain=os.getenv("WORKOS_AUTHKIT_DOMAIN") or "https://your-app.authkit.app",
     base_url="http://localhost:8000",
-    resource_server_url="http://localhost:8000/mcp",
     # redirect_path="/auth/callback",  # Default path - change if using a different callback URL
 )
 

--- a/src/fastmcp/server/auth/oauth_proxy.py
+++ b/src/fastmcp/server/auth/oauth_proxy.py
@@ -241,7 +241,6 @@ class OAuthProxy(OAuthProvider):
         redirect_path: str = "/auth/callback",
         issuer_url: AnyHttpUrl | str | None = None,
         service_documentation_url: AnyHttpUrl | str | None = None,
-        resource_server_url: AnyHttpUrl | str | None = None,
         # Client redirect URI validation
         allowed_client_redirect_uris: list[str] | None = None,
     ):
@@ -259,9 +258,6 @@ class OAuthProxy(OAuthProvider):
             redirect_path: Redirect path configured in upstream OAuth app (defaults to "/auth/callback")
             issuer_url: Issuer URL for OAuth metadata (defaults to base_url)
             service_documentation_url: Optional service documentation URL
-            resource_server_url: Path of the FastMCP server. If None, FastMCP will
-                attempt to overwrite this with the correct path to the server
-                e.g. {base_url}/mcp
             allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
                 Patterns support wildcards (e.g., "http://localhost:*", "https://*.example.com/*").
                 If None (default), only localhost redirect URIs are allowed.
@@ -283,7 +279,6 @@ class OAuthProxy(OAuthProvider):
             client_registration_options=client_registration_options,
             revocation_options=revocation_options,
             required_scopes=token_verifier.required_scopes,
-            resource_server_url=resource_server_url,
         )
 
         # Store upstream configuration
@@ -877,14 +872,22 @@ class OAuthProxy(OAuthProvider):
         except Exception as e:
             logger.warning("Failed to store tokens from upstream response: %s", e)
 
-    def get_routes(self) -> list[Route]:
+    def get_routes(
+        self,
+        mcp_path: str | None = None,
+        mcp_endpoint: Any | None = None,
+    ) -> list[Route]:
         """Get OAuth routes with custom proxy token handler.
 
         This method creates standard OAuth routes and replaces the token endpoint
         with our proxy handler that forwards requests to the upstream OAuth server.
+
+        Args:
+            mcp_path: The path where the MCP endpoint is mounted (e.g., "/mcp")
+            mcp_endpoint: The MCP endpoint handler to protect with auth
         """
         # Get standard OAuth routes from parent class
-        routes = super().get_routes()
+        routes = super().get_routes(mcp_path, mcp_endpoint)
         custom_routes = []
         token_route_found = False
 

--- a/src/fastmcp/server/auth/providers/azure.py
+++ b/src/fastmcp/server/auth/providers/azure.py
@@ -6,10 +6,13 @@ using the OAuth Proxy pattern for non-DCR OAuth flows.
 
 from __future__ import annotations
 
+import warnings
+
 import httpx
 from pydantic import SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+import fastmcp
 from fastmcp.server.auth import AccessToken, TokenVerifier
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.registry import register_provider
@@ -36,7 +39,6 @@ class AzureProviderSettings(BaseSettings):
     redirect_path: str | None = None
     required_scopes: list[str] | None = None
     timeout_seconds: int | None = None
-    resource_server_url: str | None = None
     allowed_client_redirect_uris: list[str] | None = None
 
     @field_validator("required_scopes", mode="before")
@@ -162,8 +164,8 @@ class AzureProvider(OAuthProxy):
         redirect_path: str | NotSetT = NotSet,
         required_scopes: list[str] | None | NotSetT = NotSet,
         timeout_seconds: int | NotSetT = NotSet,
-        resource_server_url: str | NotSetT = NotSet,
         allowed_client_redirect_uris: list[str] | NotSetT = NotSet,
+        resource_server_url: str | NotSetT = NotSet,  # Deprecated
     ):
         """Initialize Azure OAuth provider.
 
@@ -175,11 +177,21 @@ class AzureProvider(OAuthProxy):
             redirect_path: Redirect path configured in Azure (defaults to "/auth/callback")
             required_scopes: Required scopes (defaults to ["User.Read", "email", "openid", "profile"])
             timeout_seconds: HTTP request timeout for Azure API calls
-            resource_server_url: Path of the FastMCP server (defaults to base_url). If your MCP endpoint is at
-                a different path like {base_url}/mcp, specify it here for RFC 8707 compliance.
             allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
                 If None (default), all URIs are allowed. If empty list, no URIs are allowed.
+            resource_server_url: Deprecated. Use base_url instead.
         """
+        # Handle deprecated resource_server_url parameter
+        if resource_server_url is not NotSet:
+            # Deprecated in v2.12.1
+            if fastmcp.settings.deprecation_warnings:
+                warnings.warn(
+                    "The 'resource_server_url' parameter is deprecated and will be removed in a future version. "
+                    "Please use 'base_url' instead. The resource URL is now determined automatically based on "
+                    "the MCP endpoint path.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
         settings = AzureProviderSettings.model_validate(
             {
                 k: v
@@ -191,7 +203,6 @@ class AzureProvider(OAuthProxy):
                     "redirect_path": redirect_path,
                     "required_scopes": required_scopes,
                     "timeout_seconds": timeout_seconds,
-                    "resource_server_url": resource_server_url,
                     "allowed_client_redirect_uris": allowed_client_redirect_uris,
                 }.items()
                 if v is not NotSet
@@ -217,7 +228,7 @@ class AzureProvider(OAuthProxy):
 
         # Apply defaults
         tenant_id_final = settings.tenant_id
-        base_url_final = settings.base_url or "http://localhost:8000"
+
         redirect_path_final = settings.redirect_path or "/auth/callback"
         timeout_seconds_final = settings.timeout_seconds or 10
         # Default scopes for Azure - User.Read gives us access to user info via Graph API
@@ -227,7 +238,6 @@ class AzureProvider(OAuthProxy):
             "openid",
             "profile",
         ]
-        resource_server_url_final = settings.resource_server_url or base_url_final
         allowed_client_redirect_uris_final = settings.allowed_client_redirect_uris
 
         # Extract secret string from SecretStr
@@ -256,11 +266,10 @@ class AzureProvider(OAuthProxy):
             upstream_client_id=settings.client_id,
             upstream_client_secret=client_secret_str,
             token_verifier=token_verifier,
-            base_url=base_url_final,
+            base_url=settings.base_url,
             redirect_path=redirect_path_final,
-            issuer_url=base_url_final,
+            issuer_url=settings.base_url,
             allowed_client_redirect_uris=allowed_client_redirect_uris_final,
-            resource_server_url=resource_server_url_final,
         )
 
         logger.info(

--- a/src/fastmcp/server/auth/providers/github.py
+++ b/src/fastmcp/server/auth/providers/github.py
@@ -21,10 +21,13 @@ Example:
 
 from __future__ import annotations
 
+import warnings
+
 import httpx
 from pydantic import AnyHttpUrl, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+import fastmcp
 from fastmcp.server.auth import TokenVerifier
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
@@ -51,7 +54,6 @@ class GitHubProviderSettings(BaseSettings):
     redirect_path: str | None = None
     required_scopes: list[str] | None = None
     timeout_seconds: int | None = None
-    resource_server_url: AnyHttpUrl | str | None = None
     allowed_client_redirect_uris: list[str] | None = None
 
     @field_validator("required_scopes", mode="before")
@@ -187,7 +189,7 @@ class GitHubProvider(OAuthProxy):
         auth = GitHubProvider(
             client_id="Ov23li...",
             client_secret="abc123...",
-            base_url="https://my-server.com"  # Optional, defaults to http://localhost:8000
+            base_url="https://my-server.com"
         )
 
         mcp = FastMCP("My App", auth=auth)
@@ -203,8 +205,8 @@ class GitHubProvider(OAuthProxy):
         redirect_path: str | NotSetT = NotSet,
         required_scopes: list[str] | NotSetT = NotSet,
         timeout_seconds: int | NotSetT = NotSet,
-        resource_server_url: AnyHttpUrl | str | NotSetT = NotSet,
         allowed_client_redirect_uris: list[str] | NotSetT = NotSet,
+        resource_server_url: AnyHttpUrl | str | NotSetT = NotSet,  # Deprecated
     ):
         """Initialize GitHub OAuth provider.
 
@@ -215,11 +217,22 @@ class GitHubProvider(OAuthProxy):
             redirect_path: Redirect path configured in GitHub OAuth app (defaults to "/auth/callback")
             required_scopes: Required GitHub scopes (defaults to ["user"])
             timeout_seconds: HTTP request timeout for GitHub API calls
-            resource_server_url: Path of the FastMCP server (defaults to base_url). If your MCP endpoint is at
-                a different path like {base_url}/mcp, specify it here for RFC 8707 compliance.
             allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
                 If None (default), all URIs are allowed. If empty list, no URIs are allowed.
+            resource_server_url: Deprecated. Use base_url instead.
         """
+        # Handle deprecated resource_server_url parameter
+        if resource_server_url is not NotSet:
+            # Deprecated in v2.12.1
+            if fastmcp.settings.deprecation_warnings:
+                warnings.warn(
+                    "The 'resource_server_url' parameter is deprecated and will be removed in a future version. "
+                    "Please use 'base_url' instead. The resource URL is now determined automatically based on "
+                    "the MCP endpoint path.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
         settings = GitHubProviderSettings.model_validate(
             {
                 k: v
@@ -230,7 +243,6 @@ class GitHubProvider(OAuthProxy):
                     "redirect_path": redirect_path,
                     "required_scopes": required_scopes,
                     "timeout_seconds": timeout_seconds,
-                    "resource_server_url": resource_server_url,
                     "allowed_client_redirect_uris": allowed_client_redirect_uris,
                 }.items()
                 if v is not NotSet
@@ -248,11 +260,10 @@ class GitHubProvider(OAuthProxy):
             )
 
         # Apply defaults
-        base_url_final = settings.base_url or "http://localhost:8000"
+
         redirect_path_final = settings.redirect_path or "/auth/callback"
         timeout_seconds_final = settings.timeout_seconds or 10
         required_scopes_final = settings.required_scopes or ["user"]
-        resource_server_url_final = settings.resource_server_url or base_url_final
         allowed_client_redirect_uris_final = settings.allowed_client_redirect_uris
 
         # Create GitHub token verifier
@@ -273,11 +284,10 @@ class GitHubProvider(OAuthProxy):
             upstream_client_id=settings.client_id,
             upstream_client_secret=client_secret_str,
             token_verifier=token_verifier,
-            base_url=base_url_final,
+            base_url=settings.base_url,
             redirect_path=redirect_path_final,
-            issuer_url=base_url_final,  # We act as the issuer for client registration
+            issuer_url=settings.base_url,  # We act as the issuer for client registration
             allowed_client_redirect_uris=allowed_client_redirect_uris_final,
-            resource_server_url=resource_server_url_final,
         )
 
         logger.info(

--- a/src/fastmcp/server/auth/providers/in_memory.py
+++ b/src/fastmcp/server/auth/providers/in_memory.py
@@ -41,7 +41,6 @@ class InMemoryOAuthProvider(OAuthProvider):
         client_registration_options: ClientRegistrationOptions | None = None,
         revocation_options: RevocationOptions | None = None,
         required_scopes: list[str] | None = None,
-        resource_server_url: AnyHttpUrl | str | None = None,
     ):
         super().__init__(
             base_url=base_url or "http://fastmcp.example.com",
@@ -49,7 +48,6 @@ class InMemoryOAuthProvider(OAuthProvider):
             client_registration_options=client_registration_options,
             revocation_options=revocation_options,
             required_scopes=required_scopes,
-            resource_server_url=resource_server_url,
         )
         self.clients: dict[str, OAuthClientInformationFull] = {}
         self.auth_codes: dict[str, AuthorizationCode] = {}

--- a/src/fastmcp/server/auth/providers/jwt.py
+++ b/src/fastmcp/server/auth/providers/jwt.py
@@ -154,7 +154,7 @@ class JWTVerifierSettings(BaseSettings):
     algorithm: str | None = None
     audience: str | list[str] | None = None
     required_scopes: list[str] | None = None
-    resource_server_url: AnyHttpUrl | str | None = None
+    base_url: AnyHttpUrl | str | None = None
 
     @field_validator("required_scopes", mode="before")
     @classmethod
@@ -191,7 +191,7 @@ class JWTVerifier(TokenVerifier):
         audience: str | list[str] | None | NotSetT = NotSet,
         algorithm: str | None | NotSetT = NotSet,
         required_scopes: list[str] | None | NotSetT = NotSet,
-        resource_server_url: AnyHttpUrl | str | None | NotSetT = NotSet,
+        base_url: AnyHttpUrl | str | None | NotSetT = NotSet,
     ):
         """
         Initialize the JWT token verifier.
@@ -206,7 +206,7 @@ class JWTVerifier(TokenVerifier):
                       - Asymmetric: RS256/384/512, ES256/384/512, PS256/384/512 (default: RS256)
                       - Symmetric: HS256, HS384, HS512
             required_scopes: Required scopes for all tokens
-            resource_server_url: Resource server URL for TokenVerifier protocol
+            base_url: Base URL for TokenVerifier protocol
         """
         settings = JWTVerifierSettings.model_validate(
             {
@@ -218,7 +218,7 @@ class JWTVerifier(TokenVerifier):
                     "audience": audience,
                     "algorithm": algorithm,
                     "required_scopes": required_scopes,
-                    "resource_server_url": resource_server_url,
+                    "base_url": base_url,
                 }.items()
                 if v is not NotSet
             }
@@ -249,7 +249,7 @@ class JWTVerifier(TokenVerifier):
 
         # Initialize parent TokenVerifier
         super().__init__(
-            resource_server_url=settings.resource_server_url,
+            base_url=settings.base_url,
             required_scopes=settings.required_scopes,
         )
 

--- a/src/fastmcp/server/auth/providers/workos.py
+++ b/src/fastmcp/server/auth/providers/workos.py
@@ -10,12 +10,16 @@ Choose based on your WorkOS setup and authentication requirements.
 
 from __future__ import annotations
 
+import warnings
+from typing import Any
+
 import httpx
 from pydantic import AnyHttpUrl, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
+import fastmcp
 from fastmcp.server.auth import AccessToken, RemoteAuthProvider, TokenVerifier
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
@@ -43,7 +47,6 @@ class WorkOSProviderSettings(BaseSettings):
     redirect_path: str | None = None
     required_scopes: list[str] | None = None
     timeout_seconds: int | None = None
-    resource_server_url: AnyHttpUrl | str | None = None
     allowed_client_redirect_uris: list[str] | None = None
 
     @field_validator("required_scopes", mode="before")
@@ -169,8 +172,8 @@ class WorkOSProvider(OAuthProxy):
         redirect_path: str | NotSetT = NotSet,
         required_scopes: list[str] | None | NotSetT = NotSet,
         timeout_seconds: int | NotSetT = NotSet,
-        resource_server_url: AnyHttpUrl | str | NotSetT = NotSet,
         allowed_client_redirect_uris: list[str] | NotSetT = NotSet,
+        resource_server_url: AnyHttpUrl | str | NotSetT = NotSet,  # Deprecated
     ):
         """Initialize WorkOS OAuth provider.
 
@@ -182,11 +185,22 @@ class WorkOSProvider(OAuthProxy):
             redirect_path: Redirect path configured in WorkOS (defaults to "/auth/callback")
             required_scopes: Required OAuth scopes (no default)
             timeout_seconds: HTTP request timeout for WorkOS API calls
-            resource_server_url: Path of the FastMCP server (defaults to base_url). If your MCP endpoint is at
-                a different path like {base_url}/mcp, specify it here for RFC 8707 compliance.
             allowed_client_redirect_uris: List of allowed redirect URI patterns for MCP clients.
                 If None (default), all URIs are allowed. If empty list, no URIs are allowed.
+            resource_server_url: Deprecated. Use base_url instead.
         """
+        # Handle deprecated resource_server_url parameter
+        if resource_server_url is not NotSet:
+            # Deprecated in v2.12.1
+            if fastmcp.settings.deprecation_warnings:
+                warnings.warn(
+                    "The 'resource_server_url' parameter is deprecated and will be removed in a future version. "
+                    "Please use 'base_url' instead. The resource URL is now determined automatically based on "
+                    "the MCP endpoint path.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
         settings = WorkOSProviderSettings.model_validate(
             {
                 k: v
@@ -198,7 +212,6 @@ class WorkOSProvider(OAuthProxy):
                     "redirect_path": redirect_path,
                     "required_scopes": required_scopes,
                     "timeout_seconds": timeout_seconds,
-                    "resource_server_url": resource_server_url,
                     "allowed_client_redirect_uris": allowed_client_redirect_uris,
                 }.items()
                 if v is not NotSet
@@ -224,11 +237,9 @@ class WorkOSProvider(OAuthProxy):
         if not authkit_domain_str.startswith(("http://", "https://")):
             authkit_domain_str = f"https://{authkit_domain_str}"
         authkit_domain_final = authkit_domain_str.rstrip("/")
-        base_url_final = settings.base_url or "http://localhost:8000"
         redirect_path_final = settings.redirect_path or "/auth/callback"
         timeout_seconds_final = settings.timeout_seconds or 10
         scopes_final = settings.required_scopes or []
-        resource_server_url_final = settings.resource_server_url or base_url_final
         allowed_client_redirect_uris_final = settings.allowed_client_redirect_uris
 
         # Extract secret string from SecretStr
@@ -250,11 +261,10 @@ class WorkOSProvider(OAuthProxy):
             upstream_client_id=settings.client_id,
             upstream_client_secret=client_secret_str,
             token_verifier=token_verifier,
-            base_url=base_url_final,
+            base_url=settings.base_url,
             redirect_path=redirect_path_final,
-            issuer_url=base_url_final,
+            issuer_url=settings.base_url,
             allowed_client_redirect_uris=allowed_client_redirect_uris_final,
-            resource_server_url=resource_server_url_final,
         )
 
         logger.info(
@@ -362,17 +372,25 @@ class AuthKitProvider(RemoteAuthProvider):
         super().__init__(
             token_verifier=token_verifier,
             authorization_servers=[AnyHttpUrl(self.authkit_domain)],
-            resource_server_url=self.base_url,
+            base_url=self.base_url,
         )
 
-    def get_routes(self) -> list[Route]:
+    def get_routes(
+        self,
+        mcp_path: str | None = None,
+        mcp_endpoint: Any | None = None,
+    ) -> list[Route]:
         """Get OAuth routes including AuthKit authorization server metadata forwarding.
 
         This returns the standard protected resource routes plus an authorization server
         metadata endpoint that forwards AuthKit's OAuth metadata to clients.
+
+        Args:
+            mcp_path: The path where the MCP endpoint is mounted (e.g., "/mcp")
+            mcp_endpoint: The MCP endpoint handler to protect with auth
         """
         # Get the standard protected resource routes from RemoteAuthProvider
-        routes = super().get_routes()
+        routes = super().get_routes(mcp_path, mcp_endpoint)
 
         async def oauth_authorization_server_metadata(request):
             """Forward AuthKit OAuth authorization server metadata with FastMCP customizations."""

--- a/tests/server/auth/test_jwt_provider.py
+++ b/tests/server/auth/test_jwt_provider.py
@@ -137,6 +137,10 @@ def mcp_server_url(rsa_key_pair: RSAKeyPair) -> Generator[str]:
     with run_server_in_process(
         run_mcp_server,
         public_key=rsa_key_pair.public_key,
+        auth_kwargs=dict(
+            issuer="https://test.example.com",
+            audience="https://api.example.com",
+        ),
         run_kwargs=dict(transport="http"),
     ) as url:
         yield f"{url}/mcp"

--- a/tests/server/auth/test_oauth_proxy.py
+++ b/tests/server/auth/test_oauth_proxy.py
@@ -49,14 +49,12 @@ class TestOAuthProxyComprehensive:
             base_url="https://api.example.com",  # String instead of AnyHttpUrl
             issuer_url="https://issuer.example.com",  # String
             service_documentation_url="https://docs.example.com",  # String
-            resource_server_url="https://resources.example.com",  # String
         )
 
         # Should work fine and convert internally to AnyHttpUrl
         assert str(proxy.base_url) == "https://api.example.com/"
         assert str(proxy.issuer_url) == "https://issuer.example.com/"
         assert str(proxy.service_documentation_url) == "https://docs.example.com/"
-        assert str(proxy.resource_server_url) == "https://resources.example.com/"
 
     def test_initialization_with_all_parameters(self, jwt_verifier):
         """Test OAuthProxy initialization with all optional parameters."""
@@ -71,7 +69,6 @@ class TestOAuthProxyComprehensive:
             redirect_path="/auth/callback",
             issuer_url="https://issuer.example.com",
             service_documentation_url="https://docs.example.com",
-            resource_server_url="https://resources.example.com",
         )
 
         # Verify all parameters are set correctly
@@ -86,7 +83,6 @@ class TestOAuthProxyComprehensive:
         assert proxy._redirect_path == "/auth/callback"
         assert str(proxy.issuer_url) == "https://issuer.example.com/"
         assert str(proxy.service_documentation_url) == "https://docs.example.com/"
-        assert str(proxy.resource_server_url) == "https://resources.example.com/"
 
     def test_redirect_path_normalization(self, jwt_verifier):
         """Test that redirect_path is normalized to start with /."""


### PR DESCRIPTION
This PR fixes OAuth authentication issues related to resource URL handling and the WWW-Authenticate header.

## Problem

When an MCP server is mounted at a non-root path (e.g., `/mcp` or `/api/v1/mcp`), there were two related issues:

1. **Issue #1685**: The WWW-Authenticate header incorrectly included the MCP path in the `.well-known` URL, returning `http://localhost:8000/mcp/.well-known/oauth-protected-resource` instead of `http://localhost:8000/.well-known/oauth-protected-resource`

2. **PR #1682 regression risk**: The resource URL in the `.well-known` metadata needs to automatically reflect the actual MCP endpoint path for RFC 8707 compliance

## Solution  

Refactored the authentication architecture to dynamically determine the resource URL based on where the MCP endpoint is actually mounted, while ensuring the `.well-known` endpoint always remains at the base URL.

Key changes:
- Auth providers now accept the MCP path dynamically via `get_routes(mcp_path, mcp_endpoint)`
- The resource URL is automatically set to the MCP endpoint path
- The `.well-known` endpoint always stays at the base URL
- Deprecated `resource_server_url` parameter (with backwards compatibility)

## Example

```python
from fastmcp import FastMCP
from fastmcp.server.auth.providers.github import GitHubProvider

auth = GitHubProvider(
    client_id="your-client-id",
    client_secret="your-secret",
    base_url="http://localhost:8000"  # Only need base URL now
)

mcp = FastMCP("My Server", auth=auth)
app = mcp.http_app(path="/api/v1/mcp")  # Resource URL automatically captured
```

With this setup:
- WWW-Authenticate header points to: `http://localhost:8000/.well-known/oauth-protected-resource`
- Resource metadata shows: `"resource": "http://localhost:8000/api/v1/mcp"`

Fixes #1685