### PR TITLE
Expand timeouts

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,10 +48,10 @@ jobs:
         run: uv sync --frozen
 
       - name: Run tests (excluding integration and client_process)
-        run: uv run pytest --inline-snapshot=disable -v tests -m "not integration and not client_process" --numprocesses auto --maxprocesses 4 --dist worksteal
+        run: uv run pytest --inline-snapshot=disable tests -m "not integration and not client_process" --numprocesses auto --maxprocesses 4 --dist worksteal
 
       - name: Run client process tests separately
-        run: uv run pytest --inline-snapshot=disable -v tests -m "client_process" -x
+        run: uv run pytest --inline-snapshot=disable tests -m "client_process" -x
 
   run_integration_tests:
     name: "Run integration tests"
@@ -74,7 +74,7 @@ jobs:
 
       - name: Run integration tests
         # use longer per-test timeout than the default 3s
-        run: uv run pytest -v tests -m "integration" --timeout=15 --numprocesses auto --maxprocesses 2 --dist worksteal
+        run: uv run pytest tests -m "integration" --timeout=15 --numprocesses auto --maxprocesses 2 --dist worksteal
         env:
           FASTMCP_GITHUB_TOKEN: ${{ secrets.FASTMCP_GITHUB_TOKEN }}
           FASTMCP_TEST_AUTH_GITHUB_CLIENT_ID: ${{ secrets.FASTMCP_TEST_AUTH_GITHUB_CLIENT_ID }}

--- a/tests/client/test_sse.py
+++ b/tests/client/test_sse.py
@@ -130,18 +130,18 @@ class TestTimeout:
     async def test_timeout(self, sse_server: str):
         with pytest.raises(
             McpError,
-            match="Timed out while waiting for response to ClientRequest. Waited 0.01 seconds",
+            match="Timed out while waiting for response to ClientRequest. Waited 0.03 seconds",
         ):
             async with Client(
                 transport=SSETransport(sse_server),
-                timeout=0.01,
+                timeout=0.03,
             ) as client:
                 await client.call_tool("sleep", {"seconds": 0.1})
 
     async def test_timeout_tool_call(self, sse_server: str):
         async with Client(transport=SSETransport(sse_server)) as client:
             with pytest.raises(McpError, match="Timed out"):
-                await client.call_tool("sleep", {"seconds": 0.1}, timeout=0.01)
+                await client.call_tool("sleep", {"seconds": 0.1}, timeout=0.03)
 
     async def test_timeout_tool_call_overrides_client_timeout_if_lower(
         self, sse_server: str
@@ -151,7 +151,7 @@ class TestTimeout:
             timeout=2,
         ) as client:
             with pytest.raises(McpError, match="Timed out"):
-                await client.call_tool("sleep", {"seconds": 0.1}, timeout=0.01)
+                await client.call_tool("sleep", {"seconds": 0.1}, timeout=0.03)
 
     async def test_timeout_client_timeout_does_not_override_tool_call_timeout_if_lower(
         self, sse_server: str
@@ -165,4 +165,4 @@ class TestTimeout:
             transport=SSETransport(sse_server),
             timeout=0.1,
         ) as client:
-            await client.call_tool("sleep", {"seconds": 0.01}, timeout=2)
+            await client.call_tool("sleep", {"seconds": 0.03}, timeout=2)


### PR DESCRIPTION
Since merging #1949 there have been elevated rates of test failures when testing timeouts. In particular, a small number of tests with a 0.01 second sensitivity. These are stochastic and usually solved by rerunning the test suite. I suspect that setting up the websocket (which wasn't happening previously) is sufficient to push the test beyond the 0.01 threshold. Therefore this PR expands it to 0.03 seconds. 