### PR TITLE
fix: correct documentation link in deprecation warning

### DIFF
--- a/src/fastmcp/server/context.py
+++ b/src/fastmcp/server/context.py
@@ -573,7 +573,7 @@ class Context:
             warnings.warn(
                 "Context.get_http_request() is deprecated and will be removed in a future version. "
                 "Use get_http_request() from fastmcp.server.dependencies instead. "
-                "See https://gofastmcp.com/patterns/http-requests for more details.",
+                "See https://gofastmcp.com/servers/context#http-requests for more details.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/tests/server/test_context.py
+++ b/tests/server/test_context.py
@@ -56,7 +56,7 @@ class TestContextDeprecations:
                     "Use get_http_request() from fastmcp.server.dependencies instead"
                     in str(warning.message)
                 )
-                assert "https://gofastmcp.com/patterns/http-requests" in str(
+                assert "https://gofastmcp.com/servers/context#http-requests" in str(
                     warning.message
                 )
 


### PR DESCRIPTION
Updated the broken documentation link in Context.get_http_request() deprecation warning to point to the correct location in the context documentation at https://gofastmcp.com/servers/context#http-requests instead of the non-existent patterns/http-requests page.

Also updated the corresponding test to expect the new URL.

Fixes #1814

🤖 Generated with [Claude Code](https://claude.ai/code)