### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ NOTE:
 If you do not follow these steps, your Pull Request will be closed without review.
 -->
 
-- [ ] My change is related to issue #(issue number)
+- [ ] My change closes #(issue number)
 - [ ] I have followed the repository's development workflow
 - [ ] I have tested my changes manually and by adding relevant tests
 - [ ] I have performed all required documentation updates


### PR DESCRIPTION
When users fill out the PR template as-is, it creates a reference to the issue (good!) but does not automatically close it (not as good!) because GitHub requires the phase "closes #..." or "fixes #..." to do that automatically. This PR adjusts the template to default to closing issues if users simply type in the number.