### PR TITLE
Improve language for route_map_fn tip

### DIFF
--- a/docs/integrations/openapi.mdx
+++ b/docs/integrations/openapi.mdx
@@ -217,7 +217,7 @@ For advanced use cases that require more complex logic, you can provide a `route
 In addition to more precise targeting of methods, patterns, and tags, this function can access any additional OpenAPI metadata about the route.
 
 <Tip>
-The `route_map_fn` **is** called on routes that matched `MCPType.EXCLUDE` in your custom maps, giving you an opportunity to override the exclusion.
+The `route_map_fn` is called on all routes, even those that matched `MCPType.EXCLUDE` in your custom maps. This gives you an opportunity to customize the mapping or even override an exclusion.
 </Tip>
 
 ```python


### PR DESCRIPTION
In #1788 it became apparent that this language was not clear; it was interpreted as meaning the `route_map_fn` is called *only* on excluded routes instead of *additionally* on excluded routes. 