### PR TITLE
fix: Return invalid_client TokenError instead of None for client not …

### DIFF
--- a/src/fastmcp/server/auth/providers/in_memory.py
+++ b/src/fastmcp/server/auth/providers/in_memory.py
@@ -62,8 +62,16 @@ class InMemoryOAuthProvider(OAuthProvider):
             str, str
         ] = {}  # refresh_token_str -> access_token_str
 
-    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
-        return self.clients.get(client_id)
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull:
+        """Get client information by ID.
+
+        Raises:
+            TokenError: If client is not found, raises invalid_client error
+        """
+        client = self.clients.get(client_id)
+        if client is None:
+            raise TokenError("invalid_client", f"Client ID '{client_id}' not found")
+        return client
 
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
         if client_info.client_id in self.clients:

--- a/tests/server/auth/test_oauth_proxy.py
+++ b/tests/server/auth/test_oauth_proxy.py
@@ -425,10 +425,16 @@ class TestOAuthProxyClientRegistration:
         assert retrieved is not None
         assert retrieved.client_id == "test-client"
 
-    async def test_get_unregistered_client_returns_none(self, oauth_proxy):
-        """Test that unregistered clients return None."""
-        client = await oauth_proxy.get_client("unknown-client")
-        assert client is None
+    async def test_get_unregistered_client_raises_token_error(self, oauth_proxy):
+        """Test that unregistered clients raise TokenError with invalid_client."""
+        from mcp.server.auth.provider import TokenError
+
+        with pytest.raises(TokenError) as exc_info:
+            await oauth_proxy.get_client("unknown-client")
+
+        assert exc_info.value.error == "invalid_client"  # type: ignore[attr-defined]
+        assert "not found" in exc_info.value.error_description.lower()  # type: ignore[attr-defined]
+        assert "unknown-client" in exc_info.value.error_description  # type: ignore[attr-defined]
 
 
 class TestOAuthProxyAuthorization:

--- a/tests/server/auth/test_oauth_proxy_redirect_validation.py
+++ b/tests/server/auth/test_oauth_proxy_redirect_validation.py
@@ -193,6 +193,11 @@ class TestOAuthProxyRedirectValidation:
             allowed_client_redirect_uris=custom_patterns,
         )
 
-        # Get an unregistered client
-        client = await proxy.get_client("unknown-client")
-        assert client is None
+        # Get an unregistered client should raise TokenError
+        from mcp.server.auth.provider import TokenError
+
+        with pytest.raises(TokenError) as exc_info:
+            await proxy.get_client("unknown-client")
+
+        assert exc_info.value.error == "invalid_client"  # type: ignore[attr-defined]
+        assert "not found" in exc_info.value.error_description.lower()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Description

This PR updates the OAuth client validation behavior to ensure proper OAuth 2.0 spec compliance for claude.ai compatibility and fixes client re-registration issues.

**Changes made:**
- Update OAuth proxy `get_client()` method to raise `TokenError('invalid_client')` instead of returning `None` when client is not found
- Update InMemory provider `get_client()` method to raise `TokenError('invalid_client')` instead of returning `None` when client is not found  
- Update corresponding tests to expect `TokenError` exceptions instead of `None` returns


**Contributors Checklist**
<!--
NOTE:
1. You must create an issue in the repository before making a Pull Request.
2. You must not create a Pull Request for an issue that is already assigned to someone else.
If you do not follow these steps, your Pull Request will be closed without review.
-->
- [x] My change closes #1919
- [x] I have followed the repository's development workflow
- [x] I have tested my changes manually and by adding relevant tests
- [x] I have performed all required documentation updates

**Review Checklist**
<!-- Your Pull Request will not be reviewed if tests are failing, you have not self-reviewed your changes, or you have not checked all of the following: -->
- [x] I have self-reviewed my changes
- [x] My Pull Request is ready for review