### PR TITLE
Fix settings module import issue in VS Code debugger

### DIFF
--- a/src/fastmcp/__init__.py
+++ b/src/fastmcp/__init__.py
@@ -3,9 +3,13 @@
 import warnings
 from importlib.metadata import version as _version
 from fastmcp.settings import Settings
+import fastmcp.settings as settings_module
 from fastmcp.utilities.logging import configure_logging as _configure_logging
 
 settings = Settings()
+
+settings_module._instance = settings
+
 if settings.log_enabled:
     _configure_logging(
         level=settings.log_level,

--- a/src/fastmcp/settings.py
+++ b/src/fastmcp/settings.py
@@ -344,6 +344,9 @@ class Settings(BaseSettings):
     ] = False
 
 
+_instance = None
+
+
 def __getattr__(name: str):
     """
     Used to deprecate the module-level Image class; can be removed once it is no longer imported to root.
@@ -360,5 +363,9 @@ def __getattr__(name: str):
                 stacklevel=2,
             )
         return settings
+
+    # Proxy to injected instance (debugger fix)
+    if _instance is not None and hasattr(_instance, name):
+        return getattr(_instance, name)
 
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")


### PR DESCRIPTION
# Fix settings module import issue in VS Code debugger

This is the issue resolution PR below.
Fixes #1749

## Problem

When running FastMCP servers through VS Code debugger, the following error occurs:
```
AttributeError: module 'fastmcp.settings' has no attribute 'mask_error_details'
```

This error only happens in debugger environments, not during normal Python execution.

## Root Cause Analysis

### The Name Conflict
Python allows the same name to exist as both:
- A module: `fastmcp/settings.py` 
- A variable: `settings = Settings()` in `fastmcp/__init__.py`

When code executes `from fastmcp import settings`, Python must resolve which one to return.

### Normal Execution Behavior
1. Python checks `fastmcp/__init__.py` namespace first
2. Finds the `settings` variable (Settings instance)
3. Returns the instance → Everything works ✅

### VS Code Debugger Behavior  
1. VS Code uses `debugpy` which installs import hooks for debugging features
2. These hooks modify Python's import resolution priority
3. The module path `fastmcp/settings.py` gets higher priority
4. Returns the module instead of the instance
5. Module has no `mask_error_details` attribute → AttributeError ❌

### Why This Happens
`debugpy` needs to intercept imports to:
- Set breakpoints in modules before they're imported
- Track variable values across module boundaries
- Enable step-through debugging

This legitimate debugging requirement inadvertently changes import resolution order.

## Solution: Instance Injection Pattern

### Implementation
```python
# src/fastmcp/__init__.py
from fastmcp.settings import Settings
import fastmcp.settings as settings_module

settings = Settings()

# Fix VS Code debugger compatibility
settings_module._instance = settings
```

```python
# src/fastmcp/settings.py
# Injected by __init__.py
_instance = None

def __getattr__(name: str):
    """
    Used to deprecate the module-level Image class; can be removed once it is no longer imported to root.
    """
    if name == "settings":
        # ... existing deprecation logic ...
        return settings
    
    # Proxy to injected instance (debugger fix)
    if _instance is not None and hasattr(_instance, name):
        return getattr(_instance, name)

    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
```

### How This Solves the Problem

1. **Normal Execution Path**
   - `from fastmcp import settings` → Gets Settings instance from `__init__.py`
   - Direct attribute access works normally

2. **Debugger Execution Path**  
   - `from fastmcp import settings` → Gets `settings.py` module
   - Module's `__getattr__` is called for `mask_error_details`
   - `__getattr__` proxies to the injected `_instance`
   - Returns the same value as normal execution

3. **Single Source of Truth**
   - Only one Settings instance exists (created in `__init__.py`)
   - Both import methods access the same instance
   - Consistent behavior regardless of execution environment

### Why This is the Best Solution

1. **No Breaking Changes**: All existing imports continue to work
2. **No Circular Dependencies**: Instance is injected after creation
3. **Minimal Code Changes**: Only touches two files with surgical precision
4. **Future Proof**: Automatically handles any new settings attributes
5. **Clean Architecture**: Clear initialization flow from `__init__.py`
6. **Performance**: No overhead in normal execution path

## Testing

Verified that both import methods now work correctly:
```python
# Both work in debugger now
import fastmcp
fastmcp.settings.mask_error_details  # ✅

import fastmcp.settings as settings_module  
settings_module.mask_error_details  # ✅
```

The fix ensures FastMCP servers can be debugged in VS Code without any AttributeError.