### PR TITLE
Fix SSE endpoint accepting POST requests instead of returning 405

### DIFF
--- a/src/fastmcp/server/auth/oauth_proxy.py
+++ b/src/fastmcp/server/auth/oauth_proxy.py
@@ -873,7 +873,6 @@ class OAuthProxy(OAuthProvider):
     def get_routes(
         self,
         mcp_path: str | None = None,
-        mcp_endpoint: Any | None = None,
     ) -> list[Route]:
         """Get OAuth routes with custom proxy token handler.
 
@@ -882,10 +881,10 @@ class OAuthProxy(OAuthProvider):
 
         Args:
             mcp_path: The path where the MCP endpoint is mounted (e.g., "/mcp")
-            mcp_endpoint: The MCP endpoint handler to protect with auth
+                This is used to advertise the resource URL in metadata.
         """
         # Get standard OAuth routes from parent class
-        routes = super().get_routes(mcp_path, mcp_endpoint)
+        routes = super().get_routes(mcp_path)
         custom_routes = []
         token_route_found = False
 

--- a/src/fastmcp/server/auth/providers/descope.py
+++ b/src/fastmcp/server/auth/providers/descope.py
@@ -7,8 +7,6 @@ for seamless MCP client authentication.
 
 from __future__ import annotations
 
-from typing import Any
-
 import httpx
 from pydantic import AnyHttpUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -127,7 +125,6 @@ class DescopeProvider(RemoteAuthProvider):
     def get_routes(
         self,
         mcp_path: str | None = None,
-        mcp_endpoint: Any | None = None,
     ) -> list[Route]:
         """Get OAuth routes including Descope authorization server metadata forwarding.
 
@@ -136,10 +133,10 @@ class DescopeProvider(RemoteAuthProvider):
 
         Args:
             mcp_path: The path where the MCP endpoint is mounted (e.g., "/mcp")
-            mcp_endpoint: The MCP endpoint handler to protect with auth
+                This is used to advertise the resource URL in metadata.
         """
         # Get the standard protected resource routes from RemoteAuthProvider
-        routes = super().get_routes(mcp_path, mcp_endpoint)
+        routes = super().get_routes(mcp_path)
 
         async def oauth_authorization_server_metadata(request):
             """Forward Descope OAuth authorization server metadata with FastMCP customizations."""

--- a/src/fastmcp/server/auth/providers/scalekit.py
+++ b/src/fastmcp/server/auth/providers/scalekit.py
@@ -7,8 +7,6 @@ authentication for seamless MCP client authentication.
 
 from __future__ import annotations
 
-from typing import Any
-
 import httpx
 from pydantic import AnyHttpUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -135,7 +133,6 @@ class ScalekitProvider(RemoteAuthProvider):
     def get_routes(
         self,
         mcp_path: str | None = None,
-        mcp_endpoint: Any | None = None,
     ) -> list[Route]:
         """Get OAuth routes including Scalekit authorization server metadata forwarding.
 
@@ -144,10 +141,10 @@ class ScalekitProvider(RemoteAuthProvider):
 
         Args:
             mcp_path: The path where the MCP endpoint is mounted (e.g., "/mcp")
-            mcp_endpoint: The MCP endpoint handler to protect with auth
+                This is used to advertise the resource URL in metadata.
         """
         # Get the standard protected resource routes from RemoteAuthProvider
-        routes = super().get_routes(mcp_path, mcp_endpoint)
+        routes = super().get_routes(mcp_path)
 
         async def oauth_authorization_server_metadata(request):
             """Forward Scalekit OAuth authorization server metadata with FastMCP customizations."""

--- a/src/fastmcp/server/auth/providers/workos.py
+++ b/src/fastmcp/server/auth/providers/workos.py
@@ -10,8 +10,6 @@ Choose based on your WorkOS setup and authentication requirements.
 
 from __future__ import annotations
 
-from typing import Any
-
 import httpx
 from pydantic import AnyHttpUrl, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -364,7 +362,6 @@ class AuthKitProvider(RemoteAuthProvider):
     def get_routes(
         self,
         mcp_path: str | None = None,
-        mcp_endpoint: Any | None = None,
     ) -> list[Route]:
         """Get OAuth routes including AuthKit authorization server metadata forwarding.
 
@@ -373,10 +370,10 @@ class AuthKitProvider(RemoteAuthProvider):
 
         Args:
             mcp_path: The path where the MCP endpoint is mounted (e.g., "/mcp")
-            mcp_endpoint: The MCP endpoint handler to protect with auth
+                This is used to advertise the resource URL in metadata.
         """
         # Get the standard protected resource routes from RemoteAuthProvider
-        routes = super().get_routes(mcp_path, mcp_endpoint)
+        routes = super().get_routes(mcp_path)
 
         async def oauth_authorization_server_metadata(request):
             """Forward AuthKit OAuth authorization server metadata with FastMCP customizations."""


### PR DESCRIPTION
Fixes #1903

## Problem

After d36ea42b, the SSE endpoint (`/sse`) started accepting POST requests and returning 200 OK instead of rejecting them with 405 Method Not Allowed. This expected MCP semantics and caused clients (like Claude Desktop) to stop their search and not communicate with the "correct" SSE endpoint via a GET request.

The refactoring centralized MCP endpoint route creation in `AuthProvider.get_routes()`, but didn't specify HTTP methods, causing routes to accept all methods by default.

## Solution

Separated responsibilities clearly:
- **Auth providers** (`get_routes()`) return only their own routes (OAuth endpoints, metadata)
- **Transport layer** (`http.py`) creates the protected MCP endpoint routes with correct methods:
  - SSE: `methods=["GET"]` only
  - Streamable HTTP: no method restriction (as before)

This preserves the original behavior while fixing the bug.