### PR TITLE
cli: fix banner width by removing emoji variation selectors

### DIFF
--- a/src/fastmcp/utilities/cli.py
+++ b/src/fastmcp/utilities/cli.py
@@ -186,7 +186,7 @@ def log_server_banner(
         case "stdio":
             display_transport = "STDIO"
 
-    info_table.add_row("🖥️", "Server name:", server.name)
+    info_table.add_row("🖥", "Server name:", server.name)
     info_table.add_row("📦", "Transport:", display_transport)
 
     # Show connection info based on transport
@@ -200,7 +200,7 @@ def log_server_banner(
     # Add version information with explicit style overrides
     info_table.add_row("", "", "")
     info_table.add_row(
-        "🏎️",
+        "🏎",
         "FastMCP version:",
         Text(fastmcp.__version__, style="dim white", no_wrap=True),
     )


### PR DESCRIPTION
Fix: Align CLI banner box edges by removing emoji variation selectors

## before
<img width="698" height="463" alt="image" src="https://github.com/user-attachments/assets/68d7ec6f-c3d0-4052-87a3-8d8f3cdcbf4f" />

you can also see this on all FastMCP cloud server logs

## after
<img width="710" height="466" alt="image" src="https://github.com/user-attachments/assets/48ea5aaa-0595-4577-a9ce-3ce2673b7591" />



Problem
- The right border of the startup banner panel appeared jagged/misaligned.
- Root cause: two emojis in the info table included Unicode variation selectors (VS16):
  - U+1F5A5 U+FE0F (🖥️) on "Server name"
  - U+1F3CE U+FE0F (🏎️) on "FastMCP version"
- Many terminals and width calculators treat emoji with VS16 as double‑width (2 columns). Rich's table width calculations then disagree with the terminal's display width, shifting content to the right and causing the panel's right edge to be off.

Change
- Replace the two emojis with their base forms (no variation selector):
  - 🖥️ → 🖥
  - 🏎️ → 🏎
- No other layout or sizing changes. The table/panel centering and width remain the same.

Why this works
- Without VS16, these code points typically render with a consistent single display width in terminals, matching wcwidth used by Rich. That keeps column width math and actual rendering in sync, so the right border aligns.

Notes
- This is a visual fix only; no behavior or API changes.
- Tested manually by running `uv run fastmcp run examples/echo.py` and verifying the panel edges are straight with standard terminal fonts.
