### PR TITLE
Delay import of Provider classes until FastMCP Server Creation

### DIFF
--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -208,8 +208,8 @@ class FastMCP(Generic[LifespanResultT]):
         # if auth is `NotSet`, try to create a provider from the environment
         if auth is NotSet:
             if fastmcp.settings.server_auth is not None:
-                # ImportString returns the class itself
-                auth = fastmcp.settings.server_auth()
+                # server_auth_class returns the class itself
+                auth = fastmcp.settings.server_auth_class()
             else:
                 auth = None
         self.auth = cast(AuthProvider | None, auth)


### PR DESCRIPTION
## Description
Fix issues with Server/Settings creation with environment sourced Auth Providers as described at https://github.com/jlowin/fastmcp/issues/1749#issuecomment-3288790161 by not delaying import of the provider until server creation

**Contributors Checklist**
- [x] My change is related to issue #1749
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [x] I have performed all required documentation updates

**Review Checklist**
- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review