### PR TITLE
Upgrade GitHub workflows to claude-code-action@v1

### DIFF
--- a/.github/workflows/marvin-dedupe-issues.yml
+++ b/.github/workflows/marvin-dedupe-issues.yml
@@ -51,6 +51,7 @@ jobs:
           - Use `gh` to interact with GitHub, rather than web fetch
           - Do not use other tools, beyond `gh` and Task (eg. don't use other MCP servers, file edit, etc.)
           - Make a todo list first
+          - Never include this issue as a duplicate of itself
 
           For your comment, follow this format precisely (example with 3 suspected duplicates):
 
@@ -70,11 +71,13 @@ jobs:
           EOF
 
       - name: Run Marvin dedupe command
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
-          model: claude-3-5-haiku-latest
           prompt_file: /tmp/claude-prompts/dedupe-prompt.txt
-          allowed_tools: "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh api:*),Bash(gh issue comment:*),Task"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_FOR_CI }}
-          claude_env: |
-            GH_TOKEN: ${{ steps.marvin-token.outputs.token }}
+          claude_args: |
+            --allowedTools Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh api:*),Bash(gh issue comment:*),Task
+          settings: |
+            {
+              "GH_TOKEN": "${{ steps.marvin-token.outputs.token }}"
+            }

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -146,12 +146,14 @@ jobs:
           EOF
 
       - name: Run Marvin for Issue Triage
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           prompt_file: /tmp/claude-prompts/triage-prompt.txt
-          allowed_tools: "Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__get_pull_request_files"
-          timeout_minutes: "5"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_FOR_CI }}
-          mcp_config: /tmp/mcp-config/mcp-servers.json
-          claude_env: |
-            GH_TOKEN: ${{ steps.marvin-token.outputs.token }}
+          claude_args: |
+            --allowedTools Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__get_pull_request_files
+            --mcp-config /tmp/mcp-config/mcp-servers.json
+          settings: |
+            {
+              "GH_TOKEN": "${{ steps.marvin-token.outputs.token }}"
+            }

--- a/.github/workflows/marvin.yml
+++ b/.github/workflows/marvin.yml
@@ -59,13 +59,13 @@ jobs:
 
       # Marvin Assistant
       - name: Run Marvin
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ steps.marvin-token.outputs.token }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          mode: tag
           trigger_phrase: "/marvin"
           allowed_bots: "*"
-          allowed_tools: "WebSearch,WebFetch,Bash(uv:*),Bash(pre-commit:*),Bash(pytest:*),Bash(ruff:*),Bash(ty:*),Bash(git:*),Bash(gh:*),mcp__github__add_issue_comment,mcp__github__create_issue,mcp__github__get_issue,mcp__github__list_issues,mcp__github__search_issues,mcp__github__update_issue,mcp__github__update_issue_comment,mcp__github__create_pull_request,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__list_pull_requests,mcp__github__update_pull_request,mcp__github__update_pull_request_branch,mcp__github__update_pull_request_comment,mcp__github__merge_pull_request"
+          claude_args: |
+            --allowedTools WebSearch,WebFetch,Bash(uv:*),Bash(pre-commit:*),Bash(pytest:*),Bash(ruff:*),Bash(ty:*),Bash(git:*),Bash(gh:*),mcp__github__add_issue_comment,mcp__github__create_issue,mcp__github__get_issue,mcp__github__list_issues,mcp__github__search_issues,mcp__github__update_issue,mcp__github__update_issue_comment,mcp__github__create_pull_request,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__list_pull_requests,mcp__github__update_pull_request,mcp__github__update_pull_request_branch,mcp__github__update_pull_request_comment,mcp__github__merge_pull_request
           additional_permissions: |
             actions: read


### PR DESCRIPTION
Upgrades all Marvin workflows to use the claude-code-action@v1 release, following the migration guide at https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md.

```yaml
# Example: marvin.yml now uses automatic mode detection
- uses: anthropics/claude-code-action@v1
  with:
    trigger_phrase: "/marvin"  # Auto-detects tag mode
    claude_args: |
      --allowedTools WebSearch,WebFetch,...
```

**Changes:**
- Removed deprecated `mode` input (auto-detected from `trigger_phrase`)
- Migrated `allowed_tools` → `claude_args: --allowedTools`
- Migrated `mcp_config` → `claude_args: --mcp-config`
- Migrated `claude_env` → `settings` (JSON format)
- Removed `timeout_minutes` (set at job level)
- Removed explicit model specification (uses default)

Closes #1952