### PR TITLE
Fix OAuth pre-flight check to accept HTTP 200 responses

### DIFF
--- a/src/fastmcp/client/auth/oauth.py
+++ b/src/fastmcp/client/auth/oauth.py
@@ -318,8 +318,8 @@ class OAuth(OAuthClientProvider):
                     "OAuth client not found - cached credentials may be stale"
                 )
 
-            # For any non-redirect response, something is wrong
-            if response.status_code not in (302, 303, 307, 308):
+            # OAuth typically returns redirects, but some providers return 200 with HTML login pages
+            if response.status_code not in (200, 302, 303, 307, 308):
                 raise RuntimeError(
                     f"Unexpected authorization response: {response.status_code}"
                 )


### PR DESCRIPTION
Fixes #1798 

Some OAuth providers return HTTP 200 with HTML login pages instead of redirects during the pre-flight check. This is valid behavior - OAuth specifications don't mandate redirect responses for authorization endpoints, and providers may choose to serve interactive HTML forms directly.

The pre-flight check's primary purpose is to catch invalid client IDs (400 errors) early before opening the browser. Accepting 200 responses alongside redirect codes (302, 303, 307, 308) allows these providers to work while preserving the invalid client detection.

This restores compatibility with SSE-based OAuth flows and other providers that serve login pages directly.