### PR TITLE
Fix prompt_file input and bot attribution

### DIFF
--- a/.github/workflows/marvin-dedupe-issues.yml
+++ b/.github/workflows/marvin-dedupe-issues.yml
@@ -30,10 +30,11 @@ jobs:
           app-id: ${{ secrets.MARVIN_APP_ID }}
           private-key: ${{ secrets.MARVIN_APP_PRIVATE_KEY }}
 
-      - name: Create dedupe prompt
+      - name: Set dedupe prompt
+        id: dedupe-prompt
         run: |
-          mkdir -p /tmp/claude-prompts
-          cat > /tmp/claude-prompts/dedupe-prompt.txt << 'EOF'
+          cat >> $GITHUB_OUTPUT << 'EOF'
+          PROMPT<<PROMPT_END
           Find up to 3 likely duplicate issues for GitHub issue ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}.
 
           Follow these steps precisely:
@@ -69,13 +70,15 @@ jobs:
           - To prevent auto-closure, add a comment or 👎 this comment
 
           ---
+          PROMPT_END
           EOF
 
       - name: Run Marvin dedupe command
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ steps.marvin-token.outputs.token }}
-          prompt_file: /tmp/claude-prompts/dedupe-prompt.txt
+          bot_name: "Marvin Context Protocol"
+          prompt: ${{ steps.dedupe-prompt.outputs.PROMPT }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_FOR_CI }}
           claude_args: |
             --allowedTools Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh api:*),Bash(gh issue comment:*),Task

--- a/.github/workflows/marvin-dedupe-issues.yml
+++ b/.github/workflows/marvin-dedupe-issues.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Run Marvin dedupe command
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ steps.marvin-token.outputs.token }}
           bot_name: "Marvin Context Protocol"
           prompt: ${{ steps.dedupe-prompt.outputs.PROMPT }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_FOR_CI }}

--- a/.github/workflows/marvin-dedupe-issues.yml
+++ b/.github/workflows/marvin-dedupe-issues.yml
@@ -76,7 +76,6 @@ jobs:
       - name: Run Marvin dedupe command
         uses: anthropics/claude-code-action@v1
         with:
-          github_token: ${{ steps.marvin-token.outputs.token }}
           bot_name: "Marvin Context Protocol"
           prompt: ${{ steps.dedupe-prompt.outputs.PROMPT }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_FOR_CI }}

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -151,6 +151,7 @@ jobs:
       - name: Run Marvin for Issue Triage
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ steps.marvin-token.outputs.token }}
           bot_name: "Marvin Context Protocol"
           prompt: ${{ steps.triage-prompt.outputs.PROMPT }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_FOR_CI }}

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -151,7 +151,6 @@ jobs:
       - name: Run Marvin for Issue Triage
         uses: anthropics/claude-code-action@v1
         with:
-          github_token: ${{ steps.marvin-token.outputs.token }}
           bot_name: "Marvin Context Protocol"
           prompt: ${{ steps.triage-prompt.outputs.PROMPT }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_FOR_CI }}

--- a/.github/workflows/marvin-label-triage.yml
+++ b/.github/workflows/marvin-label-triage.yml
@@ -40,10 +40,11 @@ jobs:
           app-id: ${{ secrets.MARVIN_APP_ID }}
           private-key: ${{ secrets.MARVIN_APP_PRIVATE_KEY }}
 
-      - name: Create triage prompt
+      - name: Set triage prompt
+        id: triage-prompt
         run: |
-          mkdir -p /tmp/claude-prompts
-          cat > /tmp/claude-prompts/triage-prompt.txt << 'EOF'
+          cat >> $GITHUB_OUTPUT << 'EOF'
+          PROMPT<<PROMPT_END
           You're an issue triage assistant for FastMCP, a Python framework for building Model Context Protocol servers and clients. Your task is to analyze issues/PRs and apply appropriate labels.
 
           IMPORTANT: Your ONLY action should be to apply labels using mcp__github__update_issue. DO NOT post any comments.
@@ -120,6 +121,7 @@ jobs:
           4. Apply selected labels:
              Use mcp__github__update_issue to apply your selected labels
              DO NOT post any comments
+          PROMPT_END
           EOF
 
       - name: Setup GitHub MCP Server
@@ -150,7 +152,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ steps.marvin-token.outputs.token }}
-          prompt_file: /tmp/claude-prompts/triage-prompt.txt
+          bot_name: "Marvin Context Protocol"
+          prompt: ${{ steps.triage-prompt.outputs.PROMPT }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_FOR_CI }}
           claude_args: |
             --allowedTools Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__get_pull_request_files


### PR DESCRIPTION
Fixes the automation workflows (triage and dedupe) to work with claude-code-action@v1.

**Changes:**
- Replace `prompt_file` with `prompt` input (using GitHub output variables)
- Add `bot_name: "Marvin Context Protocol"` for proper attribution
- Keep `github_token` (matches working marvin.yml configuration)
- Keep `id-token: write` permission

The `prompt_file` input doesn't exist in v1, causing warnings. The new approach uses GitHub Actions output variables to pass the prompt text directly.