### PR TITLE
Remove redirect path for authkit example

### DIFF
--- a/examples/auth/authkit_dcr/server.py
+++ b/examples/auth/authkit_dcr/server.py
@@ -18,7 +18,6 @@ auth = AuthKitProvider(
     authkit_domain=os.getenv("FASTMCP_SERVER_AUTH_AUTHKITPROVIDER_AUTHKIT_DOMAIN")
     or "",
     base_url="http://localhost:8000",
-    # redirect_path="/auth/callback",  # Default path - change if using a different callback URL
 )
 
 mcp = FastMCP("AuthKit DCR Example Server", auth=auth)


### PR DESCRIPTION
AuthKit connects with DCR, so this is unnecessary (and uncommenting it errors)