### PR TITLE
docs: make Gemini CLI integration discoverable

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -186,6 +186,7 @@
                   "integrations/claude-code",
                   "integrations/claude-desktop",
                   "integrations/cursor",
+                  "integrations/gemini-cli",
                   "integrations/mcp-json-configuration"
                 ]
               },


### PR DESCRIPTION
Adding Gemini CLI integration to nav bar for it to be discoverable.


It is currently missing:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f6841c5d-05da-4c21-b361-d231741de292" />
