### PR TITLE
Fix route count logging in OpenAPI server

### DIFF
--- a/src/fastmcp/server/openapi.py
+++ b/src/fastmcp/server/openapi.py
@@ -785,6 +785,7 @@ class FastMCPOpenAPI(FastMCP):
         http_routes = openapi.parse_openapi_to_http_routes(openapi_spec)
 
         # Process routes
+        num_excluded = 0
         route_maps = (route_maps or []) + DEFAULT_ROUTE_MAPPINGS
         for route in http_routes:
             # Determine route type based on mappings or default rules
@@ -823,8 +824,11 @@ class FastMCPOpenAPI(FastMCP):
                 self._create_openapi_template(route, component_name, tags=route_tags)
             elif route_type == MCPType.EXCLUDE:
                 logger.info(f"Excluding route: {route.method} {route.path}")
+                num_excluded += 1
 
-        logger.info(f"Created FastMCP OpenAPI server with {len(http_routes)} routes")
+        logger.info(
+            f"Created FastMCP OpenAPI server with {len(http_routes) - num_excluded} routes"
+        )
 
     def _generate_default_name(
         self, route: openapi.HTTPRoute, mcp_names_map: dict[str, str] | None = None


### PR DESCRIPTION
The OpenAPI server was reporting the total number of routes without accounting for excluded routes. When routes are excluded via `MCPType.EXCLUDE`, the log message would still report the original total, making it confusing to understand how many routes were actually processed.

This PR adds a counter for excluded routes and subtracts it from the total when logging, providing accurate feedback about the number of routes that were actually created as MCP components.

## Example

Before: `Created FastMCP OpenAPI server with 5 routes` (even though 2 were excluded)
After: `Created FastMCP OpenAPI server with 3 routes` (correctly shows only processed routes)

Fixes #1899

<details>
<summary>Reproduction Script</summary>

```python
"""
Reproduction for issue #1899: Wrong count of routes in log message

The issue is that the OpenAPI server reports the total number of routes
without accounting for excluded routes.
"""

import httpx

from fastmcp.server.openapi import FastMCPOpenAPI, MCPType, RouteMap
from fastmcp.utilities.logging import get_logger

logger = get_logger("repro")

# Create a minimal OpenAPI spec with multiple routes
openapi_spec = {
    "openapi": "3.0.0",
    "info": {"title": "Test API", "version": "1.0.0"},
    "paths": {
        "/tool1": {
            "get": {
                "summary": "Tool 1",
                "operationId": "tool1",
                "responses": {"200": {"description": "Success"}},
            }
        },
        "/tool2": {
            "post": {
                "summary": "Tool 2",
                "operationId": "tool2",
                "responses": {"200": {"description": "Success"}},
            }
        },
        "/excluded1": {
            "get": {
                "summary": "Should be excluded",
                "operationId": "excluded1",
                "responses": {"200": {"description": "Success"}},
            }
        },
        "/excluded2": {
            "delete": {
                "summary": "Also excluded",
                "operationId": "excluded2",
                "responses": {"200": {"description": "Success"}},
            }
        },
        "/resource1": {
            "get": {
                "summary": "Resource 1",
                "operationId": "resource1",
                "responses": {"200": {"description": "Success"}},
            }
        },
    },
}

# Create route mappings to exclude specific routes
route_maps = [
    RouteMap(pattern="/excluded1", mcp_type=MCPType.EXCLUDE),
    RouteMap(pattern="/excluded2", mcp_type=MCPType.EXCLUDE),
    RouteMap(pattern="/tool.*", mcp_type=MCPType.TOOL),
    RouteMap(pattern="/resource.*", mcp_type=MCPType.RESOURCE),
]

print("Creating FastMCP OpenAPI server with:")
print("- Total routes in OpenAPI spec: 5")
print("- Routes to exclude: 2 (/excluded1, /excluded2)")
print("- Expected routes after exclusion: 3")
print()

# Create the server with route mappings
async_client = httpx.AsyncClient()
server = FastMCPOpenAPI(
    openapi_spec=openapi_spec,
    client=async_client,
    name="test_server",
    route_maps=route_maps,
)

print("\nBug demonstration:")
print("The log message above should say '3 routes' but incorrectly says '5 routes'")
print("because it doesn't subtract the excluded routes.")
```
</details>

### ai disclosure

claude code