### PR TITLE
Fix: Preserve OpenAPI parameter descriptions in experimental parser

### DIFF
--- a/src/fastmcp/experimental/utilities/openapi/schemas.py
+++ b/src/fastmcp/experimental/utilities/openapi/schemas.py
@@ -303,9 +303,11 @@ def _combine_schemas_and_map_params(
 
             # Convert refs if needed
             if convert_refs:
-                param_schema = _replace_ref_with_defs(param.schema_)
+                param_schema = _replace_ref_with_defs(param.schema_, param.description)
             else:
-                param_schema = param.schema_
+                param_schema = param.schema_.copy()
+                if param.description and not param_schema.get("description"):
+                    param_schema["description"] = param.description
             original_desc = param_schema.get("description", "")
             location_desc = f"({param.location.capitalize()} parameter)"
             if original_desc:
@@ -330,9 +332,11 @@ def _combine_schemas_and_map_params(
 
             # Convert refs if needed
             if convert_refs:
-                param_schema = _replace_ref_with_defs(param.schema_)
+                param_schema = _replace_ref_with_defs(param.schema_, param.description)
             else:
-                param_schema = param.schema_
+                param_schema = param.schema_.copy()
+                if param.description and not param_schema.get("description"):
+                    param_schema["description"] = param.description
 
             # Don't make optional parameters nullable - they can simply be omitted
             # The OpenAPI specification doesn't require optional parameters to accept null values

--- a/tests/experimental/openapi_parser/server/openapi/test_openapi_features.py
+++ b/tests/experimental/openapi_parser/server/openapi/test_openapi_features.py
@@ -155,17 +155,17 @@ class TestParameterHandling:
                 assert "X-API-Key" in properties
 
                 # Check that parameter descriptions are included
-                assert (
-                    "description" in properties["query"]
-                ), "Query parameter should have description"
+                assert "description" in properties["query"], (
+                    "Query parameter should have description"
+                )
                 assert properties["query"]["description"] == "Search query"
-                assert (
-                    "description" in properties["limit"]
-                ), "Limit parameter should have description"
+                assert "description" in properties["limit"], (
+                    "Limit parameter should have description"
+                )
                 assert properties["limit"]["description"] == "Maximum number of results"
-                assert (
-                    "description" in properties["tags"]
-                ), "Tags parameter should have description"
+                assert "description" in properties["tags"], (
+                    "Tags parameter should have description"
+                )
                 assert properties["tags"]["description"] == "Filter by tags"
 
                 # Check that required parameters are marked as required

--- a/tests/experimental/openapi_parser/server/openapi/test_openapi_features.py
+++ b/tests/experimental/openapi_parser/server/openapi/test_openapi_features.py
@@ -154,6 +154,20 @@ class TestParameterHandling:
                 assert "tags" in properties
                 assert "X-API-Key" in properties
 
+                # Check that parameter descriptions are included
+                assert (
+                    "description" in properties["query"]
+                ), "Query parameter should have description"
+                assert properties["query"]["description"] == "Search query"
+                assert (
+                    "description" in properties["limit"]
+                ), "Limit parameter should have description"
+                assert properties["limit"]["description"] == "Maximum number of results"
+                assert (
+                    "description" in properties["tags"]
+                ), "Tags parameter should have description"
+                assert properties["tags"]["description"] == "Filter by tags"
+
                 # Check that required parameters are marked as required
                 required = params.get("required", [])
                 assert "query" in required


### PR DESCRIPTION
Closes #1876

## Description
Problem: When generating tools from OpenAPI with the experimental parser, parameter descriptions (e.g., query params) were not preserved in tool inputSchema, unlike the stable path.

Solution: Thread the parameter’s description into schema resolution and set it on non-ref schemas when missing, in both collision and non-collision branches. This aligns experimental behavior with the stable combiner.

Before
```python
param_schema = _replace_ref_with_defs(param.schema_)
# ...
param_schema = param.schema_
```

After
```python
param_schema = _replace_ref_with_defs(param.schema_, param.description)
# ...
param_schema = param.schema_.copy()
if param.description and not param_schema.get("description"):
    param_schema["description"] = param.description
```

Refs: #1876

Note (as requested):
- Used AI model: gpt-5-high.

**Contributors Checklist**

- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests

**Review Checklist**

- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review

---
