### PR TITLE
Fix Python 3.13 websockets deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pydantic[email]>=2.11.7",
     "pyperclip>=1.9.0",
     "openapi-core>=0.19.5",
+    "websockets>=15.0.1",
 ]
 
 requires-python = ">=3.10"
@@ -41,7 +42,6 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-websockets = ["websockets>=15.0.1"]
 openai = ["openai>=1.102.0"]
 
 [dependency-groups]

--- a/src/fastmcp/client/oauth_callback.py
+++ b/src/fastmcp/client/oauth_callback.py
@@ -289,6 +289,7 @@ def create_oauth_callback_server(
             port=port,
             lifespan="off",
             log_level="warning",
+            ws="websockets-sansio",
         )
     )
 

--- a/src/fastmcp/server/server.py
+++ b/src/fastmcp/server/server.py
@@ -1566,6 +1566,7 @@ class FastMCP(Generic[LifespanResultT]):
         config_kwargs: dict[str, Any] = {
             "timeout_graceful_shutdown": 0,
             "lifespan": "on",
+            "ws": "websockets-sansio",
         }
         config_kwargs.update(_uvicorn_config_from_user)
 

--- a/src/fastmcp/utilities/tests.py
+++ b/src/fastmcp/utilities/tests.py
@@ -66,6 +66,7 @@ def _run_server(mcp_server: FastMCP, transport: Literal["sse"], port: int) -> No
             host="127.0.0.1",
             port=port,
             log_level="error",
+            ws="websockets-sansio",
         )
     )
     uvicorn_server.run()

--- a/tests/client/test_sse.py
+++ b/tests/client/test_sse.py
@@ -96,7 +96,9 @@ def run_nested_server(host: str, port: int) -> None:
     mount = Starlette(routes=[Mount("/nest-inner", app=app)])
     mount2 = Starlette(routes=[Mount("/nest-outer", app=mount)])
     server = uvicorn.Server(
-        config=uvicorn.Config(app=mount2, host=host, port=port, log_level="error")
+        config=uvicorn.Config(
+            app=mount2, host=host, port=port, log_level="error", ws="websockets-sansio"
+        )
     )
     server.run()
 

--- a/tests/client/test_streamable_http.py
+++ b/tests/client/test_streamable_http.py
@@ -103,6 +103,7 @@ def run_nested_server(host: str, port: int) -> None:
             port=port,
             log_level="error",
             lifespan="on",
+            ws="websockets-sansio",
         )
     )
     server.run()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -530,14 +530,12 @@ dependencies = [
     { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "rich" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
 openai = [
     { name = "openai" },
-]
-websockets = [
-    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -580,9 +578,9 @@ requires-dist = [
     { name = "pyperclip", specifier = ">=1.9.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "rich", specifier = ">=13.9.4" },
-    { name = "websockets", marker = "extra == 'websockets'", specifier = ">=15.0.1" },
+    { name = "websockets", specifier = ">=15.0.1" },
 ]
-provides-extras = ["openai", "websockets"]
+provides-extras = ["openai"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Fixes the `websockets.legacy` deprecation warning in Python 3.13 by configuring uvicorn to use `ws="websockets-sansio"` instead of the deprecated implementation.

Also moves `websockets` from optional to required dependency since it's needed to avoid the warning.

Closes #1166