### PR TITLE
Update ChatGPT docs for Chat mode with Developer Mode

### DIFF
--- a/docs/integrations/chatgpt.mdx
+++ b/docs/integrations/chatgpt.mdx
@@ -1,159 +1,157 @@
 ---
 title: ChatGPT 🤝 FastMCP
 sidebarTitle: ChatGPT
-description: Connect FastMCP servers to ChatGPT Deep Research
+description: Connect FastMCP servers to ChatGPT in Chat and Deep Research modes
 icon: message-smile
-
+tag: NEW
 ---
 
-ChatGPT supports MCP servers through remote HTTP connections, allowing you to extend ChatGPT's capabilities with custom tools and knowledge from your FastMCP servers.
-
-<Note>
-MCP integration with ChatGPT is currently limited to **Deep Research** functionality and is not available for general chat. This feature is available for ChatGPT Pro, Team, Enterprise, and Edu users.
-</Note>
+ChatGPT supports MCP servers through remote HTTP connections in two modes: **Chat mode** for interactive conversations and **Deep Research mode** for comprehensive information retrieval.
 
 <Tip>
-OpenAI's official MCP documentation and examples are built with **FastMCP v2**! Check out their [simple Deep Research-style MCP server example](https://github.com/openai/sample-deep-research-mcp) for a quick reference similar to the one in this document, or their [more complete Deep Research example](https://github.com/openai/openai-cookbook/tree/main/examples/deep_research_api/how_to_build_a_deep_research_mcp_server) from the OpenAI Cookbook, which includes vector search and more.
+**Developer Mode Required for Chat Mode**: To use MCP servers in regular ChatGPT conversations, you must first enable Developer Mode in your ChatGPT settings. This feature is available for ChatGPT Pro, Team, Enterprise, and Edu users.
 </Tip>
 
-## Deep Research
+<Note>
+OpenAI's official MCP documentation and examples are built with **FastMCP v2**! Learn more from their [MCP documentation](https://platform.openai.com/docs/mcp) and [Developer Mode guide](https://platform.openai.com/docs/guides/developer-mode).
+</Note>
 
-ChatGPT's Deep Research feature requires MCP servers to be internet-accessible HTTP endpoints with **exactly two specific tools**:
+## Build a Server
 
-- **`search`**: For searching through your resources and returning matching IDs
-- **`fetch`**: For retrieving the full content of specific resources by ID
+First, let's create a simple FastMCP server:
 
-<Warning>
-If your server doesn't implement both `search` and `fetch` tools with the correct signatures, ChatGPT will show the error: "This MCP server doesn't implement our specification". Both tools are required.
-</Warning>
-
-### Tool Descriptions Matter
-
-Since ChatGPT needs to understand how to use your tools effectively, **write detailed tool descriptions**. The description teaches ChatGPT how to form queries, what parameters to use, and what to expect from your data. Poor descriptions lead to poor search results.
-
-### Create a Server
-
-A Deep Research-compatible server must implement these two required tools:
-
-- **`search(query: str)`** - Takes a query of any kind and returns matching record IDs
-- **`fetch(id: str)`** - Takes an ID and returns the record
-
-**Critical**: Write detailed docstrings for both tools. These descriptions teach ChatGPT how to use your tools effectively. Poor descriptions lead to poor search results.
-
-The `search` tool should take a query (of any kind!) and return IDs. The `fetch` tool should take an ID and return the record.
-
-Here's a reference server implementation you can adapt (see also [OpenAI's sample server](https://github.com/openai/sample-deep-research-mcp) for comparison):
-
-```python server.py [expandable]
-import json
-from pathlib import Path
-from dataclasses import dataclass
+```python server.py
 from fastmcp import FastMCP
+import random
 
-@dataclass
-class Record:
-    id: str
-    title: str
-    text: str
-    metadata: dict
+mcp = FastMCP("Demo Server")
 
-def create_server(
-    records_path: Path | str,
-    name: str | None = None,
-    instructions: str | None = None,
-) -> FastMCP:
-    """Create a FastMCP server that can search and fetch records from a JSON file."""
-    records = json.loads(Path(records_path).read_text())
-
-    RECORDS = [Record(**r) for r in records]
-    LOOKUP = {r.id: r for r in RECORDS}
-
-    mcp = FastMCP(name=name or "Deep Research MCP", instructions=instructions)
-
-    @mcp.tool()
-    async def search(query: str):
-        """
-        Simple unranked keyword search across title, text, and metadata.
-        Searches for any of the query terms in the record content.
-        Returns a list of matching record IDs for ChatGPT to fetch.
-        """
-        toks = query.lower().split()
-        ids = []
-        for r in RECORDS:
-            record_txt = " ".join(
-                [r.title, r.text, " ".join(r.metadata.values())]
-            ).lower()
-            if any(t in record_txt for t in toks):
-                ids.append(r.id)
-
-        return {"ids": ids}
-
-    @mcp.tool()
-    async def fetch(id: str):
-        """
-        Fetch a record by ID.
-        Returns the complete record data for ChatGPT to analyze and cite.
-        """
-        if id not in LOOKUP:
-            raise ValueError(f"Unknown record ID: {id}")
-        return LOOKUP[id]
-
-    return mcp
+@mcp.tool
+def roll_dice(sides: int = 6) -> int:
+    """Roll a dice with the specified number of sides."""
+    return random.randint(1, sides)
 
 if __name__ == "__main__":
-    mcp = create_server("path/to/records.json")
     mcp.run(transport="http", port=8000)
 ```
 
-### Deploy the Server
+### Deploy Your Server
 
-Your server must be deployed to a public URL in order for ChatGPT to access it.
-
-For development, you can use tools like `ngrok` to temporarily expose a locally-running server to the internet. We'll do that for this example (you may need to install `ngrok` and create a free account), but you can use any other method to deploy your server.
-
-Assuming you saved the above code as `server.py`, you can run the following two commands in two separate terminals to deploy your server and expose it to the internet:
+Your server must be accessible from the internet. For development, use `ngrok`:
 
 <CodeGroup>
-```bash FastMCP server
+```bash Terminal 1
 python server.py
 ```
 
-```bash ngrok
+```bash Terminal 2
 ngrok http 8000
 ```
 </CodeGroup>
 
-<Warning>
-This exposes your unauthenticated server to the internet. Only run this command in a safe environment if you understand the risks.
-</Warning>
+Note your public URL (e.g., `https://abc123.ngrok.io`) for the next steps.
 
-### Connect to ChatGPT
+## Chat Mode
 
-Replace `https://your-server-url.com` with the actual URL of your server (such as your ngrok URL).
+Chat mode lets you use MCP tools directly in ChatGPT conversations. See [OpenAI's Developer Mode guide](https://platform.openai.com/docs/guides/developer-mode) for the latest requirements.
+
+### Add to ChatGPT
+
+#### 1. Enable Developer Mode
 
 1. Open ChatGPT and go to **Settings** → **Connectors**
-2. Click **Add custom connector**
-3. Enter your server details:
-   - **Name**: Library Catalog
-   - **URL**: Your server URL, including the path.
-        - **Note**: Ensure your URL includes the correct path for the transport you’re using. The defaults are /sse/ for SSE (e.g., https://abc123.ngrok.io/sse/) and /mcp/ for HTTP (e.g., https://abc123.ngrok.io/mcp/).
-   - **Description**: A library catalog for searching and retrieving books
+2. Under **Advanced**, toggle **Developer Mode** to enabled
 
-#### Test the Connection
+#### 2. Create Connector
 
-1. Start a new chat in ChatGPT
-2. Click **Tools** → **Run deep research** 
-3. Select your **Library Catalog** connector as a source
-4. Ask questions like:
-   - "Search for Python programming books"
-   - "Find books about AI and machine learning"
-   - "Show me books by the Python Software Foundation"
+1. In **Settings** → **Connectors**, click **Create**
+2. Enter:
+   - **Name**: Your server name
+   - **Server URL**: `https://your-server.ngrok.io/mcp/`
+3. Check **I trust this provider**
+4. Add authentication if needed
+5. Click **Create**
 
-ChatGPT will use your server's search and fetch tools to find relevant information and cite the sources in its response.
+<Note>
+**Without Developer Mode**: If you don't have search/fetch tools, ChatGPT will reject the server. With Developer Mode enabled, you don't need search/fetch tools for Chat mode.
+</Note>
 
-### Troubleshooting
+#### 3. Use in Chat
 
-#### "This MCP server doesn't implement our specification"
+1. Start a new chat
+2. Click the **+** button → **More** → **Developer Mode**
+3. **Enable your MCP server connector** (required - the connector must be explicitly added to each chat)
+4. Now you can use your tools:
 
+Example usage:
+- "Roll a 20-sided dice"
+- "Roll dice" (uses default 6 sides)
 
-If you get this error, it most likely means that your server doesn't implement the required tools (`search` and `fetch`). To correct it, ensure that your server meets the service requirements.
+<Tip>
+The connector must be explicitly enabled in each chat session through Developer Mode. Once added, it remains active for the entire conversation.
+</Tip>
+
+### Skip Confirmations
+
+Use `annotations={"readOnlyHint": True}` to skip confirmation prompts for read-only tools:
+
+```python
+@mcp.tool(annotations={"readOnlyHint": True})
+def get_status() -> str:
+    """Check system status."""
+    return "All systems operational"
+
+@mcp.tool()  # No annotation - ChatGPT may ask for confirmation
+def delete_item(id: str) -> str:
+    """Delete an item."""
+    return f"Deleted {id}"
+```
+
+## Deep Research Mode
+
+Deep Research mode provides systematic information retrieval with citations. See [OpenAI's MCP documentation](https://platform.openai.com/docs/mcp) for the latest Deep Research specifications.
+
+<Warning>
+**Search and Fetch Required**: Without Developer Mode, ChatGPT will reject any server that doesn't have both `search` and `fetch` tools. Even in Developer Mode, Deep Research only uses these two tools.
+</Warning>
+
+### Tool Implementation
+
+Deep Research tools must follow this pattern:
+
+```python
+@mcp.tool()
+def search(query: str) -> dict:
+    """
+    Search for records matching the query.
+    Must return {"ids": [list of string IDs]}
+    """
+    # Your search logic
+    matching_ids = ["id1", "id2", "id3"]
+    return {"ids": matching_ids}
+
+@mcp.tool()
+def fetch(id: str) -> dict:
+    """
+    Fetch a complete record by ID.
+    Return the full record data for ChatGPT to analyze.
+    """
+    # Your fetch logic
+    return {
+        "id": id,
+        "title": "Record Title",
+        "content": "Full record content...",
+        "metadata": {"author": "Jane Doe", "date": "2024"}
+    }
+```
+
+### Using Deep Research
+
+1. Ensure your server is added to ChatGPT's connectors (same as Chat mode)
+2. Start a new chat
+3. Click **+** → **Deep Research**
+4. Select your MCP server as a source
+5. Ask research questions
+
+ChatGPT will use your `search` and `fetch` tools to find and cite relevant information.
+


### PR DESCRIPTION
ChatGPT now supports MCP servers in regular Chat conversations through Developer Mode. This PR updates the documentation to reflect these new capabilities while maintaining the existing Deep Research mode documentation.